### PR TITLE
polish: EBNF Ident sync + plan-named canonical examples + P8 schema canary

### DIFF
--- a/spec/examples/validation-phase6-cvars/cvar-calibrated-threshold.tvl.yml
+++ b/spec/examples/validation-phase6-cvars/cvar-calibrated-threshold.tvl.yml
@@ -1,0 +1,39 @@
+# Canonical example (RFC 0001 §3.3): ONE calibrated variable — a routing
+# threshold produced by a calibrator, governed by require_calibration.
+# Expected: valid, no diagnostics. The minimal CVAR-bearing module.
+tvl:
+  module: corp.examples.cvar_threshold
+
+environment:
+  snapshot_id: "2026-06-05T00:00:00Z"
+
+evaluation_set:
+  dataset: s3://datasets/examples/dev.parquet
+
+tvars:
+  - name: model
+    type: enum[str]
+    domain: ["gpt-4o-mini", "gpt-4o"]
+
+cvars:
+  - name: margin_threshold
+    type: float
+    domain:
+      range: [0.0, 1.0]          # validity domain — never searched (RFC §3.3)
+    calibration:
+      source: margin_eval_pool   # calibration evidence pool (disjoint from eval)
+      signal: vote_margin_v1
+      calibrator: budget_threshold_v1
+      depends_on: [model]        # freshness relation: cert is parent-specific
+    governance:
+      require_calibration: true  # strict evidence mode (RFC §3.6)
+
+objectives:
+  - name: quality
+    direction: maximize
+
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02

--- a/spec/examples/validation-phase6-cvars/policy-cascade.tvl.yml
+++ b/spec/examples/validation-phase6-cvars/policy-cascade.tvl.yml
@@ -1,0 +1,47 @@
+# Canonical example (RFC 0001 §3.8): a two-stage CascadePolicy whose gate
+# threshold is a calibrated variable. Expected: valid, no diagnostics.
+# |gates| = |stages| - 1; escalate ⟺ margin < θ where θ is the CVAR.
+tvl:
+  module: corp.examples.policy_cascade
+
+environment:
+  snapshot_id: "2026-06-05T00:00:00Z"
+
+evaluation_set:
+  dataset: s3://datasets/examples/dev.parquet
+
+tvars:
+  - name: cheap_model
+    type: enum[str]
+    domain: ["gpt-4o-mini"]
+  - name: strong_model
+    type: enum[str]
+    domain: ["gpt-4o"]
+
+cvars:
+  - name: margin_threshold
+    type: float
+    calibration:
+      source: margin_eval_pool
+      signal: vote_margin_v1
+    governance:
+      require_calibration: true
+
+policies:
+  - name: cheap_strong_cascade
+    kind: policy                 # the literal discriminator (RFC §3.8)
+    strategy: cascade
+    stages: [cheap_model, strong_model]
+    gates:
+      - kind: margin_below
+        threshold: margin_threshold   # MUST reference a declared CVAR
+
+objectives:
+  - name: quality
+    direction: maximize
+
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02

--- a/spec/grammar/tvl.ebnf
+++ b/spec/grammar/tvl.ebnf
@@ -181,7 +181,11 @@ coefficient   = number ;
 env_ident     = ident ;                                  (* Must resolve to numeric env.context symbols, not TVARs *)
 
 (* ==================== TERMINALS ==================== *)
-ident         = ? identifier: [a-zA-Z_][a-zA-Z0-9_.]* ? ;
+ident         = ? identifier: [A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)* ? ;
+                                                         (* The single normative Ident grammar (RFC 0001 §3.7(2)):
+                                                            dot-separated segments, each starting with a letter or
+                                                            underscore — no leading/trailing/double dots. Matches
+                                                            tvl.schema.json's pattern exactly. *)
 number        = ? number literal: -?[0-9]+(\.[0-9]+)?(e[+-]?[0-9]+)? ? ;
 integer       = ? integer literal: -?[0-9]+ ? ;
 string        = ? quoted string literal with backslash escapes ("..." or '...') ? ;

--- a/spec/grammar/tvl.schema.json
+++ b/spec/grammar/tvl.schema.json
@@ -323,7 +323,8 @@
       "properties": {
         "name": {
           "type": "string",
-          "description": "Unique TVAR identifier; dotted names allowed for nested structures (§III.A)."
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$",
+          "description": "Unique TVAR identifier; dotted names allowed for nested structures (§III.A). Pattern is the single normative Ident grammar (RFC 0001 §3.7(2)) — previously unpatterned, which let TVAR names bypass the shared-namespace lexical rule the 1.1 declarations enforce."
         },
         "type": {
           "type": "string",

--- a/tests/test_cvars_policies.py
+++ b/tests/test_cvars_policies.py
@@ -159,6 +159,18 @@ def test_p1_all_existing_examples_unchanged():
         doc = yaml.safe_load(path.read_text(encoding="utf-8"))
         if not isinstance(doc, dict) or "tvars" not in doc:
             continue
+        # Schema check FIRST: no legacy module may acquire a NEW schema
+        # rejection from a name-pattern tightening (e.g. the TVarDecl.name
+        # Ident pattern) — the lint sweep alone cannot see schema-level
+        # regressions. Deliberately-invalid corpus fixtures keep their OLD
+        # rejections, so assert specifically on pattern errors at name sites.
+        name_pattern_errors = [
+            e.message
+            for e in _schema_errors(doc)
+            if "does not match" in e.message
+            and any(str(seg) == "name" for seg in e.absolute_path)
+        ]
+        assert not name_pattern_errors, (path.name, name_pattern_errors[:3])
         codes = {
             i["code"]
             for i in lint_module(doc)

--- a/tests/test_cvars_policies.py
+++ b/tests/test_cvars_policies.py
@@ -11,6 +11,7 @@ Two layers:
 
 from __future__ import annotations
 
+import json
 import pathlib
 import sys
 
@@ -52,6 +53,8 @@ def _codes(doc: dict, severity: str | None = None) -> set:
 
 EXPECTED = {
     "cvar-policies-happy.tvl.yml": (set(), None),
+    "cvar-calibrated-threshold.tvl.yml": (set(), None),
+    "policy-cascade.tvl.yml": (set(), None),
     "cvar-shadows-tvar.tvl.yml": ({"cvar_shadows_tvar"}, None),
     "cvar-missing-parent-ref.tvl.yml": ({"missing_ref"}, None),
     "gate-threshold-not-cvar.tvl.yml": ({"missing_ref"}, None),
@@ -299,3 +302,19 @@ def test_presence_based_11_opt_in():
         i["code"] == "namespace_prefix_collision" and i["severity"] == "error"
         for i in issues
     )
+
+
+def test_p8_new_declaration_shapes_are_closed():
+    """P8 schema canary (closes the recorded Phase-4 deferral): every TVL 1.1
+    declaration shape is CLOSED — additionalProperties:false — so no open
+    payload field exists to smuggle content. policy.parameters stays the one
+    deliberate opaque object (explicitly OUT of the P8 guarantee, RFC §3.8)."""
+    schema = json.loads(
+        (BASE / "spec" / "grammar" / "tvl.schema.json").read_text(encoding="utf-8")
+    )
+    defs = schema["$defs"]
+    for shape in ("CVarDecl", "PolicyDecl", "GateDecl", "Scope"):
+        assert defs[shape].get("additionalProperties") is False, shape
+    # the documented exception: parameters is an opaque object by design
+    params = defs["PolicyDecl"]["properties"]["parameters"]
+    assert params.get("type") == "object"

--- a/tests/test_cvars_policies.py
+++ b/tests/test_cvars_policies.py
@@ -315,6 +315,17 @@ def test_p8_new_declaration_shapes_are_closed():
     defs = schema["$defs"]
     for shape in ("CVarDecl", "PolicyDecl", "GateDecl", "Scope"):
         assert defs[shape].get("additionalProperties") is False, shape
-    # the documented exception: parameters is an opaque object by design
+    # the documented exception: parameters is an opaque object by design —
+    # opaque means NO property schema and NO closing; pin both so a later
+    # "structured parameters" change must consciously revisit P8.
     params = defs["PolicyDecl"]["properties"]["parameters"]
     assert params.get("type") == "object"
+    assert "properties" not in params, "parameters grew a schema — revisit P8"
+    assert params.get("additionalProperties") is not False
+    # the single normative Ident pattern now covers TVAR names too (the
+    # legacy hole the EBNF sync exposed): all four name sites share it.
+    ident = "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$"
+    tvar_name = defs["TVarDecl"]["properties"]["name"]
+    assert tvar_name.get("pattern") == ident, tvar_name
+    assert defs["CVarDecl"]["properties"]["name"].get("pattern") == ident
+    assert defs["PolicyDecl"]["properties"]["name"].get("pattern") == ident

--- a/tests/test_cvars_policies.py
+++ b/tests/test_cvars_policies.py
@@ -164,10 +164,16 @@ def test_p1_all_existing_examples_unchanged():
         # Ident pattern) — the lint sweep alone cannot see schema-level
         # regressions. Deliberately-invalid corpus fixtures keep their OLD
         # rejections, so assert specifically on pattern errors at name sites.
+        def _flatten(errors):
+            for e in errors:
+                yield e
+                if e.context:
+                    yield from _flatten(e.context)
+
         name_pattern_errors = [
             e.message
-            for e in _schema_errors(doc)
-            if "does not match" in e.message
+            for e in _flatten(_schema_errors(doc))
+            if e.validator == "pattern"
             and any(str(seg) == "name" for seg in e.absolute_path)
         ]
         assert not name_pattern_errors, (path.name, name_pattern_errors[:3])


### PR DESCRIPTION
## Summary
Post-merge polish closing three recorded gaps from the TVL-first program, plus two review-driven hardenings:

1. **EBNF Ident sync** (review-log finding 12's alignment obligation): `tvl.ebnf`'s Ident terminal now matches the single normative pattern (RFC 0001 §3.7(2)).
2. **TVarDecl.name lexical hole CLOSED** (found by review round 2): the schema patterned CVAR/policy/gate names but TVAR names were unpatterned strings — `'bad.'` was a valid TVAR name while rejected everywhere else. The normative pattern now covers TVAR names; the P1 corpus sweep proves conservativeness (no existing module breaks).
3. **Plan-named canonical examples**: `cvar-calibrated-threshold.tvl.yml` + `policy-cascade.tvl.yml` wired into the exact-diagnostic conformance enumeration.
4. **P8 schema canary** (closes the recorded deferral): CVarDecl/PolicyDecl/GateDecl/Scope locked `additionalProperties:false`; `parameters` opacity pinned structurally; all three name sites asserted to share the one Ident pattern.
5. **P1 sweep hardened** (review rounds 2-3): the conservative-extension sweep now schema-checks the corpus for NEW name-pattern rejections, recursively flattening combinator error contexts (`validator=='pattern'` at name sites) — schema-level regressions can no longer pass P1 silently.

## Review
codex gpt-5.5 xhigh, 4 rounds: REJECT (TVarDecl.name hole) → REJECT (P1 didn't schema-validate) → REJECT (nested combinator contexts) → **ACCEPT**. 304 tests pass; `tvl-validate` green on both new examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)