### PR TITLE
fix: float-domain SAT crash — constraints.py missed the _encode_bound rename

### DIFF
--- a/python/tvl/constraints.py
+++ b/python/tvl/constraints.py
@@ -244,8 +244,8 @@ def _create_variable(model: cp_model.CpModel, domain: Domain) -> cp_model.IntVar
         ub = int(domain.maximum) if domain.maximum is not None else 10_000
         return model.NewIntVar(lb, ub, name)
     if domain.kind == "float":
-        lb = domain._encode_bound(domain.minimum) if domain.minimum is not None else -1_000_000
-        ub = domain._encode_bound(domain.maximum) if domain.maximum is not None else 1_000_000
+        lb = domain._encode_bound_lower(domain.minimum) if domain.minimum is not None else -1_000_000
+        ub = domain._encode_bound_upper(domain.maximum) if domain.maximum is not None else 1_000_000
         return model.NewIntVar(lb, ub, name)
     raise ValueError(f"Unsupported domain type {domain.kind}")
 

--- a/tests/test_constraints_float_domain.py
+++ b/tests/test_constraints_float_domain.py
@@ -1,0 +1,47 @@
+"""Regression: float-domain TVARs crashed check_structural_satisfiable.
+
+`Domain` was refactored to `_encode_bound_lower`/`_encode_bound_upper`
+(model.py) and structural_sat.py was updated, but constraints.py kept calling
+the removed `_encode_bound` — any module with a float-domain TVAR raised
+AttributeError in the OR-Tools variable builder. Found by the RFC 0001
+model-checking corpus sweep (17/35 canonical spec/examples modules crashed).
+"""
+
+from __future__ import annotations
+
+from tvl.constraints import check_structural_satisfiable, compile_constraints
+
+
+def test_float_domain_variable_solves():
+    module = {
+        "tvars": [
+            {
+                "name": "temperature",
+                "type": "float",
+                "domain": {"range": [0.0, 1.0], "resolution": 0.1},
+            }
+        ],
+        "constraints": {"structural": []},
+    }
+    compiled = compile_constraints(module)
+    result = check_structural_satisfiable(compiled)
+    assert result.get("ok") is True
+
+
+def test_float_domain_bounds_use_inner_grid_points():
+    """ceil for the lower bound, floor for the upper — the integer relaxation
+    only contains grid points INSIDE the real interval."""
+    module = {
+        "tvars": [
+            {
+                "name": "t",
+                "type": "float",
+                "domain": {"range": [0.05, 0.95], "resolution": 0.1},
+            }
+        ],
+        "constraints": {"structural": []},
+    }
+    result = check_structural_satisfiable(compile_constraints(module))
+    assert result.get("ok") is True
+    value = result["assignment"]["t"]
+    assert 0.05 <= value <= 0.95


### PR DESCRIPTION
## Summary
- `check_structural_satisfiable` raised `AttributeError` for ANY module with a float-domain TVAR: `Domain` was refactored to `_encode_bound_lower`/`_encode_bound_upper` (model.py) and `structural_sat.py` was updated, but `constraints.py:247-248` kept calling the removed `_encode_bound`.
- 17 of 35 canonical `spec/examples` modules crash on unmodified `main`; zero pre-existing test coverage of this path.
- Pairing verified sound: `ceil` for the lower bound, `floor` for the upper — the integer relaxation only contains grid points INSIDE the real interval, matching `Domain.contains()` and `structural_sat.py`.

Found by the RFC 0001 model-checking corpus sweep (P1 equivalence over spec/examples). **Prerequisite for** the RFC 0001 branch train (the same patch rides `feature/cvars-model-checking` as 4eb56b0 — merges cleanly either order).

## Test plan
- New `tests/test_constraints_float_domain.py`: float-domain module solves; inner-grid bound semantics.
- Full suite: 113 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)