### PR TITLE
model-checking: small-scope models + counterexample fixtures for RFC 0001

### DIFF
--- a/python/tvl/constraints.py
+++ b/python/tvl/constraints.py
@@ -244,8 +244,8 @@ def _create_variable(model: cp_model.CpModel, domain: Domain) -> cp_model.IntVar
         ub = int(domain.maximum) if domain.maximum is not None else 10_000
         return model.NewIntVar(lb, ub, name)
     if domain.kind == "float":
-        lb = domain._encode_bound(domain.minimum) if domain.minimum is not None else -1_000_000
-        ub = domain._encode_bound(domain.maximum) if domain.maximum is not None else 1_000_000
+        lb = domain._encode_bound_lower(domain.minimum) if domain.minimum is not None else -1_000_000
+        ub = domain._encode_bound_upper(domain.maximum) if domain.maximum is not None else 1_000_000
         return model.NewIntVar(lb, ub, name)
     raise ValueError(f"Unsupported domain type {domain.kind}")
 

--- a/spec/examples/validation-phase6-cvars/README.md
+++ b/spec/examples/validation-phase6-cvars/README.md
@@ -1,0 +1,30 @@
+# Phase 6 Validation Examples — RFC 0001 (cvars + policies)
+
+Counterexample/conformance fixtures produced by the RFC 0001 model-checking
+packet (`tests/model_checking/`). They are the **executable acceptance bar for
+the validators packet**: the Phase 4 grammar/schema/lint changes are done when
+every fixture below produces exactly its expected diagnostic.
+
+> **Status note (forward fixtures).** The 1.1 surface (`cvars`, `policies`,
+> `require_calibration`, `scope`) is not yet in `tvl.schema.json`, so fixtures
+> using it intentionally FAIL schema validation today. The two
+> `namespace-prefix-collision-*` fixtures and the lint/SAT-level properties are
+> checkable now (the model suite does so at dict level, bypassing the schema).
+
+| Example | Expected outcome after Phase 4 |
+| --- | --- |
+| `cvar-policies-happy.tvl.yml` | VALID — the conformance-positive 1.1 module (RFC §3.9) |
+| `cvar-shadows-tvar.tvl.yml` | ERROR `cvar_shadows_tvar` (binding partition, §3.1) |
+| `cvar-missing-parent-ref.tvl.yml` | ERROR `missing_ref` (`depends_on` → no TVAR, §3.7(4)) |
+| `gate-threshold-not-cvar.tvl.yml` | ERROR `missing_ref` kind-mismatch (gate threshold must be a CVAR, §3.8) |
+| `cascade-arity-violation.tvl.yml` | ERROR `cascade_arity` (\|gates\| ≠ \|stages\| − 1, §3.8) |
+| `duplicate-stage.tvl.yml` | ERROR `duplicate_stage` (§3.8) |
+| `cvar-in-structural-constraint.tvl.yml` | ERROR `cvar_in_structural_constraint` (precise, not `undeclared_tvar`); SAT encoding contains only TVARs (P5) |
+| `namespace-prefix-collision-error.tvl.yml` | ERROR `namespace_prefix_collision` (module uses 1.1 constructs, §3.7(5)) |
+| `namespace-prefix-collision-legacy-warning.tvl.yml` | WARNING only — pure-1.0 module stays VALID (P1, §3.7(5)) |
+
+Dynamic semantics (resolver rejections R1–R8, certificate subject/freshness
+validity, strict-promotion fail-closed, cascade execution) are not expressible
+as static module fixtures; they are verified by the small-scope model suite in
+`tests/model_checking/` and, for the runtime, by the SDK features
+(`FR-SDK-KNOBS-CVARS-V1`, `FR-SDK-FAIL-CLOSED-PROMOTION-V1`).

--- a/spec/examples/validation-phase6-cvars/cascade-arity-violation.tvl.yml
+++ b/spec/examples/validation-phase6-cvars/cascade-arity-violation.tvl.yml
@@ -1,0 +1,43 @@
+# Phase 6 (RFC 0001): |gates| must equal |stages| - 1 (RFC §3.8).
+# Expected: ERROR cascade_arity — 3 stages with 1 gate.
+tvl:
+  module: corp.validation.cascade_arity
+
+environment:
+  snapshot_id: "2026-06-04T00:00:00Z"
+
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+
+tvars:
+  - name: model
+    type: enum[str]
+    domain: ["gpt-4o-mini", "gpt-4o"]
+
+cvars:
+  - name: theta
+    type: float
+    calibration:
+      source: pool_a
+
+policies:
+  - name: broken_cascade
+    kind: policy
+    strategy: cascade
+    stages: [cheap, mid, strong]
+    gates:
+      - kind: margin_below
+        threshold: theta     # only one gate for three stages
+
+constraints:
+  structural: []
+
+objectives:
+  - name: quality
+    direction: maximize
+
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02

--- a/spec/examples/validation-phase6-cvars/cvar-in-structural-constraint.tvl.yml
+++ b/spec/examples/validation-phase6-cvars/cvar-in-structural-constraint.tvl.yml
@@ -1,0 +1,39 @@
+# Phase 6 (RFC 0001): cvars are governed-but-not-searched — a structural
+# constraint referencing one is diagnosed precisely (RFC §3.2 / P5).
+# Expected: ERROR cvar_in_structural_constraint ("governed but not searched;
+# substitute as a constant"), NOT the generic undeclared_tvar. The SAT
+# encoding must contain ONLY tvar names either way (the P5 lock).
+tvl:
+  module: corp.validation.cvar_in_structural
+
+environment:
+  snapshot_id: "2026-06-04T00:00:00Z"
+
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+
+tvars:
+  - name: zero_shot
+    type: bool
+    domain: [true, false]
+
+cvars:
+  - name: theta
+    type: float
+    calibration:
+      source: pool_a
+
+constraints:
+  structural:
+    - when: zero_shot = true
+      then: theta = 0.5      # references a CVAR — governed, not searched
+
+objectives:
+  - name: quality
+    direction: maximize
+
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02

--- a/spec/examples/validation-phase6-cvars/cvar-missing-parent-ref.tvl.yml
+++ b/spec/examples/validation-phase6-cvars/cvar-missing-parent-ref.tvl.yml
@@ -1,0 +1,36 @@
+# Phase 6 (RFC 0001): depends_on must resolve to a declared TVAR (RFC §3.3/§3.7(4)).
+# Expected: ERROR missing_ref — "ghost" resolves to nothing; "theta" naming a
+# CVAR parent would be equally invalid in v1 (TVARs only).
+tvl:
+  module: corp.validation.cvar_missing_parent
+
+environment:
+  snapshot_id: "2026-06-04T00:00:00Z"
+
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+
+tvars:
+  - name: model
+    type: enum[str]
+    domain: ["gpt-4o-mini", "gpt-4o"]
+
+cvars:
+  - name: theta
+    type: float
+    calibration:
+      source: pool_a
+      depends_on: [ghost]   # no such declaration
+
+constraints:
+  structural: []
+
+objectives:
+  - name: quality
+    direction: maximize
+
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02

--- a/spec/examples/validation-phase6-cvars/cvar-policies-happy.tvl.yml
+++ b/spec/examples/validation-phase6-cvars/cvar-policies-happy.tvl.yml
@@ -1,0 +1,59 @@
+# Phase 6 (RFC 0001): VALID 1.1 module — cvars + policies + require_calibration.
+# Expected: no errors; the conformance-positive case for the validators packet.
+tvl:
+  module: corp.validation.cvars_happy
+
+environment:
+  snapshot_id: "2026-06-04T00:00:00Z"
+
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+
+tvars:
+  - name: model
+    type: enum[str]
+    domain: ["gpt-4o-mini", "gpt-4o"]
+  - name: retriever.k
+    type: int
+    domain:
+      range: [0, 20]
+
+cvars:
+  - name: router.margin_threshold
+    type: float
+    domain:
+      range: [0.0, 1.0]          # validity domain: closed interval, no resolution (RFC §3.3)
+    calibration:
+      source: margin_eval_pool
+      signal: vote_margin_v1
+      calibrator: budget_threshold_v1
+      depends_on: [model, retriever.k]
+    governance:
+      require_calibration: true
+    scope:
+      node: router
+
+policies:
+  - name: cheap_strong_cascade
+    kind: policy
+    strategy: cascade
+    stages: [cheap, strong]
+    gates:
+      - kind: margin_below
+        threshold: router.margin_threshold
+
+constraints:
+  structural: []
+
+objectives:
+  - name: quality
+    direction: maximize
+
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+  require_calibration:
+    enabled: true
+    hash_covered_context: [model_versions]

--- a/spec/examples/validation-phase6-cvars/cvar-shadows-tvar.tvl.yml
+++ b/spec/examples/validation-phase6-cvars/cvar-shadows-tvar.tvl.yml
@@ -1,0 +1,34 @@
+# Phase 6 (RFC 0001): binding-partition collision (RFC §3.1).
+# Expected: ERROR cvar_shadows_tvar — "model" declared as both tvar and cvar.
+tvl:
+  module: corp.validation.cvar_shadows_tvar
+
+environment:
+  snapshot_id: "2026-06-04T00:00:00Z"
+
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+
+tvars:
+  - name: model
+    type: enum[str]
+    domain: ["gpt-4o-mini", "gpt-4o"]
+
+cvars:
+  - name: model            # collides with the tvar above
+    type: float
+    calibration:
+      source: pool_a
+
+constraints:
+  structural: []
+
+objectives:
+  - name: quality
+    direction: maximize
+
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02

--- a/spec/examples/validation-phase6-cvars/duplicate-stage.tvl.yml
+++ b/spec/examples/validation-phase6-cvars/duplicate-stage.tvl.yml
@@ -1,0 +1,43 @@
+# Phase 6 (RFC 0001): stage ids must be unique within one policy (RFC §3.8).
+# Expected: ERROR duplicate_stage — "cheap" appears twice.
+tvl:
+  module: corp.validation.duplicate_stage
+
+environment:
+  snapshot_id: "2026-06-04T00:00:00Z"
+
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+
+tvars:
+  - name: model
+    type: enum[str]
+    domain: ["gpt-4o-mini", "gpt-4o"]
+
+cvars:
+  - name: theta
+    type: float
+    calibration:
+      source: pool_a
+
+policies:
+  - name: dup_stage_cascade
+    kind: policy
+    strategy: cascade
+    stages: [cheap, cheap]
+    gates:
+      - kind: margin_below
+        threshold: theta
+
+constraints:
+  structural: []
+
+objectives:
+  - name: quality
+    direction: maximize
+
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02

--- a/spec/examples/validation-phase6-cvars/gate-threshold-not-cvar.tvl.yml
+++ b/spec/examples/validation-phase6-cvars/gate-threshold-not-cvar.tvl.yml
@@ -1,0 +1,38 @@
+# Phase 6 (RFC 0001): gates[].threshold is a namespace ref that MUST resolve
+# to a CVAR — kind-checked (RFC §3.8).
+# Expected: ERROR missing_ref (kind mismatch) — "model" is a TVAR, not a CVAR.
+tvl:
+  module: corp.validation.gate_threshold_kind
+
+environment:
+  snapshot_id: "2026-06-04T00:00:00Z"
+
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+
+tvars:
+  - name: model
+    type: enum[str]
+    domain: ["gpt-4o-mini", "gpt-4o"]
+
+policies:
+  - name: bad_gate
+    kind: policy
+    strategy: cascade
+    stages: [cheap, strong]
+    gates:
+      - kind: margin_below
+        threshold: model     # kind mismatch: TVAR, not CVAR
+
+constraints:
+  structural: []
+
+objectives:
+  - name: quality
+    direction: maximize
+
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02

--- a/spec/examples/validation-phase6-cvars/namespace-prefix-collision-error.tvl.yml
+++ b/spec/examples/validation-phase6-cvars/namespace-prefix-collision-error.tvl.yml
@@ -1,0 +1,40 @@
+# Phase 6 (RFC 0001): prefix collision in a module USING 1.1 constructs
+# (RFC §3.7(5) — new-surface opt-in).
+# Expected: ERROR namespace_prefix_collision — "retriever" is a strict dotted
+# prefix of "retriever.k" and the module declares cvars.
+tvl:
+  module: corp.validation.prefix_collision_error
+
+environment:
+  snapshot_id: "2026-06-04T00:00:00Z"
+
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+
+tvars:
+  - name: retriever
+    type: bool
+    domain: [true, false]
+  - name: retriever.k
+    type: int
+    domain:
+      range: [0, 8]
+
+cvars:
+  - name: theta
+    type: float
+    calibration:
+      source: pool_a
+
+constraints:
+  structural: []
+
+objectives:
+  - name: quality
+    direction: maximize
+
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02

--- a/spec/examples/validation-phase6-cvars/namespace-prefix-collision-legacy-warning.tvl.yml
+++ b/spec/examples/validation-phase6-cvars/namespace-prefix-collision-legacy-warning.tvl.yml
@@ -1,0 +1,34 @@
+# Phase 6 (RFC 0001): the SAME prefix collision in a pure-1.0 module
+# (RFC §3.7(5) — P1 protection).
+# Expected: WARNING namespace_prefix_collision only; the module REMAINS VALID
+# (no 1.1 constructs are used, so validity is untouched).
+tvl:
+  module: corp.validation.prefix_collision_legacy
+
+environment:
+  snapshot_id: "2026-06-04T00:00:00Z"
+
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+
+tvars:
+  - name: retriever
+    type: bool
+    domain: [true, false]
+  - name: retriever.k
+    type: int
+    domain:
+      range: [0, 8]
+
+constraints:
+  structural: []
+
+objectives:
+  - name: quality
+    direction: maximize
+
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02

--- a/tests/model_checking/__init__.py
+++ b/tests/model_checking/__init__.py
@@ -1,0 +1,15 @@
+"""Finite small-scope models of RFC 0001 (knob bindings: cvars + policies).
+
+Each module here encodes one slice of the RFC's formal semantics as a tiny,
+exhaustively-enumerable Python model, then checks the RFC's property claims
+(P1-P8) over ALL instances up to a small scope bound — the small-scope
+hypothesis in executable form. Where a property is claimed to be violable
+(rejections R2-R8, collisions, staleness), the checker also EXHIBITS a
+counterexample and exports it as a conformance fixture under
+spec/examples/validation-phase6-cvars/ so the Phase 4 validators inherit
+failing-by-design inputs.
+
+No new dependencies: plain pytest + itertools (deterministic, no hypothesis).
+The real tvl package is used directly where the property concerns real code
+(P5 SAT preservation runs the actual compile_constraints encoder).
+"""

--- a/tests/model_checking/model.py
+++ b/tests/model_checking/model.py
@@ -2,14 +2,20 @@
 
 This is a MODEL, not the implementation: types are tiny, value spaces are
 finite, and the semantics transcribe the RFC clauses one-to-one so that
-property checks read like the spec. Section references are to
-formalization/rfc-0001-knob-bindings-cvars-policies.md (Draft v2).
+property checks read like the spec.
+
+PINNED RFC REVISION: Draft v4, branch feature/cvars-policies-rfc, commit
+b036485 (cross-model review round-4 ACCEPT). Section references are to
+formalization/rfc-0001-knob-bindings-cvars-policies.md at that revision —
+the RFC lives on its own branch per the one-branch-per-packet rule, so the
+pin is by SHA, not by merge.
 """
 
 from __future__ import annotations
 
 import hashlib
 import json
+import math
 import unicodedata
 from dataclasses import dataclass, field
 from typing import Any, Dict, FrozenSet, List, Mapping, Optional, Sequence, Tuple
@@ -65,6 +71,8 @@ class CVar:
     depends_on: Tuple[str, ...] = ()
     validity_domain: Optional[Tuple[float, float]] = None  # closed interval (§3.3)
     require_calibration: bool = False
+    certificate_backed_target: bool = False  # §3.6 fifth disjunct
+    target_epsilon: Optional[float] = None  # chance-style target level (R8 floor)
     signal: str = "sig_v1"
     calibrator: str = "cal_v1"
     calibrator_version: str = "1"
@@ -93,6 +101,7 @@ class Module:
     # promotion_policy strict-mode declarations (§3.6)
     require_calibration_enabled: bool = False
     has_chance_constraints: bool = False
+    has_guaranteed_selection_target: bool = False  # operational profile (§3.6)
 
     @property
     def n_t(self) -> FrozenSet[str]:
@@ -143,6 +152,31 @@ def namespace_diagnostics(module: Module) -> List[Tuple[str, str]]:
     return diags
 
 
+IDENT_RE = __import__("re").compile(
+    r"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$"
+)
+
+
+def declaration_diagnostics(module: Module) -> List[Tuple[str, str]]:
+    """Static per-declaration diagnostics beyond the namespace rules:
+    the §3.7(2) Ident grammar, §3.8 duplicate_stage and cascade arity.
+    (scope_prefix_mismatch and the policy kind/strategy registries are
+    Phase 4 lint obligations — see the fixture README.)"""
+    diags: List[Tuple[str, str]] = []
+    for name in module.declared_names:
+        if not IDENT_RE.match(name):
+            diags.append(("invalid_ident", name))
+    for policy in module.policies:
+        if len(policy.stages) != len(set(policy.stages)):
+            diags.append(("duplicate_stage", policy.name))
+        if policy.strategy == "cascade":
+            if len(policy.stages) < 1:
+                diags.append(("cascade_arity", policy.name))
+            elif len(policy.gates) != len(policy.stages) - 1:
+                diags.append(("cascade_arity", policy.name))
+    return diags
+
+
 def uses_11_constructs(module: Module) -> bool:
     """§3.7(5): the new-surface opt-in that escalates prefix collisions."""
     return bool(module.cvars or module.policies or module.require_calibration_enabled)
@@ -177,10 +211,15 @@ class FreshnessContext:
     extensions: Tuple[Tuple[str, Any], ...] = ()  # subset of CTX_EXT_KEYS
 
     def freshness_hash(self) -> str:
+        parent_names = [name for name, _ in self.tuned_parent_values]
+        if len(parent_names) != len(set(parent_names)):
+            raise ValueError("duplicate_tuned_parent")
         core = {
             "ctx_schema_version": CTX_SCHEMA_VERSION,
             "cvar_name": self.cvar_name,
-            "tuned_parent_values": list(self.tuned_parent_values),
+            # RFC: "sorted by name" is part of the definition — the model
+            # ENFORCES it rather than trusting the caller.
+            "tuned_parent_values": sorted(self.tuned_parent_values, key=lambda kv: kv[0]),
             "calibration_source_id": self.calibration_source_id,
             "signal_spec_hash": self.signal_spec_hash,
             "calibrator_id": self.calibrator_id,
@@ -192,10 +231,17 @@ class FreshnessContext:
             "eval_split": self.eval_split,
             "target": self.target,
         }
-        for key, _ in self.extensions:
+        ext_keys = [key for key, _ in self.extensions]
+        for key in ext_keys:
             if key not in CTX_EXT_KEYS:
                 raise ValueError(f"invalid_calibration_context: {key}")
-        return h_c({"core": core, "ext": list(self.extensions)})
+        if len(ext_keys) != len(set(ext_keys)):
+            raise ValueError("duplicate_calibration_context_key")
+        # Canonical: extensions are a MAP — order-insensitive by sorting on
+        # key before hashing (the JCS object-key rule, which a list of pairs
+        # would otherwise bypass).
+        ext_sorted = sorted(self.extensions, key=lambda kv: kv[0])
+        return h_c({"core": core, "ext": [list(kv) for kv in ext_sorted]})
 
 
 CERTIFIED = "CERTIFIED"
@@ -297,6 +343,17 @@ class Calibrator:
         return self.value
 
 
+def _type_conforms(value: Any, cvar_type: str) -> bool:
+    """R5 type conformance (model form of the RFC's τ(n) check)."""
+    if cvar_type == "bool":
+        return isinstance(value, bool)
+    if cvar_type == "int":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if cvar_type == "float":
+        return isinstance(value, (int, float)) and not isinstance(value, bool)
+    return isinstance(value, str)  # enum[str]/str-like
+
+
 @dataclass(frozen=True)
 class Resolution:
     accepted: bool
@@ -314,8 +371,7 @@ def resolve(
     certificates: Mapping[str, Certificate],
     contexts: Mapping[str, FreshnessContext],
     *,
-    eval_split: str = "eval",
-    evidence_floor: int = 0,
+    eval_items: frozenset = frozenset(),
 ) -> Resolution:
     """Transcription of RFC §3.4: Accept ⟺ ¬(R1∨...∨R8) ∧ ∀ calibrators ≠ ⊥.
 
@@ -364,24 +420,29 @@ def resolve(
     if n_t & n_c:
         rejections.append(R3_DUPLICATE_PROVIDER)
 
-    # R4: phase mismatch — a CVAR consumed (as gate threshold) must be
-    # resolvable, i.e. its calibrator/evidence present before use.
-    consumed = {g.threshold for p in module.policies for g in p.gates}
-    for name in consumed & n_c:
-        if name not in calibrators or name not in evidence:
+    # R4: phase mismatch — EVERY declared CVAR must be producible (its
+    # calibrator and evidence registered) BEFORE resolution consumes it: the
+    # resolved config includes every n ∈ N_C (RFC §3.4), so a missing
+    # producer is a phase error regardless of gate consumption.
+    for cvar in module.cvars:
+        if cvar.name not in calibrators or cvar.name not in evidence:
             rejections.append(R4_PHASE_MISMATCH)
 
-    # R7: evidence leakage — calibration evidence drawn from the eval split.
+    # R7: evidence leakage — the RFC condition is the true intersection
+    # 𝓔_cal ∩ 𝓔_eval ≠ ∅ over evidence items (not a split-label proxy).
     for cvar in module.cvars:
         ev = evidence.get(cvar.name)
-        if ev is not None and ev.split == eval_split:
+        if ev is not None and set(ev.items) & set(eval_items):
             rejections.append(R7_EVIDENCE_LEAKAGE)
 
-    # R8: insufficient evidence.
+    # R8: insufficient evidence — the epsilon-derived conformal floor
+    # n_cal < ⌈1/ε⌉ − 1 for a chance-style target at level ε (RFC §3.4).
     for cvar in module.cvars:
         ev = evidence.get(cvar.name)
-        if ev is not None and len(ev.items) < evidence_floor:
-            rejections.append(R8_INSUFFICIENT_EVIDENCE)
+        if ev is not None and cvar.target_epsilon is not None:
+            floor = math.ceil(1.0 / cvar.target_epsilon) - 1
+            if len(ev.items) < floor:
+                rejections.append(R8_INSUFFICIENT_EVIDENCE)
 
     # Run calibrators (only meaningful if structurally sane so far).
     values: Dict[str, Any] = {}
@@ -390,7 +451,7 @@ def resolve(
         cal = calibrators.get(cvar.name)
         ev = evidence.get(cvar.name)
         if cal is None or ev is None:
-            continue  # already covered by R4 when consumed
+            continue  # R4 already recorded above; no value to produce
         try:
             out = cal(
                 {p: suggestion.get(p) for p in cvar.depends_on},
@@ -405,6 +466,9 @@ def resolve(
             bottom.append(cvar.name)
             continue
         values[cvar.name] = out
+        # R5: TYPE conformance (RFC: "validity domain or type").
+        if not _type_conforms(out, cvar.cvar_type):
+            rejections.append(R5_INFEASIBLE_VALUE)
         # R5: validity domain.
         if cvar.validity_domain is not None:
             lo, hi = cvar.validity_domain
@@ -457,11 +521,13 @@ P7_VERDICTS = (
 
 
 def strict(module: Module, consumed_cvars: Sequence[CVar]) -> bool:
-    """RFC §3.6 strict(M, c)."""
+    """RFC §3.6 strict(M, c) — ALL FIVE disjuncts."""
     return (
         module.require_calibration_enabled
         or module.has_chance_constraints
+        or module.has_guaranteed_selection_target
         or any(c.require_calibration for c in consumed_cvars)
+        or any(c.certificate_backed_target for c in consumed_cvars)
     )
 
 

--- a/tests/model_checking/model.py
+++ b/tests/model_checking/model.py
@@ -1,0 +1,522 @@
+"""Finite abstraction of RFC 0001 §3 — binding partition, resolution, certificates.
+
+This is a MODEL, not the implementation: types are tiny, value spaces are
+finite, and the semantics transcribe the RFC clauses one-to-one so that
+property checks read like the spec. Section references are to
+formalization/rfc-0001-knob-bindings-cvars-policies.md (Draft v2).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import unicodedata
+from dataclasses import dataclass, field
+from typing import Any, Dict, FrozenSet, List, Mapping, Optional, Sequence, Tuple
+
+# ---------------------------------------------------------------------------
+# Canonical hashing H_c — model form of RFC §3.5.
+# The model uses sorted-key JSON with the RFC's value restrictions; the
+# cross-implementation RFC 8785 known-answer fixtures are a Phase 4 artifact.
+# ---------------------------------------------------------------------------
+
+
+def h_c(value: Any) -> str:
+    """Model canonical hash: NFC-normalised, sorted-key, finite-number JSON."""
+
+    def _norm(v: Any) -> Any:
+        if isinstance(v, str):
+            return unicodedata.normalize("NFC", v)
+        if isinstance(v, float):
+            if v != v or v in (float("inf"), float("-inf")):
+                raise ValueError("non-finite numbers are rejected, never hashed")
+            if v == 0.0:
+                return 0.0  # -0.0 -> 0.0
+            return v
+        if isinstance(v, Mapping):
+            keys = list(v.keys())
+            if len(keys) != len(set(keys)):
+                raise ValueError("duplicate keys rejected")
+            return {_norm(k): _norm(val) for k, val in v.items()}
+        if isinstance(v, (list, tuple)):
+            return [_norm(item) for item in v]
+        return v
+
+    payload = json.dumps(_norm(value), sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Declarations — RFC §3.1, §3.3, §3.8.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TVar:
+    name: str
+    domain: Tuple[Any, ...]  # finite searched domain (model scope)
+
+
+@dataclass(frozen=True)
+class CVar:
+    name: str
+    source: str
+    cvar_type: str = "float"
+    depends_on: Tuple[str, ...] = ()
+    validity_domain: Optional[Tuple[float, float]] = None  # closed interval (§3.3)
+    require_calibration: bool = False
+    signal: str = "sig_v1"
+    calibrator: str = "cal_v1"
+    calibrator_version: str = "1"
+    calibrator_params: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class Gate:
+    kind: str  # v1 registry: "margin_below"
+    threshold: str  # namespace ref -> MUST resolve to a CVar (§3.8)
+
+
+@dataclass(frozen=True)
+class Policy:
+    name: str
+    strategy: str  # v1 registry: "cascade"
+    stages: Tuple[str, ...]  # opaque runtime ids, NOT namespace refs (§3.8)
+    gates: Tuple[Gate, ...] = ()
+
+
+@dataclass(frozen=True)
+class Module:
+    tvars: Tuple[TVar, ...] = ()
+    cvars: Tuple[CVar, ...] = ()
+    policies: Tuple[Policy, ...] = ()
+    # promotion_policy strict-mode declarations (§3.6)
+    require_calibration_enabled: bool = False
+    has_chance_constraints: bool = False
+
+    @property
+    def n_t(self) -> FrozenSet[str]:
+        return frozenset(t.name for t in self.tvars)
+
+    @property
+    def n_c(self) -> FrozenSet[str]:
+        return frozenset(c.name for c in self.cvars)
+
+    @property
+    def declared_names(self) -> Tuple[str, ...]:
+        """All declared names in order — the shared namespace (§3.7(3))."""
+        return tuple(
+            [t.name for t in self.tvars]
+            + [c.name for c in self.cvars]
+            + [p.name for p in self.policies]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Static namespace diagnostics — RFC §3.7.
+# ---------------------------------------------------------------------------
+
+
+def namespace_diagnostics(module: Module) -> List[Tuple[str, str]]:
+    """Return (code, name) diagnostics for the shared-namespace rules.
+
+    Errors: duplicate names anywhere across tvars ∪ cvars ∪ policies.
+    Warning-or-error: namespace_prefix_collision — severity is decided by the
+    caller per §3.7(5) (warning on 1.0-valid modules, error with 1.1
+    constructs); the model just detects.
+    """
+    diags: List[Tuple[str, str]] = []
+    names = module.declared_names
+    seen: Dict[str, int] = {}
+    for name in names:
+        seen[name] = seen.get(name, 0) + 1
+    for name, count in seen.items():
+        if count > 1:
+            diags.append(("duplicate_name", name))
+    unique = sorted(seen)
+    for shorter in unique:
+        prefix = shorter + "."
+        for longer in unique:
+            if longer.startswith(prefix):
+                diags.append(("namespace_prefix_collision", shorter))
+                break
+    return diags
+
+
+def uses_11_constructs(module: Module) -> bool:
+    """§3.7(5): the new-surface opt-in that escalates prefix collisions."""
+    return bool(module.cvars or module.policies or module.require_calibration_enabled)
+
+
+# ---------------------------------------------------------------------------
+# Certificates and freshness — RFC §3.5.
+# ---------------------------------------------------------------------------
+
+CTX_SCHEMA_VERSION = 1
+CTX_EXT_KEYS = frozenset(
+    {"stage_versions", "model_versions", "budget_assumptions", "cost_assumptions"}
+)
+
+
+@dataclass(frozen=True)
+class FreshnessContext:
+    """ctx_core (always hashed) + selected extension keys."""
+
+    cvar_name: str
+    tuned_parent_values: Tuple[Tuple[str, Any], ...]  # sorted by name
+    calibration_source_id: str
+    signal_spec_hash: str
+    calibrator_id: str
+    calibrator_version: str
+    calibrator_params_hash: str
+    dataset_hash: str
+    evidence_n: int
+    calibration_split: str
+    eval_split: str
+    target: str
+    extensions: Tuple[Tuple[str, Any], ...] = ()  # subset of CTX_EXT_KEYS
+
+    def freshness_hash(self) -> str:
+        core = {
+            "ctx_schema_version": CTX_SCHEMA_VERSION,
+            "cvar_name": self.cvar_name,
+            "tuned_parent_values": list(self.tuned_parent_values),
+            "calibration_source_id": self.calibration_source_id,
+            "signal_spec_hash": self.signal_spec_hash,
+            "calibrator_id": self.calibrator_id,
+            "calibrator_version": self.calibrator_version,
+            "calibrator_params_hash": self.calibrator_params_hash,
+            "dataset_hash": self.dataset_hash,
+            "evidence_n": self.evidence_n,
+            "calibration_split": self.calibration_split,
+            "eval_split": self.eval_split,
+            "target": self.target,
+        }
+        for key, _ in self.extensions:
+            if key not in CTX_EXT_KEYS:
+                raise ValueError(f"invalid_calibration_context: {key}")
+        return h_c({"core": core, "ext": list(self.extensions)})
+
+
+CERTIFIED = "CERTIFIED"
+NO_DECISION = "NO_DECISION"
+BEST_EFFORT_UNCERTIFIED = "BEST_EFFORT_UNCERTIFIED"
+
+
+@dataclass(frozen=True)
+class Certificate:
+    subject_cvar: str
+    subject_type: str
+    subject_value_hash: str
+    target: str
+    issued_hash: str
+    decision: str
+    evidence_n: int
+    evidence_pool_hash: str
+
+    def valid_for(
+        self, cvar: str, cvar_type: str, value: Any, ctx: FreshnessContext
+    ) -> bool:
+        """RFC §3.5 (Draft v4) validity — every field participates; the audit
+        copies (target, evidence) must agree with the live context, and the
+        live context must itself name the queried CVAR (round-3 fix: closes
+        the forged-subject hole)."""
+        return (
+            ctx.cvar_name == cvar
+            and self.subject_cvar == cvar
+            and self.subject_type == cvar_type
+            and self.subject_value_hash == h_c(value)
+            and self.target == ctx.target
+            and self.evidence_n == ctx.evidence_n
+            and self.evidence_pool_hash == ctx.dataset_hash
+            and self.issued_hash == ctx.freshness_hash()
+            and self.decision == CERTIFIED
+        )
+
+
+def issue_certificate(
+    cvar: str, value: Any, ctx: FreshnessContext, cvar_type: str = "float"
+) -> Certificate:
+    return Certificate(
+        subject_cvar=cvar,
+        subject_type=cvar_type,
+        subject_value_hash=h_c(value),
+        target=ctx.target,
+        issued_hash=ctx.freshness_hash(),
+        decision=CERTIFIED,
+        evidence_n=ctx.evidence_n,
+        evidence_pool_hash=ctx.dataset_hash,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Resolution — RFC §3.4 (R1-R8 + Accept).
+# ---------------------------------------------------------------------------
+
+R1_CYCLE = "cycle"
+R2_MISSING_REF = "missing_ref"
+R3_DUPLICATE_PROVIDER = "duplicate_provider"
+R4_PHASE_MISMATCH = "phase_mismatch"
+R5_INFEASIBLE_VALUE = "infeasible_value"
+R6_STALE_CERTIFICATE = "stale_certificate"
+R7_EVIDENCE_LEAKAGE = "evidence_leakage"
+R8_INSUFFICIENT_EVIDENCE = "insufficient_evidence"
+NO_DECISION_VERDICT = "no_decision"
+
+ALL_REJECTIONS = (
+    R1_CYCLE,
+    R2_MISSING_REF,
+    R3_DUPLICATE_PROVIDER,
+    R4_PHASE_MISMATCH,
+    R5_INFEASIBLE_VALUE,
+    R6_STALE_CERTIFICATE,
+    R7_EVIDENCE_LEAKAGE,
+    R8_INSUFFICIENT_EVIDENCE,
+)
+
+
+@dataclass(frozen=True)
+class Evidence:
+    """Calibration evidence pool (model form)."""
+
+    items: Tuple[str, ...]  # item ids
+    split: str  # which split the pool was drawn from
+    pool_hash: str = "pool_v1"
+
+
+@dataclass
+class Calibrator:
+    """Model calibrator 𝒦_n: returns a fixed value, ⊥ (None), or raises."""
+
+    value: Optional[Any] = 0.5
+    raises: bool = False
+
+    def __call__(self, parents: Mapping[str, Any], evidence: Evidence) -> Optional[Any]:
+        if self.raises:
+            raise RuntimeError("calibrator exception")
+        return self.value
+
+
+@dataclass(frozen=True)
+class Resolution:
+    accepted: bool
+    config: Optional[Mapping[str, Any]]
+    rejections: Tuple[str, ...]  # subset of ALL_REJECTIONS, or (no_decision,)
+    used_fallback: Tuple[str, ...] = ()
+
+
+def resolve(
+    module: Module,
+    suggestion: Mapping[str, Any],
+    fixed: Mapping[str, Any],
+    calibrators: Mapping[str, Calibrator],
+    evidence: Mapping[str, Evidence],
+    certificates: Mapping[str, Certificate],
+    contexts: Mapping[str, FreshnessContext],
+    *,
+    eval_split: str = "eval",
+    evidence_floor: int = 0,
+) -> Resolution:
+    """Transcription of RFC §3.4: Accept ⟺ ¬(R1∨...∨R8) ∧ ∀ calibrators ≠ ⊥.
+
+    The implementation collects EVERY applicable rejection (no short-circuit)
+    so the property checks can assert exact complementarity.
+    """
+    rejections: List[str] = []
+    n_t, n_c = module.n_t, module.n_c
+
+    # R2: depends_on must resolve to a declared TVAR (exact match, §3.7(4)).
+    for cvar in module.cvars:
+        for ref in cvar.depends_on:
+            if ref not in n_t:
+                rejections.append(R2_MISSING_REF)
+    # gates[].threshold must resolve to a CVAR (kind-checked) — also R2.
+    for policy in module.policies:
+        for gate in policy.gates:
+            if gate.threshold not in n_c:
+                rejections.append(R2_MISSING_REF)
+
+    # R1: cycles. v1 graphs are bipartite CVAR→TVAR; detect anyway (the
+    # checker proves this unreachable for well-formed v1 modules).
+    adjacency = {c.name: set(c.depends_on) & n_c for c in module.cvars}
+    visited: Dict[str, int] = {}
+
+    def _has_cycle(node: str) -> bool:
+        state = visited.get(node, 0)
+        if state == 1:
+            return True
+        if state == 2:
+            return False
+        visited[node] = 1
+        for nxt in adjacency.get(node, ()):
+            if _has_cycle(nxt):
+                return True
+        visited[node] = 2
+        return False
+
+    if any(_has_cycle(name) for name in adjacency):
+        rejections.append(R1_CYCLE)
+
+    # R3: duplicate providers — fixed assignment colliding with declarations,
+    # or static partition collisions.
+    if set(fixed) & (n_t | n_c):
+        rejections.append(R3_DUPLICATE_PROVIDER)
+    if n_t & n_c:
+        rejections.append(R3_DUPLICATE_PROVIDER)
+
+    # R4: phase mismatch — a CVAR consumed (as gate threshold) must be
+    # resolvable, i.e. its calibrator/evidence present before use.
+    consumed = {g.threshold for p in module.policies for g in p.gates}
+    for name in consumed & n_c:
+        if name not in calibrators or name not in evidence:
+            rejections.append(R4_PHASE_MISMATCH)
+
+    # R7: evidence leakage — calibration evidence drawn from the eval split.
+    for cvar in module.cvars:
+        ev = evidence.get(cvar.name)
+        if ev is not None and ev.split == eval_split:
+            rejections.append(R7_EVIDENCE_LEAKAGE)
+
+    # R8: insufficient evidence.
+    for cvar in module.cvars:
+        ev = evidence.get(cvar.name)
+        if ev is not None and len(ev.items) < evidence_floor:
+            rejections.append(R8_INSUFFICIENT_EVIDENCE)
+
+    # Run calibrators (only meaningful if structurally sane so far).
+    values: Dict[str, Any] = {}
+    bottom: List[str] = []
+    for cvar in module.cvars:
+        cal = calibrators.get(cvar.name)
+        ev = evidence.get(cvar.name)
+        if cal is None or ev is None:
+            continue  # already covered by R4 when consumed
+        try:
+            out = cal(
+                {p: suggestion.get(p) for p in cvar.depends_on},
+                ev,
+            )
+        except Exception:
+            # A raising calibrator yields no value: at the RESOLVER layer this
+            # is ⊥ (no_decision). "Gate exception" is a distinct verdict at
+            # the PROMOTION layer (RFC §3.6), modeled in promotion_outcome.
+            out = None
+        if out is None:
+            bottom.append(cvar.name)
+            continue
+        values[cvar.name] = out
+        # R5: validity domain.
+        if cvar.validity_domain is not None:
+            lo, hi = cvar.validity_domain
+            if not (lo <= out <= hi):
+                rejections.append(R5_INFEASIBLE_VALUE)
+        # R6: certificate required and must be valid for (cvar, value, ctx).
+        if cvar.require_calibration:
+            cert = certificates.get(cvar.name)
+            ctx = contexts.get(cvar.name)
+            if (
+                cert is None
+                or ctx is None
+                or not cert.valid_for(cvar.name, cvar.cvar_type, out, ctx)
+            ):
+                rejections.append(R6_STALE_CERTIFICATE)
+
+    # R5 for fixed values: model fixed-domain as "value must not be the
+    # sentinel INVALID".
+    for name, value in fixed.items():
+        if value == "INVALID":
+            rejections.append(R5_INFEASIBLE_VALUE)
+
+    unique_rejections = tuple(dict.fromkeys(rejections))
+    if unique_rejections:
+        return Resolution(False, None, unique_rejections)
+    if bottom:
+        return Resolution(False, None, (NO_DECISION_VERDICT,))
+
+    config = dict(suggestion)
+    config.update(fixed)
+    config.update(values)
+    return Resolution(True, config, ())
+
+
+# ---------------------------------------------------------------------------
+# Strict promotion — RFC §3.6.
+# ---------------------------------------------------------------------------
+
+PROMOTE = "promote"
+REJECT = "reject"
+NO_CERTIFIED_SELECTION = "no_certified_selection"
+
+P7_VERDICTS = (
+    "insufficient_evidence",
+    "gate_exception",
+    "stale_certificate",
+    "calibrator_bottom",
+    "gate_no_decision",
+)
+
+
+def strict(module: Module, consumed_cvars: Sequence[CVar]) -> bool:
+    """RFC §3.6 strict(M, c)."""
+    return (
+        module.require_calibration_enabled
+        or module.has_chance_constraints
+        or any(c.require_calibration for c in consumed_cvars)
+    )
+
+
+def promotion_outcome(
+    module: Module,
+    consumed_cvars: Sequence[CVar],
+    verdict: Optional[str],
+    candidate_beats_incumbent: bool,
+) -> str:
+    """Finite promotion machine: the fail-closed law (P7).
+
+    verdict ∈ P7_VERDICTS means an evidence failure occurred; None means
+    clean evidence. Non-strict modules with clean evidence promote on
+    dominance; the model intentionally allows the LEGACY behavior (simple
+    best wins) only outside strict mode, mirroring the SDK repair scope.
+    """
+    if strict(module, consumed_cvars):
+        if verdict is not None:
+            return NO_CERTIFIED_SELECTION
+        return PROMOTE if candidate_beats_incumbent else REJECT
+    # non-strict: legacy semantics, unchanged by the RFC
+    return PROMOTE if candidate_beats_incumbent else REJECT
+
+
+# ---------------------------------------------------------------------------
+# Cascade execution — RFC §3.8.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class VoteStats:
+    margin: float
+    tie: bool = False
+
+
+def cascade_select(
+    stages: Sequence[str],
+    thetas: Sequence[float],
+    votes: Sequence[VoteStats],
+) -> int:
+    """Return the 0-based index of the stage whose output is returned.
+
+    Transcribes  j = min{ i : i = m ∨ g_i(vote_i) = stop }  with the v1 gate
+    escalate ⟺ margin < θ_i.  len(thetas) == len(stages) - 1 is the arity
+    invariant; votes are the per-stage vote statistics (votes[i] consumed by
+    gate i, the gate AFTER stage i+1's would-be source — only the first m-1
+    stages vote in this model).
+    """
+    m = len(stages)
+    if m < 1:
+        raise ValueError("cascade requires |stages| >= 1")
+    if len(thetas) != m - 1:
+        raise ValueError("|gates| must equal |stages| - 1")
+    for i in range(m - 1):
+        escalate = votes[i].margin < thetas[i]
+        if not escalate:
+            return i
+    return m - 1

--- a/tests/model_checking/test_certificate.py
+++ b/tests/model_checking/test_certificate.py
@@ -170,3 +170,28 @@ def test_forged_subject_cross_context_rejected():
     # query A with A's own live context: issued_hash (covering cvar_name) fails
     ctx_a = _ctx(cvar_name="theta_a")
     assert not forged.valid_for("theta_a", "float", 0.5, ctx_a)
+
+
+def test_extension_order_insensitive():
+    """Canonical hashing: the SAME extension map in a different order must
+    hash identically (extensions are a map, not a sequence)."""
+    a = _ctx(extensions=(("model_versions", "mv1"), ("stage_versions", "sv1")))
+    b = _ctx(extensions=(("stage_versions", "sv1"), ("model_versions", "mv1")))
+    assert a.freshness_hash() == b.freshness_hash()
+
+
+def test_duplicate_extension_key_rejected():
+    ctx = _ctx(extensions=(("model_versions", "a"), ("model_versions", "b")))
+    with pytest.raises(ValueError, match="duplicate_calibration_context_key"):
+        ctx.freshness_hash()
+
+
+def test_parent_order_insensitive_and_duplicates_rejected():
+    """tuned_parent_values is sorted-by-name BY THE MODEL (not trusted from
+    the caller); duplicate parent names are rejected."""
+    a = _ctx(tuned_parent_values=(("a", 1), ("b", 2)))
+    b = _ctx(tuned_parent_values=(("b", 2), ("a", 1)))
+    assert a.freshness_hash() == b.freshness_hash()
+    dup = _ctx(tuned_parent_values=(("a", 1), ("a", 2)))
+    with pytest.raises(ValueError, match="duplicate_tuned_parent"):
+        dup.freshness_hash()

--- a/tests/model_checking/test_certificate.py
+++ b/tests/model_checking/test_certificate.py
@@ -1,0 +1,172 @@
+"""Small-scope checks of RFC §3.5 — certificate subject binding + freshness.
+
+The two review-driven theorems:
+  (finding 2) a certificate is valid only for ITS cvar and ITS value;
+  (finding 3) ctx_core is immutable — no extension selection can disable
+              parent-specificity — and EVERY core key flip is staleness-inducing.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from .model import (
+    CTX_EXT_KEYS,
+    Certificate,
+    FreshnessContext,
+    h_c,
+    issue_certificate,
+)
+
+
+def _ctx(**overrides) -> FreshnessContext:
+    base = dict(
+        cvar_name="theta",
+        tuned_parent_values=(("model", "m1"),),
+        calibration_source_id="src",
+        signal_spec_hash=h_c("sig_v1"),
+        calibrator_id="cal_v1",
+        calibrator_version="1",
+        calibrator_params_hash=h_c({"budgets": [0.1, 0.2]}),
+        dataset_hash="pool_v1",
+        evidence_n=20,
+        calibration_split="cal",
+        eval_split="eval",
+        target="tgt",
+        extensions=(),
+    )
+    base.update(overrides)
+    return FreshnessContext(**base)
+
+
+CORE_FLIPS = [
+    ("cvar_name", "theta2"),
+    ("tuned_parent_values", (("model", "m2"),)),
+    ("calibration_source_id", "src2"),
+    ("signal_spec_hash", h_c("sig_v2")),
+    ("calibrator_id", "cal_v2"),
+    ("calibrator_version", "2"),
+    ("calibrator_params_hash", h_c({"budgets": [0.3]})),
+    ("dataset_hash", "pool_v2"),
+    ("evidence_n", 21),
+    ("calibration_split", "cal2"),
+    ("eval_split", "eval2"),
+    ("target", "tgt2"),
+]
+
+
+def test_valid_for_same_context():
+    ctx = _ctx()
+    cert = issue_certificate("theta", 0.5, ctx)
+    assert cert.valid_for("theta", "float", 0.5, ctx)
+
+
+@pytest.mark.parametrize("field_name,new_value", CORE_FLIPS)
+def test_every_core_key_flip_is_staleness_inducing(field_name, new_value):
+    """Flip each ctx_core key individually → certificate stale (P-claim from
+    the plan: 'certificates become stale when any freshness-key input changes')."""
+    ctx = _ctx()
+    cert = issue_certificate("theta", 0.5, ctx)
+    flipped = dataclasses.replace(ctx, **{field_name: new_value})
+    assert not cert.valid_for("theta", "float", 0.5, flipped), field_name
+
+
+def test_extension_key_flip_is_staleness_inducing_when_selected():
+    ctx = _ctx(extensions=(("model_versions", "mv1"),))
+    cert = issue_certificate("theta", 0.5, ctx)
+    flipped = _ctx(extensions=(("model_versions", "mv2"),))
+    assert not cert.valid_for("theta", "float", 0.5, flipped)
+
+
+def test_subject_binds_cvar_name():
+    """Finding 2: a certificate for theta is NOT valid for theta2, even with
+    an identical context shape."""
+    ctx = _ctx()
+    cert = issue_certificate("theta", 0.5, ctx)
+    ctx2 = _ctx(cvar_name="theta2")
+    assert not cert.valid_for("theta2", "float", 0.5, ctx2)
+
+
+def test_subject_binds_value():
+    """Finding 2: a certificate for value 0.5 is NOT valid for value 0.6."""
+    ctx = _ctx()
+    cert = issue_certificate("theta", 0.5, ctx)
+    assert not cert.valid_for("theta", "float", 0.6, ctx)
+
+
+def test_non_certified_decision_is_never_valid():
+    ctx = _ctx()
+    cert = issue_certificate("theta", 0.5, ctx)
+    for decision in ("NO_DECISION", "BEST_EFFORT_UNCERTIFIED"):
+        downgraded = dataclasses.replace(cert, decision=decision)
+        assert not downgraded.valid_for("theta", "float", 0.5, ctx)
+
+
+def test_parent_specificity_cannot_be_disabled_by_extension_choice():
+    """Finding 3: parent values are CORE — no extension selection makes a
+    parent-changed context hash-equal. Enumerate every extension subset."""
+    import itertools
+
+    for r in range(len(CTX_EXT_KEYS) + 1):
+        for subset in itertools.combinations(sorted(CTX_EXT_KEYS), r):
+            ext = tuple((k, "v") for k in subset)
+            ctx_m1 = _ctx(extensions=ext)
+            ctx_m2 = _ctx(tuned_parent_values=(("model", "m2"),), extensions=ext)
+            assert ctx_m1.freshness_hash() != ctx_m2.freshness_hash(), subset
+
+
+def test_invalid_extension_key_rejected():
+    ctx = _ctx(extensions=(("not_a_real_key", "v"),))
+    with pytest.raises(ValueError, match="invalid_calibration_context"):
+        ctx.freshness_hash()
+
+
+def test_canonicalization_rules():
+    """§3.5 H_c restrictions: NFC strings, -0.0 fold, non-finite rejection."""
+    assert h_c("café") == h_c("cafe\u0301")  # NFC: composed == decomposed
+    assert h_c({"x": -0.0}) == h_c({"x": 0.0})
+    with pytest.raises(ValueError):
+        h_c(float("nan"))
+    with pytest.raises(ValueError):
+        h_c(float("inf"))
+    # key order independence
+    assert h_c({"a": 1, "b": 2}) == h_c({"b": 2, "a": 1})
+
+
+def test_subject_type_checked():
+    """v3 (review round 2, new finding 1): wrong declared type => invalid."""
+    ctx = _ctx()
+    cert = issue_certificate("theta", 0.5, ctx, cvar_type="float")
+    assert not cert.valid_for("theta", "int", 0.5, ctx)
+
+
+def test_audit_copies_must_agree_with_live_context():
+    """v3: a certificate cannot DISPLAY one context while HASHING another —
+    tampered audit fields (target/evidence) invalidate even with a correct
+    issued_hash."""
+    ctx = _ctx()
+    cert = issue_certificate("theta", 0.5, ctx)
+    for field_name, bad in [
+        ("target", "tgt_forged"),
+        ("evidence_n", 999),
+        ("evidence_pool_hash", "pool_forged"),
+    ]:
+        tampered = dataclasses.replace(cert, **{field_name: bad})
+        assert not tampered.valid_for("theta", "float", 0.5, ctx), field_name
+
+
+def test_forged_subject_cross_context_rejected():
+    """v4 (review round 3): a certificate issued against CVAR B's context with
+    a FORGED subject naming A must not validate A — the live context presented
+    for A must itself name A (valid's first conjunct)."""
+    ctx_b = _ctx(cvar_name="theta_b")
+    forged = dataclasses.replace(
+        issue_certificate("theta_b", 0.5, ctx_b), subject_cvar="theta_a"
+    )
+    # query A with B's live context: first conjunct ctx.cvar_name == cvar fails
+    assert not forged.valid_for("theta_a", "float", 0.5, ctx_b)
+    # query A with A's own live context: issued_hash (covering cvar_name) fails
+    ctx_a = _ctx(cvar_name="theta_a")
+    assert not forged.valid_for("theta_a", "float", 0.5, ctx_a)

--- a/tests/model_checking/test_legacy_corpus.py
+++ b/tests/model_checking/test_legacy_corpus.py
@@ -1,0 +1,104 @@
+"""P1 — conservative extension over the REAL canonical example corpus.
+
+Phase-3 form: for every existing example module, injecting the new 1.1 blocks
+at dict level changes NEITHER the lint diagnostics NOR the structural-SAT
+verdict produced by the real python/tvl pipeline. (Schema-level P1 — the
+loader accepting the new blocks — is the Phase 4 obligation; lint_module and
+compile_constraints read only the fields they know, which is exactly what
+this suite locks.)
+"""
+
+from __future__ import annotations
+
+import copy
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tvl.constraints import check_structural_satisfiable, compile_constraints
+from tvl.lints import lint_module
+
+EXAMPLES_ROOT = Path(__file__).resolve().parents[2] / "spec" / "examples"
+
+# The phase-6 fixtures themselves are 1.1-surface documents; exclude them from
+# the LEGACY corpus (they are the forward fixtures, not the 1.0 baseline).
+CORPUS = sorted(
+    p
+    for p in EXAMPLES_ROOT.rglob("*.yml")
+    if "validation-phase6-cvars" not in str(p)
+)
+
+INJECTED_CVARS = [
+    {
+        "name": "injected.theta",
+        "type": "float",
+        "domain": {"range": [0.0, 1.0]},
+        "calibration": {"source": "pool_a"},
+        "governance": {"require_calibration": True},
+    }
+]
+
+INJECTED_POLICIES = [
+    {
+        "name": "injected.cascade",
+        "kind": "policy",
+        "strategy": "cascade",
+        "stages": ["cheap", "strong"],
+        "gates": [{"kind": "margin_below", "threshold": "injected.theta"}],
+    }
+]
+
+
+def _issues_key(issues) -> list:
+    # lint_module yields Issue objects for most checks but plain dicts for
+    # some (e.g. schema-shaped diagnostics) — normalize both.
+    def _key(issue):
+        if isinstance(issue, dict):
+            return (str(issue.get("code")), str(issue.get("path", "")))
+        return (str(issue.code), str(getattr(issue, "path", "")))
+
+    return sorted(_key(i) for i in issues)
+
+
+@pytest.mark.parametrize("path", CORPUS, ids=lambda p: str(p.relative_to(EXAMPLES_ROOT)))
+def test_p1_lint_and_sat_unchanged_by_injection(path):
+    doc = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(doc, dict) or "tvars" not in doc:
+        pytest.skip("not a module document (config/measurement/policy file)")
+
+    extended = copy.deepcopy(doc)
+    extended["cvars"] = copy.deepcopy(INJECTED_CVARS)
+    extended["policies"] = copy.deepcopy(INJECTED_POLICIES)
+
+    # Lint equivalence: identical diagnostics with and without the new blocks.
+    assert _issues_key(lint_module(doc)) == _issues_key(lint_module(extended))
+
+    # SAT equivalence where the module compiles/solves at all (some corpus
+    # files are intentionally broken; equivalence of the FAILURE is asserted
+    # instead — P1 is about identical behavior, including identical errors).
+    def _compile_and_solve(module):
+        try:
+            compiled = compile_constraints(module)
+        except Exception as exc:  # noqa: BLE001 — corpus contains intentional errors
+            return None, None, f"compile:{type(exc).__name__}"
+        try:
+            sat = check_structural_satisfiable(compiled)
+        except Exception as exc:  # noqa: BLE001 — see pre-existing _encode_bound bug
+            return compiled, None, f"solve:{type(exc).__name__}"
+        return compiled, sat, None
+
+    base_compiled, base_sat, base_error = _compile_and_solve(doc)
+    ext_compiled, ext_sat, ext_error = _compile_and_solve(extended)
+
+    assert base_error == ext_error
+    if base_compiled is not None:
+        assert set(base_compiled.domains) == set(ext_compiled.domains)
+        assert "injected.theta" not in ext_compiled.domains
+    if base_sat is not None:
+        assert base_sat.get("ok") == ext_sat.get("ok")
+        assert base_sat.get("ok") is not None
+
+
+def test_corpus_is_nonempty():
+    assert len(CORPUS) >= 20, f"corpus unexpectedly small: {len(CORPUS)}"

--- a/tests/model_checking/test_partition_namespace.py
+++ b/tests/model_checking/test_partition_namespace.py
@@ -10,9 +10,11 @@ import itertools
 
 from .model import (
     CVar,
+    Gate,
     Module,
     Policy,
     TVar,
+    declaration_diagnostics,
     namespace_diagnostics,
     uses_11_constructs,
 )
@@ -91,3 +93,39 @@ def test_shared_namespace_spans_all_three_blocks():
         assert any(
             code == "duplicate_name" for code, _ in namespace_diagnostics(module)
         ), module
+
+
+def test_ident_grammar_enforced():
+    """§3.7(2): ASCII dotted identifiers, no empty segments/leading dots."""
+    bad_names = ["1bad", "a..b", ".a", "a.", "a-b", "café"]
+    for name in bad_names:
+        module = Module(tvars=(TVar(name, (0,)),))
+        assert ("invalid_ident", name) in declaration_diagnostics(module), name
+    good = Module(tvars=(TVar("a_1.b2", (0,)),))
+    assert not declaration_diagnostics(good)
+
+
+def test_duplicate_stage_diagnosed():
+    module = Module(
+        cvars=(CVar("theta", source="s"),),
+        policies=(
+            Policy(
+                "p", "cascade", ("cheap", "cheap"), (Gate("margin_below", "theta"),)
+            ),
+        ),
+    )
+    assert ("duplicate_stage", "p") in declaration_diagnostics(module)
+
+
+def test_cascade_arity_diagnosed_statically():
+    three_stages_one_gate = Module(
+        cvars=(CVar("theta", source="s"),),
+        policies=(
+            Policy(
+                "p", "cascade", ("a", "b", "c"), (Gate("margin_below", "theta"),)
+            ),
+        ),
+    )
+    assert ("cascade_arity", "p") in declaration_diagnostics(three_stages_one_gate)
+    m1_no_gates = Module(policies=(Policy("p", "cascade", ("only",)),))
+    assert ("cascade_arity", "p") not in declaration_diagnostics(m1_no_gates)

--- a/tests/model_checking/test_partition_namespace.py
+++ b/tests/model_checking/test_partition_namespace.py
@@ -1,0 +1,93 @@
+"""Small-scope checks: binding partition (RFC §3.1) and namespaces (§3.7).
+
+Exhaustive enumeration over tiny name universes — every module shape up to
+the scope bound is checked, so these are small-scope proofs, not samples.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+from .model import (
+    CVar,
+    Module,
+    Policy,
+    TVar,
+    namespace_diagnostics,
+    uses_11_constructs,
+)
+
+NAMES = ("a", "b", "a.x")  # includes a dotted name and its strict prefix
+
+
+def all_modules_up_to_scope():
+    """Enumerate all modules with ≤2 tvars, ≤2 cvars, ≤1 policy over NAMES."""
+    for n_tvars in range(3):
+        for tvar_names in itertools.combinations(NAMES, n_tvars):
+            for n_cvars in range(3):
+                for cvar_names in itertools.combinations(NAMES, n_cvars):
+                    for policy_names in ([], ["a"], ["b"]):
+                        yield Module(
+                            tvars=tuple(TVar(n, (0, 1)) for n in tvar_names),
+                            cvars=tuple(CVar(n, source="s") for n in cvar_names),
+                            policies=tuple(
+                                Policy(n, "cascade", ("st1",)) for n in policy_names
+                            ),
+                        )
+
+
+def test_partition_collision_detected_iff_overlap():
+    """P6/§3.1: duplicate_name fires exactly when names collide across blocks."""
+    checked = 0
+    for module in all_modules_up_to_scope():
+        names = module.declared_names
+        has_dup = len(names) != len(set(names))
+        diags = {code for code, _ in namespace_diagnostics(module)}
+        assert ("duplicate_name" in diags) == has_dup, module
+        checked += 1
+    assert checked > 100  # the scope actually enumerated something substantial
+
+
+def test_prefix_collision_detected_exactly_for_strict_prefix_pairs():
+    """§3.7(5): a.x + a is a prefix collision; a.x alone or a+b is not."""
+    with_pair = Module(tvars=(TVar("a", (0,)), TVar("a.x", (0,))))
+    without_pair = Module(tvars=(TVar("a.x", (0,)), TVar("b", (0,))))
+    assert any(
+        code == "namespace_prefix_collision"
+        for code, _ in namespace_diagnostics(with_pair)
+    )
+    assert not any(
+        code == "namespace_prefix_collision"
+        for code, _ in namespace_diagnostics(without_pair)
+    )
+
+
+def test_prefix_collision_severity_policy():
+    """§3.7(5): warning on 1.0-valid modules; error only with 1.1 constructs.
+
+    The model exposes detection; severity is the declared policy — this test
+    pins the POLICY function (uses_11_constructs) that Phase 4 lints must use.
+    """
+    legacy = Module(tvars=(TVar("a", (0,)), TVar("a.x", (0,))))
+    modern = Module(
+        tvars=(TVar("a", (0,)), TVar("a.x", (0,))),
+        cvars=(CVar("c", source="s"),),
+    )
+    assert not uses_11_constructs(legacy)  # -> warning severity
+    assert uses_11_constructs(modern)  # -> error severity
+
+
+def test_shared_namespace_spans_all_three_blocks():
+    """§3.7(3): tvar/cvar/policy name collisions are all detected."""
+    cases = [
+        Module(tvars=(TVar("x", (0,)),), cvars=(CVar("x", source="s"),)),
+        Module(tvars=(TVar("x", (0,)),), policies=(Policy("x", "cascade", ("s1",)),)),
+        Module(
+            cvars=(CVar("x", source="s"),),
+            policies=(Policy("x", "cascade", ("s1",)),),
+        ),
+    ]
+    for module in cases:
+        assert any(
+            code == "duplicate_name" for code, _ in namespace_diagnostics(module)
+        ), module

--- a/tests/model_checking/test_promotion_cascade.py
+++ b/tests/model_checking/test_promotion_cascade.py
@@ -29,6 +29,7 @@ from .model import (
 STRICT_TRIGGERS = {
     "require_calibration": dict(require_calibration_enabled=True),
     "chance_constraints": dict(has_chance_constraints=True),
+    "guaranteed_selection": dict(has_guaranteed_selection_target=True),
 }
 
 
@@ -37,6 +38,7 @@ def _module(**flags) -> Module:
 
 
 GOVERNED_CVAR = CVar("theta", source="src", require_calibration=True)
+CERT_TARGET_CVAR = CVar("theta", source="src", certificate_backed_target=True)
 PLAIN_CVAR = CVar("theta", source="src", require_calibration=False)
 
 
@@ -46,7 +48,8 @@ def test_strict_trigger_enumeration():
     assert not strict(_module(), [PLAIN_CVAR])
     for flags in STRICT_TRIGGERS.values():
         assert strict(_module(**flags), [PLAIN_CVAR])
-    assert strict(_module(), [GOVERNED_CVAR])  # per-CVAR trigger alone
+    assert strict(_module(), [GOVERNED_CVAR])  # per-CVAR governance trigger alone
+    assert strict(_module(), [CERT_TARGET_CVAR])  # certificate-backed target alone
 
 
 @pytest.mark.parametrize("trigger_name,flags", list(STRICT_TRIGGERS.items()))
@@ -147,3 +150,12 @@ def test_cascade_tie_does_not_change_selection():
     assert cascade_select(
         ["cheap", "strong"], [0.5], [VoteStats(margin=0.6, tie=True)]
     ) == cascade_select(["cheap", "strong"], [0.5], [VoteStats(margin=0.6, tie=False)])
+
+
+@pytest.mark.parametrize("verdict", P7_VERDICTS)
+@pytest.mark.parametrize("beats", [False, True])
+def test_p7_certificate_backed_target_trigger(verdict, beats):
+    """§3.6 fifth disjunct: a consumed CVAR with a certificate-backed
+    TargetProperty alone makes promotion strict."""
+    outcome = promotion_outcome(_module(), [CERT_TARGET_CVAR], verdict, beats)
+    assert outcome == NO_CERTIFIED_SELECTION

--- a/tests/model_checking/test_promotion_cascade.py
+++ b/tests/model_checking/test_promotion_cascade.py
@@ -1,0 +1,149 @@
+"""P7 — strict-promotion fail-closed reachability; cascade totality (§3.8).
+
+The promotion model enumerates every (strict-trigger × verdict × dominance)
+combination and asserts the fail-closed law: under any strict trigger, every
+evidence-failure verdict yields no_certified_selection — never a
+winner-by-objective. The legacy (non-strict) lane is also pinned so the model
+documents exactly what the SDK repair must NOT change.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from .model import (
+    CVar,
+    Module,
+    NO_CERTIFIED_SELECTION,
+    P7_VERDICTS,
+    PROMOTE,
+    REJECT,
+    VoteStats,
+    cascade_select,
+    promotion_outcome,
+    strict,
+)
+
+STRICT_TRIGGERS = {
+    "require_calibration": dict(require_calibration_enabled=True),
+    "chance_constraints": dict(has_chance_constraints=True),
+}
+
+
+def _module(**flags) -> Module:
+    return Module(**flags)
+
+
+GOVERNED_CVAR = CVar("theta", source="src", require_calibration=True)
+PLAIN_CVAR = CVar("theta", source="src", require_calibration=False)
+
+
+def test_strict_trigger_enumeration():
+    """§3.6: each declared trigger independently makes the module strict —
+    including the per-CVAR governance trigger (review finding 5)."""
+    assert not strict(_module(), [PLAIN_CVAR])
+    for flags in STRICT_TRIGGERS.values():
+        assert strict(_module(**flags), [PLAIN_CVAR])
+    assert strict(_module(), [GOVERNED_CVAR])  # per-CVAR trigger alone
+
+
+@pytest.mark.parametrize("trigger_name,flags", list(STRICT_TRIGGERS.items()))
+@pytest.mark.parametrize("verdict", P7_VERDICTS)
+@pytest.mark.parametrize("beats", [False, True])
+def test_p7_fail_closed_for_every_trigger_and_verdict(trigger_name, flags, verdict, beats):
+    """The core law: strict × evidence-failure ⇒ NO_CERTIFIED_SELECTION,
+    regardless of objective dominance (`beats` must not matter)."""
+    outcome = promotion_outcome(_module(**flags), [PLAIN_CVAR], verdict, beats)
+    assert outcome == NO_CERTIFIED_SELECTION
+
+
+@pytest.mark.parametrize("verdict", P7_VERDICTS)
+@pytest.mark.parametrize("beats", [False, True])
+def test_p7_per_cvar_governance_trigger(verdict, beats):
+    outcome = promotion_outcome(_module(), [GOVERNED_CVAR], verdict, beats)
+    assert outcome == NO_CERTIFIED_SELECTION
+
+
+def test_strict_clean_evidence_promotes_on_dominance():
+    """Strict mode with CLEAN evidence is not a denial-of-service: dominance
+    still decides."""
+    module = _module(require_calibration_enabled=True)
+    assert promotion_outcome(module, [PLAIN_CVAR], None, True) == PROMOTE
+    assert promotion_outcome(module, [PLAIN_CVAR], None, False) == REJECT
+
+
+@pytest.mark.parametrize("verdict", list(P7_VERDICTS) + [None])
+@pytest.mark.parametrize("beats", [False, True])
+def test_non_strict_lane_unchanged(verdict, beats):
+    """The legacy lane: without any strict trigger the outcome is decided by
+    dominance alone (this is the byte-identical behavior the SDK repair must
+    preserve outside strict modes)."""
+    outcome = promotion_outcome(_module(), [PLAIN_CVAR], verdict, beats)
+    assert outcome == (PROMOTE if beats else REJECT)
+
+
+def test_exhaustive_no_silent_promotion_under_strict():
+    """Sweep the full cross-product: no (strict, failure-verdict) cell ever
+    returns PROMOTE."""
+    cells = 0
+    for flags in STRICT_TRIGGERS.values():
+        for verdict in P7_VERDICTS:
+            for beats in (False, True):
+                assert (
+                    promotion_outcome(_module(**flags), [PLAIN_CVAR], verdict, beats)
+                    != PROMOTE
+                )
+                cells += 1
+    assert cells == len(STRICT_TRIGGERS) * len(P7_VERDICTS) * 2
+
+
+# ---------------------------------------------------------------------------
+# Cascade totality and determinism — §3.8.
+# ---------------------------------------------------------------------------
+
+
+def test_cascade_m1_degenerate_no_gates():
+    assert cascade_select(["only"], [], []) == 0
+
+
+def test_cascade_arity_invariant_enforced():
+    with pytest.raises(ValueError):
+        cascade_select(["s1", "s2"], [], [VoteStats(0.5)])  # |gates| != m-1
+    with pytest.raises(ValueError):
+        cascade_select([], [], [])  # m >= 1
+
+
+def test_cascade_empty_vote_escalates_for_positive_theta():
+    """§3.8: empty/abstain-only vote ⇒ margin 0 ⇒ escalate for θ > 0."""
+    assert cascade_select(["cheap", "strong"], [0.6], [VoteStats(margin=0.0)]) == 1
+
+
+def test_cascade_theta_zero_never_escalates():
+    """θ = 0 means never escalate (strict inequality)."""
+    assert cascade_select(["cheap", "strong"], [0.0], [VoteStats(margin=0.0)]) == 0
+
+
+def test_cascade_deterministic_given_votes_exhaustive():
+    """Determinism: over an exhaustive small scope of (margins × thetas),
+    repeated evaluation returns the identical stage, and stage selection is
+    exactly min{i : i = m ∨ margin_i >= theta_i}."""
+    margins = [0.0, 0.3, 0.6, 1.0]
+    thetas = [0.0, 0.4, 0.8]
+    for m1, m2 in itertools.product(margins, repeat=2):
+        for t1, t2 in itertools.product(thetas, repeat=2):
+            votes = [VoteStats(m1), VoteStats(m2)]
+            first = cascade_select(["a", "b", "c"], [t1, t2], votes)
+            second = cascade_select(["a", "b", "c"], [t1, t2], votes)
+            assert first == second
+            expected = 0 if m1 >= t1 else (1 if m2 >= t2 else 2)
+            assert first == expected, (m1, m2, t1, t2)
+
+
+def test_cascade_tie_does_not_change_selection():
+    """Ties affect representative choice (runtime), never the margin or the
+    selected stage index."""
+    assert cascade_select(
+        ["cheap", "strong"], [0.5], [VoteStats(margin=0.6, tie=True)]
+    ) == cascade_select(["cheap", "strong"], [0.5], [VoteStats(margin=0.6, tie=False)])

--- a/tests/model_checking/test_resolver.py
+++ b/tests/model_checking/test_resolver.py
@@ -127,12 +127,21 @@ def _mutations():
         return m, s, f, c, e, ce, {"theta": stale_ctx}, R6_STALE_CERTIFICATE
 
     def leakage(m, s, f, c, e, ce, cx):
-        leaky = {"theta": Evidence(items=("i0",) * 10, split="eval")}
+        # calibration pool SHARES item ids with the eval split (true
+        # intersection, not a split-label proxy)
+        leaky = {"theta": Evidence(items=("e0", "i1", "i2"), split="cal")}
         return m, s, f, c, leaky, ce, cx, R7_EVIDENCE_LEAKAGE
 
     def insufficient(m, s, f, c, e, ce, cx):
+        # chance-style target at epsilon = 0.1 -> conformal floor
+        # ceil(1/0.1) - 1 = 9; only one calibration item is provided
+        bad = Module(
+            tvars=m.tvars,
+            cvars=(CVar("theta", source="src", target_epsilon=0.1),),
+            policies=(),
+        )
         tiny = {"theta": Evidence(items=("i0",), split="cal")}
-        return m, s, f, c, tiny, ce, cx, R8_INSUFFICIENT_EVIDENCE
+        return bad, s, f, c, tiny, {}, {}, R8_INSUFFICIENT_EVIDENCE
 
     return [
         ("R2_depends_on", missing_ref),
@@ -151,7 +160,7 @@ def _mutations():
 def test_p3_each_rejection_reachable_and_blocks(name, mutator):
     base = _happy_inputs()
     module, sugg, fixed, cals, evs, certs, ctxs, expected = mutator(*base)
-    kwargs = {"evidence_floor": 2} if name == "R8" else {}
+    kwargs = {"eval_items": frozenset({"e0", "e1"})} if name == "R7" else {}
     res = resolve(module, sugg, fixed, cals, evs, certs, ctxs, **kwargs)
     assert not res.accepted
     assert expected in res.rejections, (name, res.rejections)
@@ -227,10 +236,56 @@ def test_biconditional_exhaustive_small_scope():
             ),
         )
         fixed = {"model": "m1"} if fixed_collision else {}
-        ev = Evidence(("i0", "i1"), "eval" if leaky else "cal")
+        ev = Evidence(("i0", "i1"), "cal")
         cal = Calibrator(value=None if bottom else 0.5)
-        res = resolve(module, {"model": "m1"}, fixed, {"theta": cal}, {"theta": ev}, {}, {})
+        res = resolve(
+            module,
+            {"model": "m1"},
+            fixed,
+            {"theta": cal},
+            {"theta": ev},
+            {},
+            {},
+            eval_items=frozenset({"i0"}) if leaky else frozenset(),
+        )
         should_accept = not (bad_ref or fixed_collision or leaky or bottom)
         assert res.accepted == should_accept, (bad_ref, fixed_collision, leaky, bottom, res)
         if not should_accept and not (bad_ref or fixed_collision or leaky):
             assert res.rejections == (NO_DECISION_VERDICT,)
+
+
+def test_unproduced_cvar_is_phase_mismatch_even_when_unconsumed():
+    """Review (fresh round, finding 1): a DECLARED CVAR with no registered
+    calibrator/evidence must reject as R4 even if nothing consumes it — the
+    resolved config includes every n ∈ N_C, so acceptance without the value
+    would violate the Accept biconditional."""
+    module = Module(
+        tvars=(TVar("model", ("m1",)),),
+        cvars=(CVar("orphan", source="src"),),  # declared, never consumed
+    )
+    res = resolve(module, {"model": "m1"}, {}, {}, {}, {}, {})
+    assert not res.accepted
+    assert R4_PHASE_MISMATCH in res.rejections
+
+
+def test_accepted_config_contains_every_declared_cvar():
+    """Accept ⟹ dom(config) ⊇ N_C (the completeness half made concrete)."""
+    module, sugg, fixed, cals, evs, certs, ctxs = _happy_inputs()
+    res = resolve(module, sugg, fixed, cals, evs, certs, ctxs)
+    assert res.accepted
+    assert set(res.config) >= {c.name for c in module.cvars}
+
+
+def test_r5_type_conformance(  # codex fresh-round finding 2
+):
+    """A float CVAR whose calibrator returns a non-float value rejects as R5
+    even with NO validity domain declared (RFC R5: 'domain OR TYPE')."""
+    module = Module(
+        tvars=(TVar("model", ("m1",)),),
+        cvars=(CVar("theta", source="src", cvar_type="float"),),
+    )
+    cals = {"theta": Calibrator(value="not-a-number")}
+    evs = {"theta": Evidence(("i0", "i1"), "cal")}
+    res = resolve(module, {"model": "m1"}, {}, cals, evs, {}, {})
+    assert not res.accepted
+    assert R5_INFEASIBLE_VALUE in res.rejections

--- a/tests/model_checking/test_resolver.py
+++ b/tests/model_checking/test_resolver.py
@@ -1,0 +1,236 @@
+"""Small-scope checks of RFC §3.4 — the Accept biconditional (P3 + P4).
+
+The central theorem: Accept ⟺ ¬(R1∨...∨R8) ∧ all calibrators ≠ ⊥.
+The model resolver collects every applicable rejection, so the check is an
+exhaustive enumeration over a small instance space where each R_i is driven
+reachable (or, for R1 in v1, proven unreachable).
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from .model import (
+    ALL_REJECTIONS,
+    Calibrator,
+    CVar,
+    Certificate,
+    Evidence,
+    FreshnessContext,
+    Gate,
+    Module,
+    NO_DECISION_VERDICT,
+    Policy,
+    R1_CYCLE,
+    R2_MISSING_REF,
+    R3_DUPLICATE_PROVIDER,
+    R4_PHASE_MISMATCH,
+    R5_INFEASIBLE_VALUE,
+    R6_STALE_CERTIFICATE,
+    R7_EVIDENCE_LEAKAGE,
+    R8_INSUFFICIENT_EVIDENCE,
+    TVar,
+    h_c,
+    issue_certificate,
+    resolve,
+)
+
+
+def _ctx(cvar: str, parents=(), n: int = 10) -> FreshnessContext:
+    return FreshnessContext(
+        cvar_name=cvar,
+        tuned_parent_values=tuple(sorted(parents)),
+        calibration_source_id="src",
+        signal_spec_hash=h_c("sig_v1"),
+        calibrator_id="cal_v1",
+        calibrator_version="1",
+        calibrator_params_hash=h_c({}),
+        dataset_hash="pool_v1",
+        evidence_n=n,
+        calibration_split="cal",
+        eval_split="eval",
+        target="tgt",
+    )
+
+
+def _happy_inputs():
+    """A fully-valid baseline instance: must Accept (P4 witness)."""
+    module = Module(
+        tvars=(TVar("model", ("m1", "m2")),),
+        cvars=(CVar("theta", source="src", depends_on=("model",), require_calibration=True),),
+        policies=(Policy("p", "cascade", ("s1", "s2"), (Gate("margin_below", "theta"),)),),
+    )
+    suggestion = {"model": "m1"}
+    ctx = _ctx("theta", parents=(("model", "m1"),))
+    cal = Calibrator(value=0.5)
+    ev = Evidence(items=tuple(f"i{j}" for j in range(10)), split="cal")
+    cert = issue_certificate("theta", 0.5, ctx)
+    return module, suggestion, {}, {"theta": cal}, {"theta": ev}, {"theta": cert}, {"theta": ctx}
+
+
+def test_p4_completeness_happy_path_accepts():
+    module, sugg, fixed, cals, evs, certs, ctxs = _happy_inputs()
+    res = resolve(module, sugg, fixed, cals, evs, certs, ctxs)
+    assert res.accepted, res.rejections
+    assert res.config == {"model": "m1", "theta": 0.5}
+
+
+# --- Per-R_i reachability: mutate exactly one aspect of the happy instance ---
+
+
+def _mutations():
+    """(name, mutator) pairs — each drives exactly one rejection reachable."""
+
+    def missing_ref(m, s, f, c, e, ce, cx):
+        bad = Module(
+            tvars=m.tvars,
+            cvars=(CVar("theta", source="src", depends_on=("ghost",)),),
+            policies=m.policies,
+        )
+        return bad, s, f, c, e, ce, cx, R2_MISSING_REF
+
+    def gate_ref_missing(m, s, f, c, e, ce, cx):
+        bad = Module(
+            tvars=m.tvars,
+            cvars=m.cvars,
+            policies=(Policy("p", "cascade", ("s1", "s2"), (Gate("margin_below", "ghost"),)),),
+        )
+        return bad, s, f, c, e, ce, cx, R2_MISSING_REF
+
+    def duplicate_provider_fixed(m, s, f, c, e, ce, cx):
+        return m, s, {"model": "m2"}, c, e, ce, cx, R3_DUPLICATE_PROVIDER
+
+    def duplicate_provider_partition(m, s, f, c, e, ce, cx):
+        bad = Module(
+            tvars=m.tvars,
+            cvars=(CVar("model", source="src"),),  # collides with the tvar
+            policies=(),
+        )
+        return bad, s, f, {"model": Calibrator(0.5)}, {"model": e["theta"]}, {}, {}, R3_DUPLICATE_PROVIDER
+
+    def phase_mismatch(m, s, f, c, e, ce, cx):
+        # gate consumes theta but no calibrator/evidence registered for it
+        return m, s, f, {}, {}, ce, cx, R4_PHASE_MISMATCH
+
+    def infeasible(m, s, f, c, e, ce, cx):
+        bad = Module(
+            tvars=m.tvars,
+            cvars=(CVar("theta", source="src", validity_domain=(0.0, 0.4)),),
+            policies=(),
+        )
+        return bad, s, f, c, e, {}, {}, R5_INFEASIBLE_VALUE  # 0.5 outside [0, 0.4]
+
+    def stale_cert(m, s, f, c, e, ce, cx):
+        stale_ctx = _ctx("theta", parents=(("model", "m2"),))  # parent changed
+        return m, s, f, c, e, ce, {"theta": stale_ctx}, R6_STALE_CERTIFICATE
+
+    def leakage(m, s, f, c, e, ce, cx):
+        leaky = {"theta": Evidence(items=("i0",) * 10, split="eval")}
+        return m, s, f, c, leaky, ce, cx, R7_EVIDENCE_LEAKAGE
+
+    def insufficient(m, s, f, c, e, ce, cx):
+        tiny = {"theta": Evidence(items=("i0",), split="cal")}
+        return m, s, f, c, tiny, ce, cx, R8_INSUFFICIENT_EVIDENCE
+
+    return [
+        ("R2_depends_on", missing_ref),
+        ("R2_gate_threshold", gate_ref_missing),
+        ("R3_fixed", duplicate_provider_fixed),
+        ("R3_partition", duplicate_provider_partition),
+        ("R4", phase_mismatch),
+        ("R5", infeasible),
+        ("R6", stale_cert),
+        ("R7", leakage),
+        ("R8", insufficient),
+    ]
+
+
+@pytest.mark.parametrize("name,mutator", _mutations())
+def test_p3_each_rejection_reachable_and_blocks(name, mutator):
+    base = _happy_inputs()
+    module, sugg, fixed, cals, evs, certs, ctxs, expected = mutator(*base)
+    kwargs = {"evidence_floor": 2} if name == "R8" else {}
+    res = resolve(module, sugg, fixed, cals, evs, certs, ctxs, **kwargs)
+    assert not res.accepted
+    assert expected in res.rejections, (name, res.rejections)
+
+
+def test_r1_unreachable_in_v1_by_construction():
+    """RFC §3.3: v1 graphs are bipartite CVAR→TVAR — exhaustively verify that
+    no v1-well-formed module (depends_on ⊆ N_T) can produce R1."""
+    tvar_names = ("t1", "t2")
+    cvar_names = ("c1", "c2")
+    found_cycle = False
+    for deps1 in itertools.chain.from_iterable(
+        itertools.combinations(tvar_names, k) for k in range(3)
+    ):
+        for deps2 in itertools.chain.from_iterable(
+            itertools.combinations(tvar_names, k) for k in range(3)
+        ):
+            module = Module(
+                tvars=tuple(TVar(n, (0,)) for n in tvar_names),
+                cvars=(
+                    CVar("c1", source="s", depends_on=deps1),
+                    CVar("c2", source="s", depends_on=deps2),
+                ),
+            )
+            cals = {n: Calibrator(0.5) for n in cvar_names}
+            evs = {n: Evidence(("i0", "i1"), "cal") for n in cvar_names}
+            res = resolve(module, {"t1": 0, "t2": 0}, {}, cals, evs, {}, {})
+            if R1_CYCLE in res.rejections:
+                found_cycle = True
+    assert not found_cycle  # unreachability proof at this scope
+
+
+def test_r1_reachable_only_with_deferred_cvar_to_cvar_edges():
+    """Forward-compat guard: the R1 machinery itself works (counterexample for
+    the DEFERRED extension, proving the rejection is not dead code)."""
+    module = Module(
+        cvars=(
+            CVar("c1", source="s", depends_on=("c2",)),
+            CVar("c2", source="s", depends_on=("c1",)),
+        ),
+    )
+    cals = {n: Calibrator(0.5) for n in ("c1", "c2")}
+    evs = {n: Evidence(("i0", "i1"), "cal") for n in ("c1", "c2")}
+    res = resolve(module, {}, {}, cals, evs, {}, {})
+    # v1 also flags R2 (refs must be TVARs) — both fire; R1 must be among them.
+    assert R1_CYCLE in res.rejections and R2_MISSING_REF in res.rejections
+
+
+def test_calibrator_bottom_is_no_decision_not_a_rejection():
+    """§3.4: ⊥ with no rejection condition ⇒ no_decision verdict."""
+    module, sugg, fixed, cals, evs, certs, ctxs = _happy_inputs()
+    module = Module(tvars=module.tvars, cvars=(CVar("theta", source="src"),))
+    res = resolve(module, sugg, fixed, {"theta": Calibrator(value=None)}, evs, {}, {})
+    assert not res.accepted
+    assert res.rejections == (NO_DECISION_VERDICT,)
+
+
+def test_biconditional_exhaustive_small_scope():
+    """The P3/P4 biconditional over a product space of toggles: acceptance
+    holds EXACTLY when no rejection condition is induced and the calibrator
+    returns a value."""
+    toggles = list(itertools.product([False, True], repeat=4))
+    # (bad_ref, fixed_collision, leaky_evidence, calibrator_bottom)
+    for bad_ref, fixed_collision, leaky, bottom in toggles:
+        module = Module(
+            tvars=(TVar("model", ("m1",)),),
+            cvars=(
+                CVar(
+                    "theta",
+                    source="src",
+                    depends_on=("ghost",) if bad_ref else ("model",),
+                ),
+            ),
+        )
+        fixed = {"model": "m1"} if fixed_collision else {}
+        ev = Evidence(("i0", "i1"), "eval" if leaky else "cal")
+        cal = Calibrator(value=None if bottom else 0.5)
+        res = resolve(module, {"model": "m1"}, fixed, {"theta": cal}, {"theta": ev}, {}, {})
+        should_accept = not (bad_ref or fixed_collision or leaky or bottom)
+        assert res.accepted == should_accept, (bad_ref, fixed_collision, leaky, bottom, res)
+        if not should_accept and not (bad_ref or fixed_collision or leaky):
+            assert res.rejections == (NO_DECISION_VERDICT,)

--- a/tests/model_checking/test_sat_preservation.py
+++ b/tests/model_checking/test_sat_preservation.py
@@ -84,6 +84,8 @@ def test_p5_encoding_identical_with_and_without_new_blocks(constraints, extra_bl
     assert set(compiled_base.domains) == set(compiled_ext.domains)
     assert set(compiled_ext.domains) == {"model", "zero_shot", "retriever.k"}
     assert compiled_base.domains == compiled_ext.domains
+    # Identical CLAUSE sets (P5's strongest form, not just the verdict).
+    assert compiled_base.constraints == compiled_ext.constraints
 
     # Identical satisfiability verdict.
     sat_base = check_structural_satisfiable(compiled_base)

--- a/tests/model_checking/test_sat_preservation.py
+++ b/tests/model_checking/test_sat_preservation.py
@@ -1,0 +1,121 @@
+"""P5 — SAT preservation, checked against the REAL tvl encoder.
+
+For any module M and its cvar/policy-stripped projection M⁻:
+compile_constraints(M) and compile_constraints(M⁻) must produce identical
+variable sets (= N_T) and identical satisfiability. This runs the actual
+python/tvl encoder (compile_constraints / check_structural_satisfiable) on
+dict-level modules — the encoder reads only `tvars`, and this suite LOCKS
+that fact before the Phase 4 schema admits the new blocks.
+"""
+
+from __future__ import annotations
+
+import copy
+import itertools
+
+import pytest
+
+from tvl.constraints import check_structural_satisfiable, compile_constraints
+
+CVARS_BLOCK = [
+    {
+        "name": "router.margin_threshold",
+        "type": "float",
+        "domain": {"range": [0.0, 1.0]},
+        "calibration": {"source": "margin_eval_pool", "depends_on": ["model"]},
+        "governance": {"require_calibration": True},
+    }
+]
+
+POLICIES_BLOCK = [
+    {
+        "name": "cheap_strong_cascade",
+        "kind": "policy",
+        "strategy": "cascade",
+        "stages": ["cheap", "strong"],
+        "gates": [{"kind": "margin_below", "threshold": "router.margin_threshold"}],
+    }
+]
+
+
+def _base_module(constraints=None) -> dict:
+    return {
+        "tvars": [
+            {"name": "model", "type": "enum[str]", "domain": ["m1", "m2"]},
+            {"name": "zero_shot", "type": "bool", "domain": [True, False]},
+            {"name": "retriever.k", "type": "int", "domain": {"range": [0, 4]}},
+        ],
+        "constraints": {"structural": constraints or []},
+    }
+
+
+SAT_CASES = [
+    [],  # unconstrained
+    [{"when": "zero_shot = true", "then": "retriever.k = 0"}],  # satisfiable
+    [  # unsatisfiable: k must be both 0 and >= 1
+        {"when": "zero_shot = true", "then": "retriever.k = 0"},
+        {"when": "zero_shot = true", "then": "retriever.k != 0"},
+        {"when": "zero_shot = false", "then": "zero_shot = true"},
+    ],
+]
+
+
+@pytest.mark.parametrize("constraints", SAT_CASES)
+@pytest.mark.parametrize(
+    "extra_blocks",
+    list(
+        itertools.chain.from_iterable(
+            itertools.combinations(["cvars", "policies"], r) for r in range(1, 3)
+        )
+    ),
+)
+def test_p5_encoding_identical_with_and_without_new_blocks(constraints, extra_blocks):
+    base = _base_module(constraints)
+    extended = copy.deepcopy(base)
+    if "cvars" in extra_blocks:
+        extended["cvars"] = copy.deepcopy(CVARS_BLOCK)
+    if "policies" in extra_blocks:
+        extended["policies"] = copy.deepcopy(POLICIES_BLOCK)
+
+    compiled_base = compile_constraints(base)
+    compiled_ext = compile_constraints(extended)
+
+    # Identical variable universe — solver sees exactly N_T.
+    assert set(compiled_base.domains) == set(compiled_ext.domains)
+    assert set(compiled_ext.domains) == {"model", "zero_shot", "retriever.k"}
+    assert compiled_base.domains == compiled_ext.domains
+
+    # Identical satisfiability verdict.
+    sat_base = check_structural_satisfiable(compiled_base)
+    sat_ext = check_structural_satisfiable(compiled_ext)
+    assert sat_base.get("ok") == sat_ext.get("ok")
+    assert sat_base.get("ok") is not None
+
+
+def test_p5_cvar_name_never_becomes_a_solver_variable():
+    extended = _base_module()
+    extended["cvars"] = copy.deepcopy(CVARS_BLOCK)
+    compiled = compile_constraints(extended)
+    assert "router.margin_threshold" not in compiled.domains
+
+
+def test_float_domain_variable_solves_regression():
+    """Regression for a pre-existing canonical-repo bug found by this packet's
+    P1 corpus sweep: float-domain TVARs crashed check_structural_satisfiable
+    with AttributeError ('Domain' object has no attribute '_encode_bound') —
+    python/tvl/constraints.py was missed in the _encode_bound_lower/_upper
+    rename (structural_sat.py was updated; constraints.py was not; no
+    existing test exercised a float domain through this path)."""
+    module = {
+        "tvars": [
+            {
+                "name": "temperature",
+                "type": "float",
+                "domain": {"range": [0.0, 1.0], "resolution": 0.1},
+            }
+        ],
+        "constraints": {"structural": []},
+    }
+    compiled = compile_constraints(module)
+    result = check_structural_satisfiable(compiled)
+    assert result.get("ok") is True


### PR DESCRIPTION
## Summary
Phase 3 of the TVL-first program: exhaustive small-scope enumeration (plain pytest, zero new deps) transcribing RFC 0001 Draft v4 (pinned by SHA `b036485`) one-to-one — 132 checks:

- Accept-biconditional (P3 ∧ P4): per-Rᵢ reachability fixtures, R1 unreachability proof for v1, exhaustive toggle-product equivalence
- Certificate semantics: 12 per-core-key staleness flips, subject binding, forged-subject cross-context counterexample, parent-specificity over EVERY extension subset, canonicalization rules (order-insensitive maps, duplicate rejection)
- P5 against the REAL encoder: identical variable + clause sets with/without injected 1.1 blocks (anti-vacuity guarded)
- P7: exhaustive (five strict triggers × five verdicts × dominance) — no strict cell ever promotes on an evidence failure; non-strict lane pinned byte-identical
- Cascade totality (m=1, arity, empty-vote, θ=0, tie-independence, exhaustive determinism)
- P1 over the real example corpus — this sweep **found the float-domain SAT crash fixed in #1** (same patch rides here as `4eb56b0`; merges cleanly either order)
- 9 conformance fixtures under `spec/examples/validation-phase6-cvars/` — the executable acceptance bar consumed by the validators PR

243 tests pass (111 pre-existing + 132 new). Hardened by two independent review rounds (model-fidelity findings fixed: unproduced-CVAR acceptance, R5 type conformance, R7 true intersection, R8 ε-derived floor, all-five strict triggers, extension canonicalization).

**Merge order note:** merge after #1 (shared bugfix patch); the validators PR rewrites the fixture README's status note — keep the validators version on conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)