### PR TITLE
RFC 0002: Composite Knobs — sealed algebra + pattern catalog (spec, model checking, validators)

### DIFF
--- a/formalization/rfc-0002-composite-knobs.md
+++ b/formalization/rfc-0002-composite-knobs.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Status** | **DRAFT v2** — under cross-model review; owner acceptance pending |
+| **Status** | **DRAFT v3** — under cross-model review; owner acceptance pending |
 | **Target language version** | TVL 1.2 (conservative extension of 1.1) |
 | **Tracking** | `FR-TVL-COMPOSITE-KNOBS-V1` · ChangeSession `cs_aef1b9d2edfa5200` |
 | **Builds on** | RFC 0001 (ACCEPTED): one-Knob model, cvars, certificates, policies, strict promotion |
@@ -141,9 +141,10 @@ Loop      ::= ⟨ body : Arm,
                 max_iters : ℕ≥1 ⟩                (* REQUIRED bound — totality *)
 
 GateDecl  ::= ⟨ kind : margin_below | signal_below,   (* v1 registry *)
-                threshold : Ident,               (* MUST resolve to a CVAR
-                                                    (kind-checked), as RFC 0001 §3.8 *)
-                signal? : SignalSourceRef ⟩      (* REQUIRED iff kind=signal_below *)
+                threshold : Ident,               (* MUST resolve to a CVAR of TVL
+                                                    type int or float (kind- AND
+                                                    type-checked; §3.2 item 6) *)
+                signal? : SignalUse ⟩            (* REQUIRED iff kind=signal_below *)
 
 AcceptDecl ::= ⟨ kind : stat_at_least,           (* v1 registry — acceptance
                                                     direction is ≥, deliberately
@@ -160,18 +161,27 @@ AggregateDecl ::= ⟨ kind : majority_vote | judge_max,  (* v1 registry *)
 
 StopDecl  ::= ⟨ kind : signal_accept | external_accept | exhausted,
                 threshold? : Ident,              (* REQUIRED iff kind=signal_accept:
-                                                    MUST resolve to a CVAR *)
-                signal? : SignalSourceRef,       (* REQUIRED iff kind=signal_accept;
-                                                    a function of state_keys only *)
+                                                    MUST resolve to a CVAR of TVL
+                                                    type int or float *)
+                signal? : SignalUse,             (* REQUIRED iff kind=signal_accept;
+                                                    inputs MUST ⊆ state_keys *)
                 predicate? : Ident ⟩             (* REQUIRED iff kind=external_accept:
                                                     OPAQUE runtime predicate id,
                                                     StageRef-style — outside P8 *)
 
-SignalSourceRef ::= Ident    (* a calibration-source id from the SAME operational
-                                registry RFC 0001 cvars use
-                                (calibration_source_id, §3.5 there): an
-                                implementation-defined identifier, opaque to the
-                                module namespace — NOT a new declaration surface *)
+SignalUse ::= ⟨ spec : SignalSpec,    (* RFC 0001 §3.5's closed signal shape —
+                                         id, version, score function + version,
+                                         comparator + version — hashed H_c(σ)
+                                         exactly as calibration.signal is. NOT a
+                                         calibration SOURCE id: sources identify
+                                         evidence pools; specs identify the signal
+                                         FUNCTION (the RFC 0001 source/signal
+                                         split is preserved) *)
+                inputs : Ident* ⟩     (* the declared input keys the signal reads:
+                                         for stops, MUST ⊆ the loop's state_keys
+                                         (statically checked); for pre-gates,
+                                         opaque input-feature identifiers
+                                         (environment.bindings precedent) *)
 ```
 
 **Well-formedness (statically checked; error codes in §3.11):**
@@ -203,11 +213,32 @@ SignalSourceRef ::= Ident    (* a calibration-source id from the SAME operationa
 7. Ensemble cardinality: present iff `|arms| = 1`
    (`cardinality_arity_mismatch`); must reference a TVAR or CVAR whose
    declared TVL type is `int` (`invalid_cardinality_type`); resolution-time
-   values `k < 1` are rejection **R9** (`invalid_cardinality_value`),
-   extending RFC 0001 §3.4's rejection family.
-8. Loop: `stop.signal`, when present, may reference only declared
-   `state_keys` inputs (`stop_signal_outside_state`); `max_iters ≥ 1`
+   values `k < 1` are rejection **R9** (`invalid_cardinality_value`).
+   **Acceptance-algebra extension (TVL 1.2):** RFC 0001 §3.4's resolution
+   acceptance extends to
+
+   ```
+   Accept₁.₂ ⟺ ¬(R1 ∨ … ∨ R8 ∨ R9) ∧ calibrators ≠ ⊥
+   ```
+
+   with P3/P4 (the two directions of the acceptance biconditional) carrying
+   over verbatim with R9 in the disjunction. This is conservative: a TVL 1.1
+   module declares no composites, so R9 is unreachable and `Accept₁.₂`
+   coincides with RFC 0001's `Accept` on all 1.1 modules.
+8. Loop: `stop.signal.inputs`, when present, MUST be a subset of the
+   declared `state_keys` (`stop_signal_outside_state`); `max_iters ≥ 1`
    (`invalid_max_iters`).
+9. **`tuned_params` entries resolve to TVARs only**: every entry of a
+   stage arm's `tuned_params` MUST resolve (exact match, RFC 0001 §3.7) to
+   a declared TVAR; an entry naming a CVAR, policy, composite, or nothing
+   is rejected (`invalid_tuned_param`). Together with §3.5 this makes C6
+   hold by construction: `required_parents` is a union of validated
+   TVAR-only sets.
+10. **Numeric thresholds**: every gate/accept/stop `threshold` CVAR must
+   have declared TVL type `int` or `float` (`invalid_threshold_type`) —
+   the execution comparisons (`margin < θ`, `σ ≥ θ`, `stat ≥ θ`) are over
+   finite numbers; a non-finite resolved value fails the item's evaluation
+   per the existing exception rules (never a silent comparison).
 
 **Execution semantics.**
 
@@ -459,20 +490,31 @@ offers `unroll`. Outside the conditions no equivalence is claimed.
 
 ### 3.9 Surface syntax (draft normative for the validators packet)
 
+**The arm surface form** — ONE shape, used EVERYWHERE an `Arm` appears
+(cascade `arms[]`, loop `body`, ensemble `arms[]` and `judge`):
+
+```
+ArmSurface ::= Ident                                      (* bare = stage, tuned_params [] *)
+             | { stage: Ident, tuned_params?: [Ident*] }  (* explicit stage form *)
+             | { composite: Ident }                       (* tagged nesting *)
+```
+
+Unknown keys in the object forms reject (`invalid_arm_shape`); absent
+`tuned_params` defaults to `[]`. There is no separate per-composite
+`arm_params` map — parentage is declared ON the arm, so body/judge/nested
+arms are expressed identically.
+
 ```yaml
 composites:
   - name: answerer
     kind: cascade            # cascade | ensemble | loop (closed)
     placement: post          # cascade only; default post
-    arms:                    # bare identifier = STAGE (always);
-      - cheap_stage          #   nesting REQUIRES the tagged form
-      - strong_stage
-    arm_params:              # optional: per-stage tuned_params declaration
-      cheap_stage: [cheap_model, temperature]
-      strong_stage: [strong_model]
+    arms:
+      - { stage: cheap_stage, tuned_params: [cheap_model, temperature] }
+      - { stage: strong_stage, tuned_params: [strong_model] }
     gates:
       - kind: margin_below
-        threshold: router.margin_threshold     # MUST resolve to a CVAR
+        threshold: router.margin_threshold     # CVAR of type float
     pattern: binary_cascade  # provenance annotation (closed shape §3.7)
 
   - name: coder
@@ -514,9 +556,12 @@ fixture in the validators packet):
 `missing_judge` · `unknown_aggregate_kind` · `unknown_stop_kind` ·
 `missing_stop_threshold` · `missing_stop_predicate` ·
 `stop_signal_outside_state` · `invalid_max_iters` ·
-`missing_composite_parent` · `duplicate_stage` (extended scope) — plus the
-RFC 0001 `missing_ref` family reused unchanged for every CVAR/threshold
-reference.
+`missing_composite_parent` · `invalid_tuned_param` ·
+`invalid_threshold_type` · `invalid_arm_shape` ·
+`duplicate_stage` (extended scope) — plus the RFC 0001 `missing_ref`
+family reused unchanged for every CVAR/threshold reference, and rejection
+**R9** (`invalid_cardinality_value`) extending the §3.4 acceptance algebra
+as `Accept₁.₂` (§3.2 item 7).
 
 ## 4. Compatibility and migration (P1 argument)
 
@@ -647,6 +692,8 @@ increment (§2).
 | Round | Reviewer | Verdict | Disposition |
 |---|---|---|---|
 | 1 | codex (gpt-5.5, xhigh, read-only) — 2026-06-06 | **REJECT** — 10 blocking, 5 non-blocking | All addressed in Draft v2: (1) arm resolution made tag-driven (`stage`/`composite` tags; bare = stage always; `ambiguous_arm` rejection); (2) pre-cascade made total (first-match-wins routing with fallback arm, per-gate signals + per-gate cost, absent-signal routes onward, `pre_gate_requires_signal`); (3) ensemble cardinality: required iff single-arm, int-typed, R9 rejection for k<1, both cost forms; (4) judge output contract (finite numeric score, exclusion rules, all-excluded fails, deterministic tie-break); (5) loop state formalized (`state_keys` + `stop_signal_outside_state`; pure ⟺ empty); (6) dependency compilation rebuilt as DECLARED parentage (`tuned_params` on stage arms) + static coverage obligations (`missing_composite_parent`), `missing_ref` stays single authority, judge/signal parents included; (7) root-consumption rule (all N_X roots, conservative fail-closed; selective consumption deferred); (8) subsumption made exact (scope?/parameters? carried onto Composite verbatim; empty tuned_params on migrated stages stated as intended ratchet); (9) Provenance closed shape (param_hash only, canary in admission contract); (10) C5 verification split by mechanism incl. condition 4. Non-blocking: full error-code surface §3.11; SignalSourceRef clarified as the RFC 0001 calibration-source registry (no new declaration surface); degenerate fixtures added to §9; AcceptDecl separated from GateDecl with opposite inequality; P6 note absorbed. |
+
+| 2 | codex (gpt-5.5, xhigh, read-only) — 2026-06-06 | **REJECT** — 5 blocking (all on the NEW round-1 machinery); round-1 dispositions confirmed closed | All addressed in Draft v3: (1) R9 integrated into the acceptance algebra — explicit `Accept₁.₂ ⟺ ¬(R1∨…∨R9) ∧ calibrators ≠ ⊥` with P3/P4 carrying over and a conservativity note (R9 unreachable on 1.1 modules); (2) `tuned_params` entries now have a static TVAR-only resolution rule (`invalid_tuned_param`, well-formedness item 9) making C6 hold by construction; (3) `arm_params` map REPLACED by a single ArmSurface form declared ON the arm (bare Ident │ {stage, tuned_params?} │ {composite}) used identically for cascade arms, loop body, ensemble arms and judge — `invalid_arm_shape` for unknown keys; (4) `SignalSourceRef` (a source id) replaced by `SignalUse ⟨spec: SignalSpec, inputs⟩` preserving RFC 0001's source/signal split — the spec is the §3.5 closed signal shape hashed H_c(σ); stop inputs MUST ⊆ state_keys making `stop_signal_outside_state` precisely checkable; (5) numeric threshold type rule (`invalid_threshold_type`: thresholds are int/float CVARs; non-finite resolved values fail evaluation). |
 
 Design pre-review (before Draft v1): Option E architecture ACCEPTed by
 codex (gpt-5.5 xhigh — 4 hard constraints + terminology edits, all

--- a/formalization/rfc-0002-composite-knobs.md
+++ b/formalization/rfc-0002-composite-knobs.md
@@ -1,0 +1,486 @@
+# RFC 0002 — Composite Knobs: a sealed control-flow algebra and a named pattern catalog
+
+| | |
+|---|---|
+| **Status** | **DRAFT v1** — under cross-model review; owner acceptance pending |
+| **Target language version** | TVL 1.2 (conservative extension of 1.1) |
+| **Tracking** | `FR-TVL-COMPOSITE-KNOBS-V1` · ChangeSession `cs_aef1b9d2edfa5200` |
+| **Builds on** | RFC 0001 (ACCEPTED): one-Knob model, cvars, certificates, policies, strict promotion |
+| **Downstream gate** | Acceptance of this RFC + green model checking unblock the validators packet and all SDK implementation |
+
+## 1. Motivation
+
+Agentic systems repeat a small number of control-flow patterns whose variables
+travel together: a *cascade* runs a cheap arm and escalates past a calibrated
+gate; an *ensemble* fans out `k` samples and aggregates; a *self-debug loop*
+generates, critiques, and revises under a stop rule. Today TVL can declare the
+individual variables (RFC 0001: tvars, cvars, one cascade policy strategy) but
+has no construct that says *"these members form one reusable pattern with its
+own dependency structure, calibratable surface, cost model, and telemetry."*
+Each consumer rebuilds the bundle by convention; conventions drift.
+
+This RFC introduces the **CompositeKnob**: a named bundle of member variables
+and policies with a declared control-flow shape. The design is two-layered
+(design review 2026-06-06; codex gpt-5.5 + gemini concurring):
+
+- a **sealed structural algebra** — three disjoint **structural constructors**
+  (`CompositeKind ∈ {cascade, ensemble, loop}`), closed under nesting — that
+  machines consume: the optimizer's projection, the certificate coverage fold,
+  the freshness dependency compilation, cost models, and the model checker;
+- an **open, curated pattern catalog** — procedurally named factories
+  (`binary_cascade`, `n_cascade`, `self_consistency`, `best_of_n`,
+  `self_debug`, `self_refine`) — that humans consume: each pattern is a
+  **macro** that expands deterministically into the algebra, stamping every
+  emitted node with provenance. Patterns are never subclasses; the algebra
+  never grows because a pattern was added.
+
+The split resolves the classic tension: disjointness where it buys theorems
+and fail-closed governance; procedural, plural naming where adoption lives.
+
+## 2. Scope freeze (Phase 0)
+
+**In scope for TVL 1.2 and this program increment:**
+
+- the sealed three-constructor algebra with nesting closure (§3.2);
+- per-constructor calibratable surfaces (§3.3) and cost models (§3.4);
+- dependency compilation onto leaf TVARs (§3.5);
+- the certificate coverage fold extending RFC 0001 §3.6 strict promotion
+  (§3.6);
+- the pattern-catalog contract and the v1 catalog (§3.7);
+- the `Loop → NCascade` bounded-unroll **compilation relation** (§3.8);
+- a `composites:` surface block as a conservative grammar extension (§3.9);
+- subsumption of `policies.strategy: cascade` by exact expansion mapping (§4).
+
+**Explicitly deferred** (out of scope for TVL 1.2 and this increment):
+
+- any wire/schema crossing: composites do not ride the typed session wire,
+  TraigentSchema is untouched, backend/FE see no new fields (contract
+  decision v1; a content-free composite summary is a recorded revisit
+  trigger);
+- CVAR→CVAR dependencies (`depends_on` still names TVARs only — the RFC 0001
+  deferral stands; composite edges COMPILE DOWN to leaf TVARs, §3.5);
+- in-loop CVAR re-fitting and CVAR optimizers (RFC 0001 deferrals stand);
+- learned routers / dispatch functions as calibrators (would extend the
+  calibrator registry, not this algebra);
+- a pattern marketplace or third-party catalog mechanism (the v1 catalog is
+  in-repo and curated);
+- changes to configuration documents (`tvl-configuration.schema.json`
+  untouched, as in RFC 0001).
+
+## 3. Formal model (Phase 1)
+
+### 3.1 What a composite is — and is not
+
+RFC 0001's **one-Knob model is unchanged**: every configuration variable is a
+knob with exactly one typed binding — `Tuned | Fixed | Calibrated` — and the
+binding partition `N = N_T ⊎ N_F ⊎ N_C` is untouched. A **CompositeKnob is
+not a binding kind**: it is a **namespace/expansion/provenance unit** that
+*groups* member knobs and gate declarations under a declared control-flow
+shape. A composite never binds, carries, or defaults a value; a module that
+attempts to bind a value on a composite is rejected
+(`composite_binds_value`).
+
+Composite names form a new declaration class `N_X` in the **same scoped
+namespace** as tvars/cvars/policies: shadowing across classes is rejected
+exactly as in RFC 0001 P6 (`binding_partition_collision` generalizes;
+surfaced as `composite_shadows_name`). `N_X` never enters `Γ`,
+`Config(Δ, E_τ)`, `F^str`, or the optimizer projection `Σ` (§3.2 of RFC 0001
+is unchanged): the optimizer sees member TVARs individually; the composite is
+invisible to search exactly as cvars are (Property P2/P5 preserved).
+
+### 3.2 The sealed algebra
+
+```
+Composite ::= ⟨ name : Ident,
+                kind : CompositeKind,            (* CLOSED registry *)
+                body : Cascade | Ensemble | Loop,(* discriminated by kind *)
+                pattern? : Ident ⟩               (* provenance annotation, §3.7 *)
+
+CompositeKind ::= cascade | ensemble | loop      (* SEALED: a fourth kind is a
+                                                    new RFC, not a registry entry *)
+
+Arm       ::= StageRef | CompositeName           (* nesting: an arm may be another
+                                                    declared composite *)
+
+Cascade   ::= ⟨ arms : Arm+,                     (* |arms| = m ≥ 1 *)
+                gates : GateDecl*,               (* |gates| = m − 1 *)
+                placement : pre | post ⟩         (* DEFAULT post *)
+
+Ensemble  ::= ⟨ arms : Arm+,                     (* |arms| ≥ 1 *)
+                cardinality? : Ident,            (* namespace ref → TVAR or CVAR:
+                                                    the per-arm sample count k *)
+                aggregate : AggregateDecl ⟩
+
+Loop      ::= ⟨ body : Arm,
+                stop : StopDecl,
+                max_iters : ℕ≥1 ⟩                (* REQUIRED bound — totality *)
+
+GateDecl  ::= ⟨ kind : margin_below | signal_below,   (* v1 registry *)
+                threshold : Ident,               (* MUST resolve to a CVAR
+                                                    (kind-checked), as RFC 0001 §3.8 *)
+                signal? : Ident ⟩                (* REQUIRED iff kind=signal_below:
+                                                    resolves to a declared SignalSpec *)
+
+AggregateDecl ::= ⟨ kind : majority_vote | judge_max,  (* v1 registry *)
+                    judge? : StageRef,           (* REQUIRED iff kind=judge_max *)
+                    accept? : GateDecl ⟩         (* optional acceptance gate over
+                                                    the aggregate's vote statistics *)
+
+StopDecl  ::= ⟨ kind : signal_accept | external_accept | exhausted,
+                threshold? : Ident,              (* REQUIRED iff kind=signal_accept:
+                                                    MUST resolve to a CVAR *)
+                signal? : Ident,                 (* REQUIRED iff kind=signal_accept *)
+                predicate? : Ident ⟩             (* REQUIRED iff kind=external_accept:
+                                                    OPAQUE runtime predicate id,
+                                                    StageRef-style (§3.8 of RFC 0001) *)
+```
+
+**Well-formedness (statically checked):**
+
+1. `kind` ∈ the closed registry; anything else rejects
+   (`unknown_composite_kind`).
+2. Gate/arm arity: `|gates| = |arms| − 1` for cascades (degenerate `m = 1`
+   cascade has no gates and always returns its arm — RFC 0001's rule carries
+   over).
+3. Every `Arm` that is a `CompositeName` must resolve to a declared composite
+   (exact match, RFC 0001 §3.7 namespace rules); the resulting **reference
+   graph over `N_X` must be acyclic** (`composite_cycle`). Composition depth
+   is finite by construction: nesting is the ONLY composition mechanism, and
+   DAG-shaped configurations are the **closure of nesting** — there is no
+   fourth "DAG kind".
+4. Gate/stop thresholds resolve to CVARs (kind-checked, reusing RFC 0001's
+   gate rule); signals resolve to declared SignalSpecs (§3.5 of RFC 0001).
+5. `StageRef` remains an opaque operational identifier (RFC 0001 §3.8,
+   review finding 6) — not a namespace reference; duplicates within one
+   composite are rejected (`duplicate_stage`).
+6. Discriminator totality: exactly the body fields of the declared kind are
+   present; unknown or cross-kind fields reject (closed shapes, exact
+   diagnostics — the RFC 0001 grammar discipline).
+
+**Execution semantics.**
+
+- `placement: post` cascade is EXACTLY RFC 0001 §3.8 cascade execution
+  (normative text incorporated by reference): run arm `i`, vote over `k_i`
+  samples, escalate iff `margin < θ_i`; totality/determinism/error rules
+  unchanged, including fail-closed propagation of stage exceptions under
+  strict modes.
+- `placement: pre` cascade (dispatch): the gate's `signal` is evaluated on
+  the INPUT before any arm runs; `route to arm_{i+1} ⟺ signal(x) < θ_i`
+  applied left to right; exactly one arm executes. Cost consequences in §3.4.
+  Empty/abstaining signal evaluation escalates (the RFC 0001 `margin = 0`
+  rule generalizes: an absent signal value compares below any `θ > 0`).
+- `ensemble`: run each arm (or one arm `k` times when `cardinality` is
+  declared and `|arms| = 1`); aggregate by the declared kind
+  (`majority_vote` over caller-defined equivalence keys with the RFC 0001
+  tie/abstain rules; `judge_max` runs the judge stage over candidate outputs
+  and selects the maximum-scored candidate deterministically, ties broken by
+  the RFC 0001 total order). An `accept` gate, when present, evaluates over
+  the aggregate's content-free vote statistics; failing it is an honest
+  no-accept outcome that propagates to the consumer (under strict modes it
+  feeds the fail-closed law).
+- `loop`: execute `body`; evaluate `stop` over the declared loop state;
+  repeat up to `max_iters`. State is explicitly threaded: iteration `i+1`
+  sees a declared accumulator (operationally defined by the runtime, like
+  stage bindings), never ambient hidden state. `exhausted` means "always run
+  `max_iters` iterations"; `signal_accept` stops when
+  `signal(state) ≥ θ` (acceptance, not escalation — the inequality direction
+  is deliberate and lint-pinned); `external_accept` delegates to an opaque
+  runtime predicate (outside the P8 surface, like `parameters`).
+
+### 3.3 Calibratable surface
+
+Each constructor *defines* which members admit calibration and with what
+target-property shape — this is the machine-facing payoff of sealing:
+
+| Constructor | Calibratable members | Target-property shape |
+|---|---|---|
+| `cascade` (post) | each gate threshold `θ_i` | conditional property of the ACCEPTANCE REGION the gate induces (e.g. `P(arm_i correct │ margin ≥ θ_i) ≥ p`) — exactly RFC 0001 §3.5's per-CVAR scope |
+| `cascade` (pre) | each routing threshold `θ_i` | conditional property of the ROUTE the signal induces (e.g. `P(arm_i adequate │ signal < θ_i) ≥ p`) |
+| `ensemble` | `accept.threshold`; `cardinality` when bound Calibrated | acceptance: `P(aggregate correct │ vote stat ≥ θ) ≥ p`; cardinality: cost-bounded sufficiency |
+| `loop` | `stop.threshold` (signal_accept) | stop adequacy: `P(accepted state meets target │ signal ≥ θ) ≥ p` |
+
+The **claim scope** paragraph of RFC 0001 §3.5 (2026-06-06 clarification)
+applies verbatim: each certificate is a per-variable, procedural claim about
+the conditional, component-level property the variable controls under the
+documented assumptions. **A composite's end-to-end metrics remain
+observations** under the promotion judgment; nothing in this RFC creates a
+config-level guarantee, and user-facing copy MUST NOT present a composite as
+one.
+
+### 3.4 Cost models and compositionality
+
+Each constructor carries a normative expected-cost form over its members,
+with nested composites contributing their own cost recursively:
+
+```
+cost(StageRef s)                       = c(s)                       (runtime-supplied)
+cost(Cascade_post(a₁..a_m, θ₁..θ_{m−1})) = cost(a₁) + Σ_{i=1}^{m−1} P(esc₁..esc_i) · cost(a_{i+1})
+cost(Cascade_pre (a₁..a_m, θ₁..θ_{m−1})) = c(signal) + Σ_i P(route = i) · cost(a_i)
+cost(Ensemble(a, k, agg))               = k · cost(a) + c(agg)      (single-arm form;
+                                           multi-arm: Σ_j cost(a_j) + c(agg))
+cost(Loop(b, stop, K))                  = E[iters] · cost(b),  E[iters] ≤ K
+```
+
+Escalation/route/stop probabilities are *operational estimates* (observed
+telemetry or calibration-split estimates) — the cost model is a structured
+estimator, not a guarantee (§3.3 claim scope applies). **Compositionality
+(claim C4)**: `cost(X)` for a nested composite arm is the arm's own cost
+form — the equations close over the algebra. This is what makes
+frontier/constrained search over composites structurally informed instead of
+black-box.
+
+### 3.5 Dependency compilation (leaf TVARs only)
+
+RFC 0001 defers CVAR→CVAR dependencies; this RFC **keeps that deferral** and
+defines how composite structure compiles onto the existing mechanism:
+
+```
+leafT : Arm → ℘(N_T)
+leafT(StageRef s)     = T(s)            (* the tuned variables parameterizing the
+                                           stage, per the module's declarations *)
+leafT(CompositeName x) = ⋃_{a ∈ arms/body(x)} leafT(a)
+
+Compile_π(gate θ_i in Cascade(arms..)) :
+    π(θ_i) ⊇ leafT(a₁) ∪ … ∪ leafT(a_i)     (post: everything the gate observes)
+    π(θ_i) ⊇ ∅ ∪ signal's tuned parents      (pre: the signal's parameterization)
+Compile_π(accept θ in Ensemble(arms, k)) :
+    π(θ) ⊇ ⋃_j leafT(a_j) ∪ {k if k ∈ N_T}
+Compile_π(stop θ in Loop(body))         :
+    π(θ) ⊇ leafT(body)
+```
+
+The compiled `depends_on` sets contain **TVARs only** (claim C6); the
+RFC 0001 `missing_ref` lint remains the single authority. The payoff is that
+the freshness cascade becomes structural: swap an arm's model and every gate
+observing that arm reads stale through the existing
+`tuned_parent_values` core — by construction, not convention.
+
+### 3.6 Certificate coverage fold (extends RFC 0001 §3.6)
+
+```
+Cal : Composite → ℘(N_C)
+Cal(Cascade(arms, gates, _)) = ⋃ Cal(arms) ∪ { g.threshold : g ∈ gates }
+Cal(Ensemble(arms, k, agg))  = ⋃ Cal(arms) ∪ { agg.accept.threshold if present }
+                               ∪ { k if k ∈ N_C }
+Cal(Loop(body, stop, _))     = Cal(body) ∪ { stop.threshold if kind=signal_accept }
+Cal(StageRef)                = ∅
+```
+
+Under `strict(M, c)` (RFC 0001 §3.6, unchanged), `CalibrationPass(c, M)`
+extends to require a valid, fresh certificate for **every** CVAR in
+`Cal(root)` for every composite the configuration consumes. The fold is
+**fail-closed** (claim C3): any uncertified or stale member ⇒ no certified
+selection — never a partial pass, never a silent skip of a nested level.
+
+### 3.7 The pattern catalog contract
+
+```
+Pattern ::= ⟨ name : Ident,
+              params : ParamSchema,
+              expand : params → Composite ⟩    (* DETERMINISTIC, TOTAL on
+                                                  validated params *)
+```
+
+A pattern is a **macro**: `expand` emits algebra nodes, every one stamped
+with `pattern = name` (the provenance annotation of §3.2). Provenance is a
+content-free identifier: it rides operational metadata (and any future wire
+summary) as an annotation, never as schema vocabulary — adding a pattern is
+an SDK release, not a language or schema change.
+
+**Admission contract** — a pattern enters the catalog only with ALL of:
+
+1. an expansion into the sealed algebra (no pattern-private node kinds);
+2. provenance/source-map metadata on every emitted node;
+3. a calibration recipe for every CVAR the expansion introduces (which
+   signal, which split, which target-property shape from §3.3);
+4. standard telemetry names (§3.10);
+5. a byte-stable **golden expansion test** (known-answer fixture);
+6. demonstrated fail-closed behavior under the §3.6 fold (a red-first test
+   in the consuming SDK).
+
+**Catalog v1:**
+
+| Pattern | Expansion (sketch) | Notes |
+|---|---|---|
+| `binary_cascade` | `Cascade(arms=[base, expert], gates=[margin_below θ], post)` | the RFC 0001 cascade policy's exact shape; migration target (§4) |
+| `n_cascade` | `Cascade(arms=[a₁..a_m], gates=[θ₁..θ_{m−1}], post)` | ordered escalation |
+| `self_consistency` | `Ensemble(arms=[a], cardinality=k, majority_vote, accept: margin_below θ?)` | k tuned or calibrated |
+| `best_of_n` | `Ensemble(arms=[a], cardinality=k, judge_max(judge))` | judge is a StageRef |
+| `self_debug` | `Loop(body=a, stop=external_accept(tests), max_iters=K)` | "2-step knob" at K=1 |
+| `self_refine` | `Loop(body=a, stop=signal_accept(σ, θ), max_iters=K)` | calibrated stop |
+
+The catalog is curated in-repo; growth follows the admission contract, never
+ad-hoc (the documented failure mode of open chain taxonomies).
+
+### 3.8 Loop → NCascade: a compilation relation
+
+For a bounded loop, define the unrolling
+`Unroll(Loop(b, stop, K)) = Cascade_post(arms=[b₍₁₎..b₍K₎], gates=[¬stop₍₁₎..¬stop₍K−1₎])`
+where `b₍ᵢ₎` is the body specialized to iteration `i`'s threaded state and
+each gate escalates exactly when the stop rule does NOT accept.
+
+This is a **compilation relation, not semantic equality** (design review,
+codex): it is meaning-preserving **only under all of**:
+
+1. the body is pure, or its state is explicitly threaded through the
+   declared accumulator (no ambient mutation);
+2. the stop rule is a deterministic function of the declared state;
+3. iterations are bounded by `max_iters` (always true in this algebra —
+   `max_iters` is required);
+4. telemetry/side effects are observationally accounted: `iterations_used`
+   maps to "index of the selected arm", and per-iteration effects are
+   declared effects of the corresponding arm.
+
+Implementations MAY offer the unrolled compilation (e.g. `unroll=K` on loop
+patterns); claim C5 model-checks the relation under conditions 1–3 at small
+scopes. Outside the conditions no equivalence is claimed.
+
+### 3.9 Surface syntax (draft normative for the validators packet)
+
+```yaml
+composites:
+  - name: answerer
+    kind: cascade            # cascade | ensemble | loop (closed)
+    placement: post          # cascade only; default post
+    arms: [cheap_stage, strong_stage]          # StageRef | composite name
+    gates:
+      - kind: margin_below
+        threshold: router.margin_threshold     # MUST resolve to a CVAR
+    pattern: binary_cascade  # optional provenance annotation
+
+  - name: coder
+    kind: loop
+    body: draft_stage
+    stop: { kind: external_accept, predicate: run_unit_tests }
+    max_iters: 3
+    pattern: self_debug
+```
+
+Closed shapes with exact diagnostics throughout (RFC 0001 grammar
+discipline); the EBNF and `tvl.schema.json` deltas land in the validators
+packet, gated on this RFC's acceptance. Modules with no `composites:` block
+parse byte-identically to TVL 1.1 (§4).
+
+### 3.10 Standard telemetry (content-free)
+
+Per-constructor measure names every implementation emits (counts, rates,
+enums only — nothing content-typed; P8 discipline):
+
+- cascade: `escalation_rate`, `stage_selected` (index), per-gate
+  `gate_margin_pass_rate`;
+- ensemble: `vote_agreement`, `vote_margin`, `candidates_evaluated`;
+- loop: `iterations_used`, `stop_reason` (enum over StopDecl kinds ∪
+  `exhausted`).
+
+## 4. Compatibility and migration (P1 argument)
+
+**Conservative extension.** The `composites:` block is additive: every valid
+TVL 1.1 module parses identically with the same meaning (no existing block's
+grammar changes; the namespace rule extends by adding `N_X` to the same
+collision discipline). The shipped canonical examples remain green unchanged.
+
+**Cascade-policy subsumption.** The RFC 0001 policy form maps exactly:
+
+```
+PolicyDecl⟨name, "policy", "cascade", stages = s₁..s_m, gates = g₁..g_{m−1}⟩
+  ≡ Composite⟨name, cascade, arms = s₁..s_m, gates = g₁..g_{m−1}, placement = post⟩
+```
+
+field for field — same StageRef opacity, same gate→CVAR rule, same execution
+semantics (§3.2 incorporates RFC 0001 §3.8 by reference). `policies` with
+`strategy: cascade` remains VALID in TVL 1.2 (no deprecation this
+increment); the `binary_cascade`/`n_cascade` patterns are its forward form,
+and a future increment may add a migration lint. The SDK's shipped
+`CascadePolicy` is the execution target for cascade composites; the binary
+`Router` (unmerged) is a future *pattern/adapter* over it, and nothing in
+this RFC assumes its API.
+
+## 5. Property claims (Phase 2)
+
+| Claim | Statement | Verification plan |
+|---|---|---|
+| **C1** Constructor disjointness | every composite node has exactly one kind from the closed registry; cross-kind/unknown fields reject | model checking (kind partition); lints with exact diagnostics |
+| **C2** Nesting well-formedness | the `N_X` reference graph is acyclic; expansion terminates; depth finite | model checking (acyclicity + a MUST-BE-SAT cyclic counterexample); `composite_cycle` lint |
+| **C3** Coverage-fold soundness | `Cal(root)` collects EXACTLY the calibratable members of the whole expansion (no over-, no under-collection); strict selection fails closed on any gap | model checking (fold vs. ground-truth member walk + a MUST-BE-SAT uncertified-gate violation); red-first SDK tests |
+| **C4** Cost compositionality | the cost forms close over nesting: substituting an arm's cost form yields the composite's | model checking at small scopes (structural induction skeleton); SDK property tests |
+| **C5** Loop→NCascade compilation | under §3.8 conditions 1–3, `Unroll` preserves selected output and accounted telemetry at small scopes | model checking (bounded K ≤ 4); golden fixtures for `unroll=K` patterns |
+| **C6** Dependency-compilation soundness | every `Compile_π` edge lands in `N_T`; no CVAR→CVAR edge is ever emitted | model checking (codomain check + MUST-BE-SAT violation transition); reuse of the RFC 0001 `missing_ref` lint as the single authority |
+
+Model-checking discipline: every UNSAT assertion is paired with a
+deliberately-broken transition that MUST be SAT (vacuity teeth — program
+convention).
+
+## 6. Documented assumptions
+
+The claims above hold under, and only under:
+
+1. **RFC 0001's assumption set** (§5 there) for everything
+   certificate/freshness related — split independence, dataset-hash
+   stability, canonical hashing, exchangeability for statistical targets.
+2. **Stage cost stability** — `c(StageRef)` is a runtime-supplied estimate;
+   cost-model outputs are estimators, never guarantees.
+3. **Probability estimates are operational** — escalation/route/stop
+   probabilities come from observed telemetry or calibration splits;
+   distribution shift degrades the estimate and is surfaced through the same
+   freshness context keys as RFC 0001 (no new drift detection is introduced).
+4. **Loop state discipline** — the §3.8 conditions are the implementation's
+   responsibility to uphold; the algebra makes them checkable, not
+   automatic.
+5. **Pattern determinism** — `expand` is a pure function of validated
+   params; catalog entries violating this are rejected at admission.
+
+## 7. Field categorization (P8 alignment)
+
+Composites introduce **no content-typed fields**: kinds, placements, arity,
+identifiers (names, StageRefs, predicate ids), one required integer
+(`max_iters`), and namespace references. `pattern` is a content-free
+identifier. Telemetry (§3.10) is counts/rates/enums. The opaque escape
+hatches (`StageRef`, `external_accept.predicate`) follow RFC 0001's
+`environment.bindings` precedent and sit outside the P8 surface exactly as
+`policies[].parameters` does. Nothing in this RFC crosses the wire this
+increment (§2).
+
+## 8. Prior art (informative)
+
+- **Model cascades / FrugalGPT** (Chen et al. 2023) and draft-verify
+  pipelines: the post-cascade with calibrated acceptance is the productized
+  core of RFC 0001's cascade policy; this RFC generalizes arity and nesting.
+- **Self-consistency** (Wang et al. 2022), best-of-n / judge selection: the
+  ensemble constructor with `majority_vote`/`judge_max`; the program's own
+  margin-routing study (vote-margin AUC 0.71) supplies the calibration
+  recipe shape for `accept` gates.
+- **Self-Refine** (Madaan et al. 2023), **Reflexion** (Shinn et al. 2023),
+  CRITIC: the loop constructor; "self-debug as a 2-step knob" is
+  `self_debug` at `max_iters = 1..K`.
+- **Composition-over-inheritance** in API design (Effective Java items
+  18–20; React's component model) and the LangChain-Chains →
+  LCEL/DSPy migration: the empirical case for sealing structure and naming
+  recipes — taxonomy-as-inheritance collapsed under exactly the pressure the
+  pattern catalog absorbs.
+
+## 9. Acceptance criteria for this RFC
+
+1. Cross-model review converged: anchored codex (gpt-5.5, xhigh) rounds to
+   ACCEPT **plus** one fresh unanchored full-document pass with all blocking
+   findings dispositioned in §10.
+2. Model-checking packet green for C1–C6, including every paired MUST-BE-SAT
+   vacuity check, on a re-run executed by the integrating agent.
+3. The §3.9 surface syntax validated against the §4 subsumption mapping (the
+   policy form and its composite form lint identically on the shared
+   examples).
+4. Owner acceptance recorded in this header and §10 (human-only gate).
+5. No semantic change to any RFC 0001 construct: the RFC 0001 conformance
+   fixtures pass unchanged.
+
+## 10. Review log
+
+| Round | Reviewer | Verdict | Disposition |
+|---|---|---|---|
+| — | (pending: anchored codex rounds, fresh pass, owner gate) | — | — |
+
+Design pre-review (before this draft): Option E architecture ACCEPTed by
+codex (gpt-5.5 xhigh — 4 hard constraints + terminology edits, all
+incorporated: not-a-binding-kind §3.1; no CVAR→CVAR deps §3.5; CascadePolicy
+anchor §4; compilation-relation framing §3.8; "structural constructors"
+naming) and by gemini (workspace-impact concurrence: schema stability,
+JS parity, spine coverage-fold fit, FE provenance rendering).

--- a/formalization/rfc-0002-composite-knobs.md
+++ b/formalization/rfc-0002-composite-knobs.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Status** | **DRAFT v6** — under cross-model review; owner acceptance pending |
+| **Status** | **DRAFT v7** — under cross-model review; owner acceptance pending |
 | **Target language version** | TVL 1.2 (conservative extension of 1.1) |
 | **Tracking** | `FR-TVL-COMPOSITE-KNOBS-V1` · ChangeSession `cs_aef1b9d2edfa5200` |
 | **Builds on** | RFC 0001 (ACCEPTED): one-Knob model, cvars, certificates, policies, strict promotion |
@@ -203,8 +203,9 @@ SignalUse ::= ⟨ signal : Ident,       (* a NAMED signal reference into the SAM
 
 1. `kind` ∈ the closed registry (`unknown_composite_kind`); exactly the body
    fields of the declared kind are present — unknown or cross-kind fields
-   reject (closed shapes, exact diagnostics).
-2. Cascade arity: `|gates| = |arms| − 1`; the degenerate `m = 1` cascade has
+   reject (`unknown_composite_field`; closed shapes, exact diagnostics).
+2. Cascade arity: `|gates| = |arms| − 1` (`cascade_arity`, reused from
+   RFC 0001 with identical semantics); the degenerate `m = 1` cascade has
    no gates and always returns its arm (RFC 0001 rule carries over).
    `arms` must be non-empty for every constructor (`empty_arms`).
 3. **Arm resolution is tag-driven and unambiguous**: `composite(x)` must
@@ -793,11 +794,16 @@ New codes introduced by this RFC (each with a happy + rejecting conformance
 fixture in the validators packet). The list and the well-formedness /
 execution rules above are in **1:1 correspondence** — every code below is
 emitted by exactly the cited rule, and every rule that rejects cites exactly
-one of these codes (or the reused RFC 0001 `missing_ref` family):
+one of these codes or a REUSED RFC 0001 code (`missing_ref` family,
+`cascade_arity`, `unknown_gate_kind` — reused with identical semantics on
+the composite construct):
 
 | Code | Emitted by |
 |---|---|
 | `unknown_composite_kind` | item 1 — `kind` outside the closed registry |
+| `unknown_composite_field` | item 1 — unknown or cross-kind body fields on a composite (closed shapes) |
+| `cascade_arity` (reused, RFC 0001) | item 2 — `\|gates\| ≠ \|arms\| − 1` on a cascade composite |
+| `unknown_gate_kind` (reused, RFC 0001) | `GateDecl` — gate kind outside the v1 registry |
 | `composite_binds_value` | §3.1 — a value bound on a composite |
 | `composite_shadows_name` | §3.1 — `N_X` name shadows another class |
 | `duplicate_composite` | §3.1 — duplicate name within `N_X` |
@@ -1014,6 +1020,8 @@ increment (§2).
 | 4 | codex (gpt-5.5, xhigh, read-only) — 2026-06-06 | **REJECT** — 1 blocking (round-3 deltas confirmed closed): the signal/threshold calibration binding was not normative | Addressed in Draft v5: §3.2 item 11 — every thresholded construct determines a signal id (explicit `SignalUse.signal` for `signal_below`/`signal_accept`; canonical stat ids `vote_margin`/`vote_agreement` for `margin_below`/`stat_at_least`); `θ.calibration.signal` MUST equal it; static lints `signal_mismatch` + `missing_calibration_signal`; rationale recorded (a threshold calibrated against signal A gating signal B is vacuously fresh); §3.3 notes the rule makes the target-property shapes well-posed. |
 
 | 5 | codex (gpt-5.5, xhigh, read-only, FRESH unanchored) — 2026-06-06 | **REJECT** — 8 blocking + 4 non-blocking | All addressed in Draft v6. Blocking: (FB1) §3.2 item-11 signal binding broke P1 (RFC 0001 leaves `calibration.signal` OPTIONAL) → rule re-scoped to COMPOSITES ONLY, fires at the composite USE SITE, never on `cvars`/`policies`; §4 subsumption narrowed to exact-on-execution-semantics + two intended composite-only ratchets (empty-`tuned_params`, signal binding); §4 P1-preserved sentence added (1.1 modules declare no composites); §9 criterion 3 "lint identically" carved out for the two ratchets. (FB2) use-site `SignalUse.inputs` not freshness-bound → `signal_inputs` added to the RFC 0001 §3.5 `ctx_ext` extension registry (conservative); item-11 rule requires `hash_covered_context ⊇ {signal_inputs}` AND covered value = use-site list when `inputs ≠ []`, else `unbound_signal_inputs`. (FB3) nested-certificate freshness honestly scoped → C3/C6 reworded to per-member coverage / TVAR-only obligations, explicitly NOT cross-level value-dependency freshness; §6 assumption 8 added (riding the §2 CVAR→CVAR deferral) with non-normative SHOULD to re-issue outer certificates on inner recalibration; §2 deferral bullet gains a revisit trigger; §3.6 fold scope note added. (FB4) `leafT` extended so a sampling ensemble's tuned `cardinality` (`{cardinality} ∩ N_T`) is in its leaf set, recursively through nesting. (FB5) post-cascade gate typing with strict placement symmetry — `margin_below` POST-only + gated arm must be margin-bearing (stage / `majority_vote` ensemble) else `gate_arm_incompatible`; `signal_below` PRE-only; `gate_kind_placement_mismatch` covers both misuse directions (retiring `pre_gate_requires_signal`); `missing_gate_signal` for signal-less `signal_below`; future output-signal post-gate noted deferred. (FB6) §3.2.1 closed result algebra `ArmResult ::= output(o, vote_stats?) | no_accept | error` with total/deterministic propagation rules unifying the per-construct exception/no-accept sentences; root no_accept → §3.6 fail-closed under strict / honest no-output (runtime-defined scoring) under non-strict; vote abstention stays internal. (FB7) §3.8 + C5 rewritten — `Unroll` is a SEMANTIC compilation into an internal K-chain IR (no surface state-predicate gate exists), `signal_accept` loops only; `external_accept`/`exhausted` offer no unroll; catalog table made honest (`self_debug` external_accept ⇒ no unroll). (FB8) §3.7/§3.9 — surface `pattern:` is sugar → `Provenance.pattern`; the full closed `Provenance` object is expansion-output (SDK-internal), never surface syntax. Non-blocking: (NB9) §3.3 cross-ref now cites the RFC 0001 §3.5 *Claim scope* paragraph accurately (2026-06-06 post-acceptance owner wording-audit clarification, §10 `post-acceptance` row); (NB10) pre-cascade route fixed to `j = min({ i < m : σ_i(x) ≥ θ_i } ∪ {m})`; (NB11) §3.11 restated as a 1:1 code↔rule table incl. `missing_gate_signal`, `missing_stop_signal`, `unbound_signal_inputs`, `gate_arm_incompatible`, `gate_kind_placement_mismatch`; (NB12) C4 verification narrowed — structural induction validates FORM closure only, operational estimate quality out of scope (assumption 3), cross-impl `c(agg)`/cost forms pinned by SHARED golden cost fixtures. |
+
+| 6 | codex (gpt-5.5, xhigh, read-only) — 2026-06-06 | **REJECT** — 1 blocking (all round-5 dispositions confirmed closed): §3.11's 1:1 claim missed codes for cascade arity and cross-kind/unknown body fields | Addressed in Draft v7: `unknown_composite_field` added (item 1); RFC 0001's `cascade_arity` and `unknown_gate_kind` explicitly reused with identical semantics and added to the table; the 1:1 claim wording now names the reused-code set precisely. |
 
 Design pre-review (before Draft v1): Option E architecture ACCEPTed by
 codex (gpt-5.5 xhigh — 4 hard constraints + terminology edits, all

--- a/formalization/rfc-0002-composite-knobs.md
+++ b/formalization/rfc-0002-composite-knobs.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Status** | **DRAFT v7** — under cross-model review; owner acceptance pending |
+| **Status** | **ACCEPTED** — owner acceptance recorded 2026-06-06 (nimrod, interactive) after anchored codex rounds 1–7 (ACCEPT), the fresh unanchored pass (all findings dispositioned), and the green C1–C6 model-checking suite (re-run by the integrating agent; see §10) |
 | **Target language version** | TVL 1.2 (conservative extension of 1.1) |
 | **Tracking** | `FR-TVL-COMPOSITE-KNOBS-V1` · ChangeSession `cs_aef1b9d2edfa5200` |
 | **Builds on** | RFC 0001 (ACCEPTED): one-Knob model, cvars, certificates, policies, strict promotion |
@@ -540,6 +540,11 @@ dependency kind):
 
 ```
 required_parents(θ_i in Cascade_post)  = leafT(a₁) ∪ … ∪ leafT(a_i)
+    (* indexing pinned: gate g_i sits BETWEEN a_i and a_{i+1}; it reads a_i's
+       vote statistics and, on escalation, admits a_{i+1}. Worked m=3: gates
+       g₁,g₂; required_parents(θ₁) = leafT(a₁); required_parents(θ₂) =
+       leafT(a₁) ∪ leafT(a₂); the margin-bearing typing rule of §3.2 item 5
+       applies to the OBSERVED arm a_i. *)
 required_parents(θ_i in Cascade_pre)   = leafT(a_i)            (the arm the gate
                                                                  admits; the signal's
                                                                  parents come via the
@@ -551,6 +556,12 @@ required_parents(θ in Ensemble.accept) = ⋃_j leafT(a_j) ∪ leafT(judge if pr
                                                                        k flow in via leafT *)
 required_parents(θ in Loop.stop)       = leafT(body)
 ```
+
+Note (model-checking packet, 2026-06-06): because `leafT` is recursive, a
+`signal_accept` loop whose body is a COMPOSITE arm accrues the entire nested
+subtree's TVARs into its stop threshold's obligation — a deliberately heavy,
+fail-closed requirement an author should anticipate when looping over deep
+composites.
 
 A new lint (`missing_composite_parent`) checks
 `required_parents(θ) ⊆ depends_on(θ)` for every threshold CVAR — purely
@@ -1022,6 +1033,9 @@ increment (§2).
 | 5 | codex (gpt-5.5, xhigh, read-only, FRESH unanchored) — 2026-06-06 | **REJECT** — 8 blocking + 4 non-blocking | All addressed in Draft v6. Blocking: (FB1) §3.2 item-11 signal binding broke P1 (RFC 0001 leaves `calibration.signal` OPTIONAL) → rule re-scoped to COMPOSITES ONLY, fires at the composite USE SITE, never on `cvars`/`policies`; §4 subsumption narrowed to exact-on-execution-semantics + two intended composite-only ratchets (empty-`tuned_params`, signal binding); §4 P1-preserved sentence added (1.1 modules declare no composites); §9 criterion 3 "lint identically" carved out for the two ratchets. (FB2) use-site `SignalUse.inputs` not freshness-bound → `signal_inputs` added to the RFC 0001 §3.5 `ctx_ext` extension registry (conservative); item-11 rule requires `hash_covered_context ⊇ {signal_inputs}` AND covered value = use-site list when `inputs ≠ []`, else `unbound_signal_inputs`. (FB3) nested-certificate freshness honestly scoped → C3/C6 reworded to per-member coverage / TVAR-only obligations, explicitly NOT cross-level value-dependency freshness; §6 assumption 8 added (riding the §2 CVAR→CVAR deferral) with non-normative SHOULD to re-issue outer certificates on inner recalibration; §2 deferral bullet gains a revisit trigger; §3.6 fold scope note added. (FB4) `leafT` extended so a sampling ensemble's tuned `cardinality` (`{cardinality} ∩ N_T`) is in its leaf set, recursively through nesting. (FB5) post-cascade gate typing with strict placement symmetry — `margin_below` POST-only + gated arm must be margin-bearing (stage / `majority_vote` ensemble) else `gate_arm_incompatible`; `signal_below` PRE-only; `gate_kind_placement_mismatch` covers both misuse directions (retiring `pre_gate_requires_signal`); `missing_gate_signal` for signal-less `signal_below`; future output-signal post-gate noted deferred. (FB6) §3.2.1 closed result algebra `ArmResult ::= output(o, vote_stats?) | no_accept | error` with total/deterministic propagation rules unifying the per-construct exception/no-accept sentences; root no_accept → §3.6 fail-closed under strict / honest no-output (runtime-defined scoring) under non-strict; vote abstention stays internal. (FB7) §3.8 + C5 rewritten — `Unroll` is a SEMANTIC compilation into an internal K-chain IR (no surface state-predicate gate exists), `signal_accept` loops only; `external_accept`/`exhausted` offer no unroll; catalog table made honest (`self_debug` external_accept ⇒ no unroll). (FB8) §3.7/§3.9 — surface `pattern:` is sugar → `Provenance.pattern`; the full closed `Provenance` object is expansion-output (SDK-internal), never surface syntax. Non-blocking: (NB9) §3.3 cross-ref now cites the RFC 0001 §3.5 *Claim scope* paragraph accurately (2026-06-06 post-acceptance owner wording-audit clarification, §10 `post-acceptance` row); (NB10) pre-cascade route fixed to `j = min({ i < m : σ_i(x) ≥ θ_i } ∪ {m})`; (NB11) §3.11 restated as a 1:1 code↔rule table incl. `missing_gate_signal`, `missing_stop_signal`, `unbound_signal_inputs`, `gate_arm_incompatible`, `gate_kind_placement_mismatch`; (NB12) C4 verification narrowed — structural induction validates FORM closure only, operational estimate quality out of scope (assumption 3), cross-impl `c(agg)`/cost forms pinned by SHARED golden cost fixtures. |
 
 | 6 | codex (gpt-5.5, xhigh, read-only) — 2026-06-06 | **REJECT** — 1 blocking (all round-5 dispositions confirmed closed): §3.11's 1:1 claim missed codes for cascade arity and cross-kind/unknown body fields | Addressed in Draft v7: `unknown_composite_field` added (item 1); RFC 0001's `cascade_arity` and `unknown_gate_kind` explicitly reused with identical semantics and added to the table; the 1:1 claim wording now names the reused-code set precisely. |
+
+| MC | model-checking packet (small-scope Python suite, house convention) — 2026-06-06 | **GREEN** — C1–C6, 38 checks incl. paired vacuity teeth; independent oracles (reachability, member walk, dual execution); full tvl suite 342 pass, re-run personally by the integrating agent | Two §3.5 clarifications folded in at acceptance (loop-over-composite stop obligation note; gate/arm indexing worked example). RECORDED OBLIGATION for the validators packet: §3.2 item-11 signal/threshold binding + `signal_inputs` freshness (`missing_calibration_signal`, `signal_mismatch`, `unbound_signal_inputs`) are verified by validator conformance fixtures, NOT by the algebra suite. |
+| owner | nimrod (interactive) — 2026-06-06 | **ACCEPTED** | Owner acceptance recorded after the full chain: anchored rounds 1–7, fresh unanchored pass, green model checking. Opens the validators packet (P4) and SDK pattern factories (P5). |
 
 Design pre-review (before Draft v1): Option E architecture ACCEPTed by
 codex (gpt-5.5 xhigh — 4 hard constraints + terminology edits, all

--- a/formalization/rfc-0002-composite-knobs.md
+++ b/formalization/rfc-0002-composite-knobs.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Status** | **DRAFT v1** — under cross-model review; owner acceptance pending |
+| **Status** | **DRAFT v2** — under cross-model review; owner acceptance pending |
 | **Target language version** | TVL 1.2 (conservative extension of 1.1) |
 | **Tracking** | `FR-TVL-COMPOSITE-KNOBS-V1` · ChangeSession `cs_aef1b9d2edfa5200` |
 | **Builds on** | RFC 0001 (ACCEPTED): one-Knob model, cvars, certificates, policies, strict promotion |
@@ -43,7 +43,7 @@ and fail-closed governance; procedural, plural naming where adoption lives.
 
 - the sealed three-constructor algebra with nesting closure (§3.2);
 - per-constructor calibratable surfaces (§3.3) and cost models (§3.4);
-- dependency compilation onto leaf TVARs (§3.5);
+- dependency-coverage compilation onto leaf TVARs (§3.5);
 - the certificate coverage fold extending RFC 0001 §3.6 strict promotion
   (§3.6);
 - the pattern-catalog contract and the v1 catalog (§3.7);
@@ -58,10 +58,13 @@ and fail-closed governance; procedural, plural naming where adoption lives.
   decision v1; a content-free composite summary is a recorded revisit
   trigger);
 - CVAR→CVAR dependencies (`depends_on` still names TVARs only — the RFC 0001
-  deferral stands; composite edges COMPILE DOWN to leaf TVARs, §3.5);
+  deferral stands; composite structure compiles to leaf-TVAR coverage
+  obligations, §3.5);
 - in-loop CVAR re-fitting and CVAR optimizers (RFC 0001 deferrals stand);
 - learned routers / dispatch functions as calibrators (would extend the
   calibrator registry, not this algebra);
+- selective composite consumption (per-candidate enable/disable of declared
+  composites — v1 uses the conservative all-roots rule, §3.6);
 - a pattern marketplace or third-party catalog mechanism (the v1 catalog is
   in-repo and curated);
 - changes to configuration documents (`tvl-configuration.schema.json`
@@ -83,10 +86,11 @@ attempts to bind a value on a composite is rejected
 Composite names form a new declaration class `N_X` in the **same scoped
 namespace** as tvars/cvars/policies: shadowing across classes is rejected
 exactly as in RFC 0001 P6 (`binding_partition_collision` generalizes;
-surfaced as `composite_shadows_name`). `N_X` never enters `Γ`,
-`Config(Δ, E_τ)`, `F^str`, or the optimizer projection `Σ` (§3.2 of RFC 0001
-is unchanged): the optimizer sees member TVARs individually; the composite is
-invisible to search exactly as cvars are (Property P2/P5 preserved).
+surfaced as `composite_shadows_name`, with `duplicate_composite` for
+collisions within `N_X`). `N_X` never enters `Γ`, `Config(Δ, E_τ)`, `F^str`,
+or the optimizer projection `Σ` (§3.2 of RFC 0001 is unchanged): the
+optimizer sees member TVARs individually; the composite is invisible to
+search exactly as cvars are (Property P2/P5 preserved).
 
 ### 3.2 The sealed algebra
 
@@ -94,98 +98,171 @@ invisible to search exactly as cvars are (Property P2/P5 preserved).
 Composite ::= ⟨ name : Ident,
                 kind : CompositeKind,            (* CLOSED registry *)
                 body : Cascade | Ensemble | Loop,(* discriminated by kind *)
-                pattern? : Ident ⟩               (* provenance annotation, §3.7 *)
+                scope? : Scope,                  (* RFC 0001 §3.7 scope_spec,
+                                                    same semantics as PolicyDecl *)
+                parameters? : Map,               (* opaque operational map —
+                                                    OUTSIDE the P8 surface, exactly
+                                                    as PolicyDecl.parameters *)
+                provenance? : Provenance ⟩       (* closed shape, §3.7 *)
 
 CompositeKind ::= cascade | ensemble | loop      (* SEALED: a fourth kind is a
                                                     new RFC, not a registry entry *)
 
-Arm       ::= StageRef | CompositeName           (* nesting: an arm may be another
-                                                    declared composite *)
+Arm ::= stage(StageRef, tuned_params : Ident*)   (* TAGGED. tuned_params declares
+                                                    the TVARs parameterizing this
+                                                    opaque stage — possibly empty;
+                                                    the author's declaration, since
+                                                    stages are opaque (§3.5) *)
+      | composite(CompositeName)                 (* TAGGED nesting reference;
+                                                    exact-match into N_X *)
 
 Cascade   ::= ⟨ arms : Arm+,                     (* |arms| = m ≥ 1 *)
                 gates : GateDecl*,               (* |gates| = m − 1 *)
                 placement : pre | post ⟩         (* DEFAULT post *)
 
 Ensemble  ::= ⟨ arms : Arm+,                     (* |arms| ≥ 1 *)
-                cardinality? : Ident,            (* namespace ref → TVAR or CVAR:
-                                                    the per-arm sample count k *)
+                cardinality? : Ident,            (* REQUIRED iff |arms| = 1
+                                                    (sampling form); FORBIDDEN if
+                                                    |arms| > 1 (committee form).
+                                                    Namespace ref → TVAR or CVAR
+                                                    of TVL type int; resolved
+                                                    values MUST satisfy k ≥ 1 *)
                 aggregate : AggregateDecl ⟩
 
 Loop      ::= ⟨ body : Arm,
+                state_keys : Ident*,             (* the DECLARED threaded-state
+                                                    keys; [] ⟺ body treated pure.
+                                                    Keys are content-free
+                                                    identifiers; the runtime
+                                                    supplies state operationally
+                                                    (environment.bindings
+                                                    precedent) *)
                 stop : StopDecl,
                 max_iters : ℕ≥1 ⟩                (* REQUIRED bound — totality *)
 
 GateDecl  ::= ⟨ kind : margin_below | signal_below,   (* v1 registry *)
                 threshold : Ident,               (* MUST resolve to a CVAR
                                                     (kind-checked), as RFC 0001 §3.8 *)
-                signal? : Ident ⟩                (* REQUIRED iff kind=signal_below:
-                                                    resolves to a declared SignalSpec *)
+                signal? : SignalSourceRef ⟩      (* REQUIRED iff kind=signal_below *)
+
+AcceptDecl ::= ⟨ kind : stat_at_least,           (* v1 registry — acceptance
+                                                    direction is ≥, deliberately
+                                                    DISTINCT from cascade
+                                                    escalation's < (no semantic
+                                                    drift between the two) *)
+                 stat : vote_margin | vote_agreement,
+                 threshold : Ident ⟩             (* MUST resolve to a CVAR *)
 
 AggregateDecl ::= ⟨ kind : majority_vote | judge_max,  (* v1 registry *)
-                    judge? : StageRef,           (* REQUIRED iff kind=judge_max *)
-                    accept? : GateDecl ⟩         (* optional acceptance gate over
-                                                    the aggregate's vote statistics *)
+                    judge? : Arm,                (* REQUIRED iff kind=judge_max;
+                                                    stage- or composite-tagged *)
+                    accept? : AcceptDecl ⟩
 
 StopDecl  ::= ⟨ kind : signal_accept | external_accept | exhausted,
                 threshold? : Ident,              (* REQUIRED iff kind=signal_accept:
                                                     MUST resolve to a CVAR *)
-                signal? : Ident,                 (* REQUIRED iff kind=signal_accept *)
+                signal? : SignalSourceRef,       (* REQUIRED iff kind=signal_accept;
+                                                    a function of state_keys only *)
                 predicate? : Ident ⟩             (* REQUIRED iff kind=external_accept:
                                                     OPAQUE runtime predicate id,
-                                                    StageRef-style (§3.8 of RFC 0001) *)
+                                                    StageRef-style — outside P8 *)
+
+SignalSourceRef ::= Ident    (* a calibration-source id from the SAME operational
+                                registry RFC 0001 cvars use
+                                (calibration_source_id, §3.5 there): an
+                                implementation-defined identifier, opaque to the
+                                module namespace — NOT a new declaration surface *)
 ```
 
-**Well-formedness (statically checked):**
+**Well-formedness (statically checked; error codes in §3.11):**
 
-1. `kind` ∈ the closed registry; anything else rejects
-   (`unknown_composite_kind`).
-2. Gate/arm arity: `|gates| = |arms| − 1` for cascades (degenerate `m = 1`
-   cascade has no gates and always returns its arm — RFC 0001's rule carries
-   over).
-3. Every `Arm` that is a `CompositeName` must resolve to a declared composite
-   (exact match, RFC 0001 §3.7 namespace rules); the resulting **reference
-   graph over `N_X` must be acyclic** (`composite_cycle`). Composition depth
-   is finite by construction: nesting is the ONLY composition mechanism, and
-   DAG-shaped configurations are the **closure of nesting** — there is no
-   fourth "DAG kind".
-4. Gate/stop thresholds resolve to CVARs (kind-checked, reusing RFC 0001's
-   gate rule); signals resolve to declared SignalSpecs (§3.5 of RFC 0001).
-5. `StageRef` remains an opaque operational identifier (RFC 0001 §3.8,
-   review finding 6) — not a namespace reference; duplicates within one
-   composite are rejected (`duplicate_stage`).
-6. Discriminator totality: exactly the body fields of the declared kind are
-   present; unknown or cross-kind fields reject (closed shapes, exact
-   diagnostics — the RFC 0001 grammar discipline).
+1. `kind` ∈ the closed registry (`unknown_composite_kind`); exactly the body
+   fields of the declared kind are present — unknown or cross-kind fields
+   reject (closed shapes, exact diagnostics).
+2. Cascade arity: `|gates| = |arms| − 1`; the degenerate `m = 1` cascade has
+   no gates and always returns its arm (RFC 0001 rule carries over).
+   `arms` must be non-empty for every constructor (`empty_arms`).
+3. **Arm resolution is tag-driven and unambiguous**: `composite(x)` must
+   resolve (exact match, RFC 0001 §3.7) into `N_X`
+   (`missing_composite_ref`); `stage(s)` is opaque and never consults the
+   namespace. In the surface syntax (§3.9) a BARE identifier in an arm
+   position is ALWAYS a stage (back-compatible with `policies.stages`);
+   nesting REQUIRES the tagged form. A bare arm identifier that collides
+   with a declared composite name is rejected (`ambiguous_arm`) rather than
+   silently resolved.
+4. The `composite(·)` reference graph over `N_X` must be acyclic
+   (`composite_cycle`); composition depth is therefore finite. Nesting is
+   the ONLY composition mechanism — DAG-shaped configurations are the
+   **closure of nesting**; there is no fourth "DAG kind".
+5. `placement: pre` requires EVERY gate to be `signal_below` with a declared
+   signal (`pre_gate_requires_signal`); `margin_below` is valid only with
+   `placement: post` (it consumes the executed arm's vote statistics).
+6. Gate/accept/stop thresholds resolve to CVARs (kind-checked, reusing
+   RFC 0001's gate rule — `missing_ref` family); `stage(·)` duplicates
+   within one composite are rejected (`duplicate_stage`).
+7. Ensemble cardinality: present iff `|arms| = 1`
+   (`cardinality_arity_mismatch`); must reference a TVAR or CVAR whose
+   declared TVL type is `int` (`invalid_cardinality_type`); resolution-time
+   values `k < 1` are rejection **R9** (`invalid_cardinality_value`),
+   extending RFC 0001 §3.4's rejection family.
+8. Loop: `stop.signal`, when present, may reference only declared
+   `state_keys` inputs (`stop_signal_outside_state`); `max_iters ≥ 1`
+   (`invalid_max_iters`).
 
 **Execution semantics.**
 
-- `placement: post` cascade is EXACTLY RFC 0001 §3.8 cascade execution
+- **`placement: post` cascade** is EXACTLY RFC 0001 §3.8 cascade execution
   (normative text incorporated by reference): run arm `i`, vote over `k_i`
   samples, escalate iff `margin < θ_i`; totality/determinism/error rules
   unchanged, including fail-closed propagation of stage exceptions under
-  strict modes.
-- `placement: pre` cascade (dispatch): the gate's `signal` is evaluated on
-  the INPUT before any arm runs; `route to arm_{i+1} ⟺ signal(x) < θ_i`
-  applied left to right; exactly one arm executes. Cost consequences in §3.4.
-  Empty/abstaining signal evaluation escalates (the RFC 0001 `margin = 0`
-  rule generalizes: an absent signal value compares below any `θ > 0`).
-- `ensemble`: run each arm (or one arm `k` times when `cardinality` is
-  declared and `|arms| = 1`); aggregate by the declared kind
-  (`majority_vote` over caller-defined equivalence keys with the RFC 0001
-  tie/abstain rules; `judge_max` runs the judge stage over candidate outputs
-  and selects the maximum-scored candidate deterministically, ties broken by
-  the RFC 0001 total order). An `accept` gate, when present, evaluates over
-  the aggregate's content-free vote statistics; failing it is an honest
-  no-accept outcome that propagates to the consumer (under strict modes it
-  feeds the fail-closed law).
-- `loop`: execute `body`; evaluate `stop` over the declared loop state;
-  repeat up to `max_iters`. State is explicitly threaded: iteration `i+1`
-  sees a declared accumulator (operationally defined by the runtime, like
-  stage bindings), never ambient hidden state. `exhausted` means "always run
-  `max_iters` iterations"; `signal_accept` stops when
-  `signal(state) ≥ θ` (acceptance, not escalation — the inequality direction
-  is deliberate and lint-pinned); `external_accept` delegates to an opaque
-  runtime predicate (outside the P8 surface, like `parameters`).
+  strict modes. Nested-composite arms execute their own semantics and
+  contribute their selected output as the arm output.
+- **`placement: pre` cascade (dispatch)**: no arm runs before routing. Gates
+  are evaluated LEFT TO RIGHT, first match wins:
+
+  ```
+  route(x) = arm_j  where  j = min{ i < m : σ_i(x) ≥ θ_i } ∪ {m}
+  ```
+
+  Gate `i` asks "is arm `i` adequate for x?" — adequate ⟺
+  `σ_i(x) ≥ θ_i` selects `arm_i`; otherwise evaluation proceeds to the next
+  gate; `arm_m` is the **fallback arm** and needs no gate. Exactly one arm
+  executes. An absent/abstaining signal value is INADEQUATE (routes onward
+  — fail-toward-the-stronger-arm); a signal-evaluation exception fails the
+  item's evaluation (never silently routes), feeding the fail-closed law
+  under strict modes. Each gate may carry a DISTINCT signal; cost
+  accounting is per-gate (§3.4).
+- **`ensemble`**: in the sampling form (`|arms| = 1`, cardinality `k`), the
+  single arm runs `k` times; in the committee form (`|arms| > 1`), each arm
+  runs once. Aggregation:
+  - `majority_vote`: votes over caller-defined equivalence keys with the
+    RFC 0001 tie/abstain rules (deterministic total order over serialized
+    keys).
+  - `judge_max`: the judge arm is invoked once per candidate output and
+    MUST yield a **finite numeric score** (the judge output contract). A
+    candidate whose judging raises, or yields NaN/±∞/non-numeric, is
+    EXCLUDED from selection; if ALL candidates are excluded the ensemble
+    evaluation FAILS (propagates as an evaluation error — never a silent
+    pick), feeding the fail-closed law under strict modes. Selection is the
+    maximum score; ties break by the RFC 0001 deterministic total order
+    over the candidates' serialized equivalence keys.
+  - `accept` (optional, either aggregate kind): `stat_at_least` evaluates
+    the named content-free vote statistic; failing it is an honest
+    no-accept outcome that propagates to the consumer (under strict modes
+    it feeds the fail-closed law). The acceptance inequality is `stat ≥ θ`
+    — deliberately the OPPOSITE direction of cascade escalation
+    (`margin < θ`), and a distinct registry, so the two cannot drift into
+    each other.
+- **`loop`**: execute `body`; the runtime threads the declared `state_keys`
+  (iteration `i+1` observes exactly the keys iteration `i` produced —
+  operationally supplied, like stage bindings; an undeclared key is simply
+  invisible to `stop`); evaluate `stop`; repeat up to `max_iters`.
+  `exhausted` always runs `max_iters` iterations; `signal_accept` stops
+  when `σ(state) ≥ θ` (acceptance direction, lint-pinned);
+  `external_accept` delegates to an opaque runtime predicate (outside the
+  P8 surface, like `parameters`). A body/stop exception fails the item's
+  evaluation (no partial-iteration output), feeding the fail-closed law
+  under strict modes.
 
 ### 3.3 Calibratable surface
 
@@ -195,9 +272,9 @@ target-property shape — this is the machine-facing payoff of sealing:
 | Constructor | Calibratable members | Target-property shape |
 |---|---|---|
 | `cascade` (post) | each gate threshold `θ_i` | conditional property of the ACCEPTANCE REGION the gate induces (e.g. `P(arm_i correct │ margin ≥ θ_i) ≥ p`) — exactly RFC 0001 §3.5's per-CVAR scope |
-| `cascade` (pre) | each routing threshold `θ_i` | conditional property of the ROUTE the signal induces (e.g. `P(arm_i adequate │ signal < θ_i) ≥ p`) |
-| `ensemble` | `accept.threshold`; `cardinality` when bound Calibrated | acceptance: `P(aggregate correct │ vote stat ≥ θ) ≥ p`; cardinality: cost-bounded sufficiency |
-| `loop` | `stop.threshold` (signal_accept) | stop adequacy: `P(accepted state meets target │ signal ≥ θ) ≥ p` |
+| `cascade` (pre) | each routing threshold `θ_i` | conditional property of the ROUTE the signal induces (e.g. `P(arm_i adequate │ σ_i ≥ θ_i) ≥ p`) |
+| `ensemble` | `accept.threshold`; `cardinality` when bound Calibrated | acceptance: `P(aggregate correct │ stat ≥ θ) ≥ p`; cardinality: cost-bounded sufficiency |
+| `loop` | `stop.threshold` (signal_accept) | stop adequacy: `P(accepted state meets target │ σ ≥ θ) ≥ p` |
 
 The **claim scope** paragraph of RFC 0001 §3.5 (2026-06-06 clarification)
 applies verbatim: each certificate is a per-variable, procedural claim about
@@ -213,12 +290,14 @@ Each constructor carries a normative expected-cost form over its members,
 with nested composites contributing their own cost recursively:
 
 ```
-cost(StageRef s)                       = c(s)                       (runtime-supplied)
-cost(Cascade_post(a₁..a_m, θ₁..θ_{m−1})) = cost(a₁) + Σ_{i=1}^{m−1} P(esc₁..esc_i) · cost(a_{i+1})
-cost(Cascade_pre (a₁..a_m, θ₁..θ_{m−1})) = c(signal) + Σ_i P(route = i) · cost(a_i)
-cost(Ensemble(a, k, agg))               = k · cost(a) + c(agg)      (single-arm form;
-                                           multi-arm: Σ_j cost(a_j) + c(agg))
-cost(Loop(b, stop, K))                  = E[iters] · cost(b),  E[iters] ≤ K
+cost(stage s)                            = c(s)                  (runtime-supplied)
+cost(Cascade_post(a₁..a_m, θ₁..θ_{m−1}))  = cost(a₁) + Σ_{i=1}^{m−1} P(esc₁..esc_i) · cost(a_{i+1})
+cost(Cascade_pre (a₁..a_m, σ/θ pairs))    = Σ_{i=1}^{m−1} P(reach gate i) · c(σ_i)
+                                            + Σ_{i=1}^{m} P(route = i) · cost(a_i)
+cost(Ensemble_sampling(a, k, agg))        = k · cost(a) + c(agg)
+cost(Ensemble_committee(a₁..a_j, agg))    = Σ_j cost(a_j) + c(agg)
+   where c(judge_max agg) = (candidates evaluated) · cost(judge arm)
+cost(Loop(b, stop, K))                    = E[iters] · (cost(b) + c(stop)),  E[iters] ≤ K
 ```
 
 Escalation/route/stop probabilities are *operational estimates* (observed
@@ -229,68 +308,103 @@ form — the equations close over the algebra. This is what makes
 frontier/constrained search over composites structurally informed instead of
 black-box.
 
-### 3.5 Dependency compilation (leaf TVARs only)
+### 3.5 Dependency coverage compiled onto leaf TVARs
 
-RFC 0001 defers CVAR→CVAR dependencies; this RFC **keeps that deferral** and
-defines how composite structure compiles onto the existing mechanism:
+RFC 0001 defers CVAR→CVAR dependencies; this RFC **keeps that deferral**.
+Because StageRefs are opaque, leaf parentage cannot be inferred — it is
+**declared**: each stage-tagged arm carries `tuned_params`, the TVARs
+parameterizing that stage (the author's knowledge; possibly empty). Define:
 
 ```
-leafT : Arm → ℘(N_T)
-leafT(StageRef s)     = T(s)            (* the tuned variables parameterizing the
-                                           stage, per the module's declarations *)
-leafT(CompositeName x) = ⋃_{a ∈ arms/body(x)} leafT(a)
-
-Compile_π(gate θ_i in Cascade(arms..)) :
-    π(θ_i) ⊇ leafT(a₁) ∪ … ∪ leafT(a_i)     (post: everything the gate observes)
-    π(θ_i) ⊇ ∅ ∪ signal's tuned parents      (pre: the signal's parameterization)
-Compile_π(accept θ in Ensemble(arms, k)) :
-    π(θ) ⊇ ⋃_j leafT(a_j) ∪ {k if k ∈ N_T}
-Compile_π(stop θ in Loop(body))         :
-    π(θ) ⊇ leafT(body)
+leafT(stage(s, ps))     = ps
+leafT(composite(x))     = ⋃_{a ∈ arms/body/judge(x)} leafT(a)
 ```
 
-The compiled `depends_on` sets contain **TVARs only** (claim C6); the
-RFC 0001 `missing_ref` lint remains the single authority. The payoff is that
-the freshness cascade becomes structural: swap an arm's model and every gate
-observing that arm reads stale through the existing
-`tuned_parent_values` core — by construction, not convention.
+The compilation then emits **coverage OBLIGATIONS over the EXISTING
+`depends_on` mechanism** (never automatic edge insertion, never a new
+dependency kind):
+
+```
+required_parents(θ_i in Cascade_post)  = leafT(a₁) ∪ … ∪ leafT(a_i)
+required_parents(θ_i in Cascade_pre)   = leafT(a_i)            (the arm the gate
+                                                                 admits; the signal's
+                                                                 parents come via the
+                                                                 CVAR's own calibration
+                                                                 context as in RFC 0001)
+required_parents(θ in Ensemble.accept) = ⋃_j leafT(a_j) ∪ leafT(judge if present)
+                                          ∪ ({cardinality} ∩ N_T)
+required_parents(θ in Loop.stop)       = leafT(body)
+```
+
+A new lint (`missing_composite_parent`) checks
+`required_parents(θ) ⊆ depends_on(θ)` for every threshold CVAR — purely
+static, since both sides are declared identifier sets. `depends_on` entries
+themselves remain TVAR-only and remain validated by the RFC 0001
+`missing_ref` lint, which stays the **single authority** on entry validity
+(claim C6: no rule in this RFC can introduce a non-TVAR edge). The payoff is
+that the freshness cascade becomes structural: swap the TVAR assignment
+parameterizing an arm, and every gate whose obligation covers that arm reads
+stale through the existing `tuned_parent_values` core — by declaration, not
+convention.
 
 ### 3.6 Certificate coverage fold (extends RFC 0001 §3.6)
 
 ```
 Cal : Composite → ℘(N_C)
 Cal(Cascade(arms, gates, _)) = ⋃ Cal(arms) ∪ { g.threshold : g ∈ gates }
-Cal(Ensemble(arms, k, agg))  = ⋃ Cal(arms) ∪ { agg.accept.threshold if present }
-                               ∪ { k if k ∈ N_C }
+Cal(Ensemble(arms, k, agg))  = ⋃ Cal(arms) ∪ Cal(agg.judge if present)
+                               ∪ { agg.accept.threshold if present }
+                               ∪ ({k} ∩ N_C)
 Cal(Loop(body, stop, _))     = Cal(body) ∪ { stop.threshold if kind=signal_accept }
-Cal(StageRef)                = ∅
+Cal(stage(·))                = ∅
+Cal(composite(x))            = Cal(body(x))
 ```
+
+**Root consumption (v1, conservative).** The composites a candidate `c`
+consumes are the **roots** of the module's `N_X` reference DAG — every
+declared composite not referenced as a nested arm of another. v1 has no
+selective-consumption mechanism (§2 deferral): all roots are consumed by
+every candidate. This is deliberately fail-closed — it can only
+over-require certificates, never under-require.
 
 Under `strict(M, c)` (RFC 0001 §3.6, unchanged), `CalibrationPass(c, M)`
 extends to require a valid, fresh certificate for **every** CVAR in
-`Cal(root)` for every composite the configuration consumes. The fold is
-**fail-closed** (claim C3): any uncertified or stale member ⇒ no certified
-selection — never a partial pass, never a silent skip of a nested level.
+`⋃_{r ∈ roots(M)} Cal(r)` in addition to RFC 0001's consumed-CVAR set. The
+fold is **fail-closed** (claim C3): any uncertified or stale member ⇒ no
+certified selection — never a partial pass, never a silent skip of a nested
+level.
 
 ### 3.7 The pattern catalog contract
 
 ```
-Pattern ::= ⟨ name : Ident,
-              params : ParamSchema,
-              expand : params → Composite ⟩    (* DETERMINISTIC, TOTAL on
-                                                  validated params *)
+Pattern    ::= ⟨ name : Ident,
+                 params : ParamSchema,
+                 expand : params → Composite ⟩   (* DETERMINISTIC, TOTAL on
+                                                    validated params *)
+
+Provenance ::= ⟨ pattern : Ident,                (* the catalog name *)
+                 pattern_version? : Ident,
+                 param_hash? : Hash,             (* H_c(canonical validated
+                                                    params) — raw params NEVER
+                                                    serialize *)
+                 node_path? : Ident ⟩            (* source-map position within
+                                                    the expansion *)
 ```
 
 A pattern is a **macro**: `expand` emits algebra nodes, every one stamped
-with `pattern = name` (the provenance annotation of §3.2). Provenance is a
-content-free identifier: it rides operational metadata (and any future wire
-summary) as an annotation, never as schema vocabulary — adding a pattern is
-an SDK release, not a language or schema change.
+with a `Provenance` value. **Provenance is a CLOSED shape** (identifiers
+and one canonical hash — no raw-params field, no content-typed field
+exists), so it can ride operational metadata and any future content-free
+summary without widening the P8 surface; a canary test (sentinel in a
+pattern param must never appear in serialized provenance/metadata) is part
+of the admission contract. Adding a pattern is an SDK release, not a
+language or schema change.
 
 **Admission contract** — a pattern enters the catalog only with ALL of:
 
 1. an expansion into the sealed algebra (no pattern-private node kinds);
-2. provenance/source-map metadata on every emitted node;
+2. closed-shape provenance on every emitted node + the P8 canary test
+   (sentinel param never serializes);
 3. a calibration recipe for every CVAR the expansion introduces (which
    signal, which split, which target-property shape from §3.3);
 4. standard telemetry names (§3.10);
@@ -302,12 +416,12 @@ an SDK release, not a language or schema change.
 
 | Pattern | Expansion (sketch) | Notes |
 |---|---|---|
-| `binary_cascade` | `Cascade(arms=[base, expert], gates=[margin_below θ], post)` | the RFC 0001 cascade policy's exact shape; migration target (§4) |
-| `n_cascade` | `Cascade(arms=[a₁..a_m], gates=[θ₁..θ_{m−1}], post)` | ordered escalation |
-| `self_consistency` | `Ensemble(arms=[a], cardinality=k, majority_vote, accept: margin_below θ?)` | k tuned or calibrated |
-| `best_of_n` | `Ensemble(arms=[a], cardinality=k, judge_max(judge))` | judge is a StageRef |
-| `self_debug` | `Loop(body=a, stop=external_accept(tests), max_iters=K)` | "2-step knob" at K=1 |
-| `self_refine` | `Loop(body=a, stop=signal_accept(σ, θ), max_iters=K)` | calibrated stop |
+| `binary_cascade` | `Cascade(arms=[stage(base), stage(expert)], gates=[margin_below θ], post)` | the RFC 0001 cascade policy's exact shape; migration target (§4) |
+| `n_cascade` | `Cascade(arms=[stage(a₁)..stage(a_m)], gates=[θ₁..θ_{m−1}], post)` | ordered escalation |
+| `self_consistency` | `Ensemble(arms=[stage(a)], cardinality=k, majority_vote, accept: stat_at_least(vote_margin, θ)?)` | k tuned or calibrated |
+| `best_of_n` | `Ensemble(arms=[stage(a)], cardinality=k, judge_max(stage(judge)))` | judge output contract §3.2 |
+| `self_debug` | `Loop(body=stage(a), state_keys=[attempt, critique], stop=external_accept(tests), max_iters=K)` | "2-step knob" at K=1 |
+| `self_refine` | `Loop(body=stage(a), state_keys=[draft], stop=signal_accept(σ, θ), max_iters=K)` | calibrated stop |
 
 The catalog is curated in-repo; growth follows the admission contract, never
 ad-hoc (the documented failure mode of open chain taxonomies).
@@ -315,25 +429,33 @@ ad-hoc (the documented failure mode of open chain taxonomies).
 ### 3.8 Loop → NCascade: a compilation relation
 
 For a bounded loop, define the unrolling
-`Unroll(Loop(b, stop, K)) = Cascade_post(arms=[b₍₁₎..b₍K₎], gates=[¬stop₍₁₎..¬stop₍K−1₎])`
-where `b₍ᵢ₎` is the body specialized to iteration `i`'s threaded state and
-each gate escalates exactly when the stop rule does NOT accept.
+`Unroll(Loop(b, S, stop, K)) = Cascade_post(arms=[b₍₁₎..b₍K₎], gates=[¬stop₍₁₎..¬stop₍K−1₎])`
+where `b₍ᵢ₎` is the body specialized to iteration `i`'s threaded state over
+the declared `state_keys`, and each gate escalates exactly when the stop
+rule does NOT accept.
 
 This is a **compilation relation, not semantic equality** (design review,
 codex): it is meaning-preserving **only under all of**:
 
-1. the body is pure, or its state is explicitly threaded through the
-   declared accumulator (no ambient mutation);
-2. the stop rule is a deterministic function of the declared state;
+1. the body's state flows exclusively through the declared `state_keys`
+   (`state_keys = []` ⟺ pure body) — no ambient mutation;
+2. the stop rule is a deterministic function of the declared state
+   (structurally enforced for `signal_accept` by
+   `stop_signal_outside_state`; asserted-by-contract for
+   `external_accept`);
 3. iterations are bounded by `max_iters` (always true in this algebra —
    `max_iters` is required);
-4. telemetry/side effects are observationally accounted: `iterations_used`
-   maps to "index of the selected arm", and per-iteration effects are
-   declared effects of the corresponding arm.
+4. telemetry and side effects are observationally accounted:
+   `iterations_used` maps to "index of the selected arm", `stop_reason`
+   maps to the final gate decision, and per-iteration effects are declared
+   effects of the corresponding arm.
 
 Implementations MAY offer the unrolled compilation (e.g. `unroll=K` on loop
-patterns); claim C5 model-checks the relation under conditions 1–3 at small
-scopes. Outside the conditions no equivalence is claimed.
+patterns). Verification is split by mechanism (claim C5): the model checker
+verifies output/selection preservation under conditions 1–3 at small
+scopes; the telemetry/effect accounting of condition 4 is verified by the
+golden expansion fixtures and SDK property tests for every pattern that
+offers `unroll`. Outside the conditions no equivalence is claimed.
 
 ### 3.9 Surface syntax (draft normative for the validators packet)
 
@@ -342,15 +464,21 @@ composites:
   - name: answerer
     kind: cascade            # cascade | ensemble | loop (closed)
     placement: post          # cascade only; default post
-    arms: [cheap_stage, strong_stage]          # StageRef | composite name
+    arms:                    # bare identifier = STAGE (always);
+      - cheap_stage          #   nesting REQUIRES the tagged form
+      - strong_stage
+    arm_params:              # optional: per-stage tuned_params declaration
+      cheap_stage: [cheap_model, temperature]
+      strong_stage: [strong_model]
     gates:
       - kind: margin_below
         threshold: router.margin_threshold     # MUST resolve to a CVAR
-    pattern: binary_cascade  # optional provenance annotation
+    pattern: binary_cascade  # provenance annotation (closed shape §3.7)
 
   - name: coder
     kind: loop
-    body: draft_stage
+    body: { composite: answerer }              # tagged nesting
+    state_keys: [attempt, critique]
     stop: { kind: external_accept, predicate: run_unit_tests }
     max_iters: 3
     pattern: self_debug
@@ -364,13 +492,31 @@ parse byte-identically to TVL 1.1 (§4).
 ### 3.10 Standard telemetry (content-free)
 
 Per-constructor measure names every implementation emits (counts, rates,
-enums only — nothing content-typed; P8 discipline):
+enums, finite numbers only — nothing content-typed; P8 discipline):
 
 - cascade: `escalation_rate`, `stage_selected` (index), per-gate
   `gate_margin_pass_rate`;
-- ensemble: `vote_agreement`, `vote_margin`, `candidates_evaluated`;
+- ensemble: `vote_agreement`, `vote_margin`, `candidates_evaluated`,
+  `candidates_excluded` (judge contract violations);
 - loop: `iterations_used`, `stop_reason` (enum over StopDecl kinds ∪
   `exhausted`).
+
+### 3.11 Error-code surface (exact diagnostics)
+
+New codes introduced by this RFC (each with a happy + rejecting conformance
+fixture in the validators packet):
+
+`unknown_composite_kind` · `composite_binds_value` ·
+`composite_shadows_name` · `duplicate_composite` · `empty_arms` ·
+`ambiguous_arm` · `missing_composite_ref` · `composite_cycle` ·
+`pre_gate_requires_signal` · `cardinality_arity_mismatch` ·
+`invalid_cardinality_type` · `invalid_cardinality_value` (R9) ·
+`missing_judge` · `unknown_aggregate_kind` · `unknown_stop_kind` ·
+`missing_stop_threshold` · `missing_stop_predicate` ·
+`stop_signal_outside_state` · `invalid_max_iters` ·
+`missing_composite_parent` · `duplicate_stage` (extended scope) — plus the
+RFC 0001 `missing_ref` family reused unchanged for every CVAR/threshold
+reference.
 
 ## 4. Compatibility and migration (P1 argument)
 
@@ -379,32 +525,41 @@ TVL 1.1 module parses identically with the same meaning (no existing block's
 grammar changes; the namespace rule extends by adding `N_X` to the same
 collision discipline). The shipped canonical examples remain green unchanged.
 
-**Cascade-policy subsumption.** The RFC 0001 policy form maps exactly:
+**Cascade-policy subsumption.** The RFC 0001 policy form maps exactly on
+ALL fields:
 
 ```
-PolicyDecl⟨name, "policy", "cascade", stages = s₁..s_m, gates = g₁..g_{m−1}⟩
-  ≡ Composite⟨name, cascade, arms = s₁..s_m, gates = g₁..g_{m−1}, placement = post⟩
+PolicyDecl⟨name, "policy", "cascade", stages = s₁..s_m,
+           gates = g₁..g_{m−1}, parameters?, scope?⟩
+  ≡ Composite⟨name, cascade,
+              arms = stage(s₁,[])..stage(s_m,[]), gates = g₁..g_{m−1},
+              placement = post, parameters?, scope?⟩
 ```
 
-field for field — same StageRef opacity, same gate→CVAR rule, same execution
-semantics (§3.2 incorporates RFC 0001 §3.8 by reference). `policies` with
-`strategy: cascade` remains VALID in TVL 1.2 (no deprecation this
-increment); the `binary_cascade`/`n_cascade` patterns are its forward form,
-and a future increment may add a migration lint. The SDK's shipped
-`CascadePolicy` is the execution target for cascade composites; the binary
-`Router` (unmerged) is a future *pattern/adapter* over it, and nothing in
-this RFC assumes its API.
+`stages` map to stage-tagged arms with empty `tuned_params` (the policy form
+never declared parentage — the obligation lint §3.5 is vacuous on migrated
+forms until authors declare `arm_params`, an explicit and intended
+ratchet); `parameters?` and `scope?` carry over verbatim with identical
+semantics and the identical outside-P8 categorization. StageRef opacity, the
+gate→CVAR rule, and execution semantics are unchanged (§3.2 incorporates
+RFC 0001 §3.8 by reference). `policies` with `strategy: cascade` remains
+VALID in TVL 1.2 (no deprecation this increment); the
+`binary_cascade`/`n_cascade` patterns are its forward form, and a future
+increment may add a migration lint. The SDK's shipped `CascadePolicy` is
+the execution target for cascade composites; the binary `Router` (unmerged)
+is a future *pattern/adapter* over it, and nothing in this RFC assumes its
+API.
 
 ## 5. Property claims (Phase 2)
 
 | Claim | Statement | Verification plan |
 |---|---|---|
-| **C1** Constructor disjointness | every composite node has exactly one kind from the closed registry; cross-kind/unknown fields reject | model checking (kind partition); lints with exact diagnostics |
-| **C2** Nesting well-formedness | the `N_X` reference graph is acyclic; expansion terminates; depth finite | model checking (acyclicity + a MUST-BE-SAT cyclic counterexample); `composite_cycle` lint |
-| **C3** Coverage-fold soundness | `Cal(root)` collects EXACTLY the calibratable members of the whole expansion (no over-, no under-collection); strict selection fails closed on any gap | model checking (fold vs. ground-truth member walk + a MUST-BE-SAT uncertified-gate violation); red-first SDK tests |
-| **C4** Cost compositionality | the cost forms close over nesting: substituting an arm's cost form yields the composite's | model checking at small scopes (structural induction skeleton); SDK property tests |
-| **C5** Loop→NCascade compilation | under §3.8 conditions 1–3, `Unroll` preserves selected output and accounted telemetry at small scopes | model checking (bounded K ≤ 4); golden fixtures for `unroll=K` patterns |
-| **C6** Dependency-compilation soundness | every `Compile_π` edge lands in `N_T`; no CVAR→CVAR edge is ever emitted | model checking (codomain check + MUST-BE-SAT violation transition); reuse of the RFC 0001 `missing_ref` lint as the single authority |
+| **C1** Constructor disjointness | every composite node has exactly one kind from the closed registry; cross-kind/unknown fields reject | model checking (kind partition); lints with exact diagnostics (§3.11) |
+| **C2** Nesting well-formedness | the `N_X` reference graph is acyclic; expansion terminates; depth finite; arm resolution unambiguous (tag-driven + `ambiguous_arm`) | model checking (acyclicity + a MUST-BE-SAT cyclic counterexample); `composite_cycle`/`ambiguous_arm` lints |
+| **C3** Coverage-fold soundness | `Cal` over all roots collects EXACTLY the calibratable members of the whole expansion (no over-, no under-collection, judge and nested levels included); strict selection fails closed on any gap | model checking (fold vs. ground-truth member walk + a MUST-BE-SAT uncertified-gate violation); red-first SDK tests |
+| **C4** Cost compositionality | the cost forms close over nesting: substituting an arm's cost form yields the composite's, for all five forms (§3.4) | model checking at small scopes (structural induction skeleton); SDK property tests |
+| **C5** Loop→NCascade compilation | under §3.8 conditions 1–3, `Unroll` preserves the selected output at small scopes (model-checked); condition 4's telemetry accounting holds for every catalog pattern offering `unroll` (golden fixtures + SDK property tests) | split by mechanism as stated |
+| **C6** Dependency-compilation soundness | `required_parents` obligations land in `N_T` only and are checkable statically; no rule of this RFC can emit or require a non-TVAR `depends_on` entry; `missing_ref` remains the single entry-validity authority | model checking (codomain check + MUST-BE-SAT violation transition); `missing_composite_parent` lint tests |
 
 Model-checking discipline: every UNSAT assertion is paired with a
 deliberately-broken transition that MUST be SAT (vacuity teeth — program
@@ -417,25 +572,37 @@ The claims above hold under, and only under:
 1. **RFC 0001's assumption set** (§5 there) for everything
    certificate/freshness related — split independence, dataset-hash
    stability, canonical hashing, exchangeability for statistical targets.
-2. **Stage cost stability** — `c(StageRef)` is a runtime-supplied estimate;
+2. **Stage cost stability** — `c(stage)` is a runtime-supplied estimate;
    cost-model outputs are estimators, never guarantees.
 3. **Probability estimates are operational** — escalation/route/stop
    probabilities come from observed telemetry or calibration splits;
    distribution shift degrades the estimate and is surfaced through the same
-   freshness context keys as RFC 0001 (no new drift detection is introduced).
-4. **Loop state discipline** — the §3.8 conditions are the implementation's
-   responsibility to uphold; the algebra makes them checkable, not
-   automatic.
-5. **Pattern determinism** — `expand` is a pure function of validated
+   freshness context keys as RFC 0001 (no new drift detection is
+   introduced).
+4. **Declared parentage honesty** — `tuned_params` on stage arms is the
+   author's declaration of an opaque stage's parameterization; an
+   under-declared arm under-states `required_parents`. The lint can enforce
+   consistency of what is declared, not completeness of the declaration
+   (same epistemic position as RFC 0001's `depends_on` itself).
+5. **Loop state discipline** — §3.8 condition 1 is structurally encouraged
+   (`state_keys` + `stop_signal_outside_state`) but ambient-effect freedom
+   is the implementation's responsibility; `external_accept` determinism
+   (condition 2) is asserted by contract, not proven.
+6. **Judge contract** — the judge's finite-numeric-score obligation is a
+   runtime contract; violations are detected per §3.2 (exclusion /
+   fail-closed), not prevented.
+7. **Pattern determinism** — `expand` is a pure function of validated
    params; catalog entries violating this are rejected at admission.
 
 ## 7. Field categorization (P8 alignment)
 
 Composites introduce **no content-typed fields**: kinds, placements, arity,
-identifiers (names, StageRefs, predicate ids), one required integer
-(`max_iters`), and namespace references. `pattern` is a content-free
-identifier. Telemetry (§3.10) is counts/rates/enums. The opaque escape
-hatches (`StageRef`, `external_accept.predicate`) follow RFC 0001's
+identifiers (names, StageRefs, predicate ids, state keys, signal-source
+ids), one required integer (`max_iters`), and namespace references.
+`Provenance` is a CLOSED shape (identifiers + one canonical hash; raw
+pattern params never serialize — admission-contract canary). Telemetry
+(§3.10) is counts/rates/enums/finite numbers. The opaque escape hatches
+(`StageRef`, `external_accept.predicate`, `parameters`) follow RFC 0001's
 `environment.bindings` precedent and sit outside the P8 surface exactly as
 `policies[].parameters` does. Nothing in this RFC crosses the wire this
 increment (§2).
@@ -467,7 +634,10 @@ increment (§2).
    vacuity check, on a re-run executed by the integrating agent.
 3. The §3.9 surface syntax validated against the §4 subsumption mapping (the
    policy form and its composite form lint identically on the shared
-   examples).
+   examples), with explicit degenerate fixtures: `m=1` cascade, `k=1`
+   sampling ensemble, committee ensemble, `max_iters=1` loop, empty-arms
+   rejection, tagged-nesting under an ensemble judge, and an
+   `ambiguous_arm` rejection.
 4. Owner acceptance recorded in this header and §10 (human-only gate).
 5. No semantic change to any RFC 0001 construct: the RFC 0001 conformance
    fixtures pass unchanged.
@@ -476,9 +646,9 @@ increment (§2).
 
 | Round | Reviewer | Verdict | Disposition |
 |---|---|---|---|
-| — | (pending: anchored codex rounds, fresh pass, owner gate) | — | — |
+| 1 | codex (gpt-5.5, xhigh, read-only) — 2026-06-06 | **REJECT** — 10 blocking, 5 non-blocking | All addressed in Draft v2: (1) arm resolution made tag-driven (`stage`/`composite` tags; bare = stage always; `ambiguous_arm` rejection); (2) pre-cascade made total (first-match-wins routing with fallback arm, per-gate signals + per-gate cost, absent-signal routes onward, `pre_gate_requires_signal`); (3) ensemble cardinality: required iff single-arm, int-typed, R9 rejection for k<1, both cost forms; (4) judge output contract (finite numeric score, exclusion rules, all-excluded fails, deterministic tie-break); (5) loop state formalized (`state_keys` + `stop_signal_outside_state`; pure ⟺ empty); (6) dependency compilation rebuilt as DECLARED parentage (`tuned_params` on stage arms) + static coverage obligations (`missing_composite_parent`), `missing_ref` stays single authority, judge/signal parents included; (7) root-consumption rule (all N_X roots, conservative fail-closed; selective consumption deferred); (8) subsumption made exact (scope?/parameters? carried onto Composite verbatim; empty tuned_params on migrated stages stated as intended ratchet); (9) Provenance closed shape (param_hash only, canary in admission contract); (10) C5 verification split by mechanism incl. condition 4. Non-blocking: full error-code surface §3.11; SignalSourceRef clarified as the RFC 0001 calibration-source registry (no new declaration surface); degenerate fixtures added to §9; AcceptDecl separated from GateDecl with opposite inequality; P6 note absorbed. |
 
-Design pre-review (before this draft): Option E architecture ACCEPTed by
+Design pre-review (before Draft v1): Option E architecture ACCEPTed by
 codex (gpt-5.5 xhigh — 4 hard constraints + terminology edits, all
 incorporated: not-a-binding-kind §3.1; no CVAR→CVAR deps §3.5; CascadePolicy
 anchor §4; compilation-relation framing §3.8; "structural constructors"

--- a/formalization/rfc-0002-composite-knobs.md
+++ b/formalization/rfc-0002-composite-knobs.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Status** | **DRAFT v5** — under cross-model review; owner acceptance pending |
+| **Status** | **DRAFT v6** — under cross-model review; owner acceptance pending |
 | **Target language version** | TVL 1.2 (conservative extension of 1.1) |
 | **Tracking** | `FR-TVL-COMPOSITE-KNOBS-V1` · ChangeSession `cs_aef1b9d2edfa5200` |
 | **Builds on** | RFC 0001 (ACCEPTED): one-Knob model, cvars, certificates, policies, strict promotion |
@@ -47,7 +47,8 @@ and fail-closed governance; procedural, plural naming where adoption lives.
 - the certificate coverage fold extending RFC 0001 §3.6 strict promotion
   (§3.6);
 - the pattern-catalog contract and the v1 catalog (§3.7);
-- the `Loop → NCascade` bounded-unroll **compilation relation** (§3.8);
+- the `Loop → K-chain` bounded-unroll **semantic compilation relation**
+  (`signal_accept` loops only; §3.8);
 - a `composites:` surface block as a conservative grammar extension (§3.9);
 - subsumption of `policies.strategy: cascade` by exact expansion mapping (§4).
 
@@ -59,7 +60,12 @@ and fail-closed governance; procedural, plural naming where adoption lives.
   trigger);
 - CVAR→CVAR dependencies (`depends_on` still names TVARs only — the RFC 0001
   deferral stands; composite structure compiles to leaf-TVAR coverage
-  obligations, §3.5);
+  obligations, §3.5). **Revisit trigger:** because this deferral leaves
+  nested-certificate freshness per-member and NOT cross-level (an outer
+  certificate is not bound to inner CVAR values — §3.6 scope, §6
+  assumption 8), the CVAR→CVAR mechanism is the work item that would let an
+  inner recalibration stale an outer certificate; revisit when cross-level
+  value-dependency freshness is required;
 - in-loop CVAR re-fitting and CVAR optimizers (RFC 0001 deferrals stand);
 - learned routers / dispatch functions as calibrators (would extend the
   calibrator registry, not this algebra);
@@ -144,7 +150,8 @@ GateDecl  ::= ⟨ kind : margin_below | signal_below,   (* v1 registry *)
                 threshold : Ident,               (* MUST resolve to a CVAR of TVL
                                                     type int or float (kind- AND
                                                     type-checked; §3.2 item 6) *)
-                signal? : SignalUse ⟩            (* REQUIRED iff kind=signal_below *)
+                signal? : SignalUse ⟩            (* REQUIRED iff kind=signal_below
+                                                    (`missing_gate_signal`) *)
 
 AcceptDecl ::= ⟨ kind : stat_at_least,           (* v1 registry — acceptance
                                                     direction is ≥, deliberately
@@ -163,7 +170,8 @@ StopDecl  ::= ⟨ kind : signal_accept | external_accept | exhausted,
                 threshold? : Ident,              (* REQUIRED iff kind=signal_accept:
                                                     MUST resolve to a CVAR of TVL
                                                     type int or float *)
-                signal? : SignalUse,             (* REQUIRED iff kind=signal_accept;
+                signal? : SignalUse,             (* REQUIRED iff kind=signal_accept
+                                                    (`missing_stop_signal`);
                                                     inputs MUST ⊆ state_keys *)
                 predicate? : Ident ⟩             (* REQUIRED iff kind=external_accept:
                                                     OPAQUE runtime predicate id,
@@ -211,9 +219,31 @@ SignalUse ::= ⟨ signal : Ident,       (* a NAMED signal reference into the SAM
    (`composite_cycle`); composition depth is therefore finite. Nesting is
    the ONLY composition mechanism — DAG-shaped configurations are the
    **closure of nesting**; there is no fourth "DAG kind".
-5. `placement: pre` requires EVERY gate to be `signal_below` with a declared
-   signal (`pre_gate_requires_signal`); `margin_below` is valid only with
-   `placement: post` (it consumes the executed arm's vote statistics).
+5. **Gate kind / placement / arm typing** (strict placement symmetry).
+   The two gate kinds are placement-exclusive and one carries an arm-typing
+   obligation:
+   - `margin_below` is **POST-only** — it consumes the just-executed arm's
+     vote statistics. Its gated arm (the arm `i` whose margin gate `g_i`
+     reads in a post-cascade) MUST be **margin-bearing**: either a `stage`
+     arm (RFC 0001 vote semantics produce its vote statistics) or an
+     `ensemble` arm whose `aggregate.kind = majority_vote` (the committee's
+     vote statistics). Gating any other arm kind — a `loop` arm, a nested
+     **pre**-cascade composite, a `judge_max` ensemble (it yields a score,
+     not a vote margin), or a nested **post**-cascade composite — with
+     `margin_below` rejects statically (`gate_arm_incompatible`).
+   - `signal_below` is **PRE-only** — it scores the input before any arm
+     runs and routes (§ execution semantics). It requires a declared
+     `signal` field; a `signal_below` gate missing its `signal` rejects
+     (`missing_gate_signal`).
+   - A `margin_below` gate under `placement: pre`, or a `signal_below` gate
+     under `placement: post`, rejects (`gate_kind_placement_mismatch` —
+     covers BOTH directions of kind/placement misuse, subsuming the former
+     pre-with-margin case).
+
+   *Future extension (deferred):* post-cascade gates keyed on an output
+   signal (a `signal_below`-style post gate scoring the executed arm's
+   output rather than its vote margin) are out of scope for TVL 1.2 — the
+   v1 post gate is `margin_below` only.
 6. Gate/accept/stop thresholds resolve to CVARs (kind-checked, reusing
    RFC 0001's gate rule — `missing_ref` family); `stage(·)` duplicates
    within one composite are rejected (`duplicate_stage`).
@@ -246,7 +276,8 @@ SignalUse ::= ⟨ signal : Ident,       (* a NAMED signal reference into the SAM
    the execution comparisons (`margin < θ`, `σ ≥ θ`, `stat ≥ θ`) are over
    finite numbers; a non-finite resolved value fails the item's evaluation
    per the existing exception rules (never a silent comparison).
-11. **Signal/threshold calibration binding** (cross-model round 4): every
+11. **Signal/threshold calibration binding** (cross-model round 4;
+   **COMPOSITE-SCOPED**, cross-model fresh pass): every **composite-bound**
    thresholded construct determines a signal id —
 
    ```
@@ -257,16 +288,47 @@ SignalUse ::= ⟨ signal : Ident,       (* a NAMED signal reference into the SAM
    ```
 
    where the canonical vote-statistic ids live in the SAME registry
-   namespace as named signals. The threshold CVAR `θ` of every such
-   construct MUST declare `calibration.signal = sig(construct)`: a missing
-   `calibration.signal` on `θ` rejects (`missing_calibration_signal`); a
-   differing one rejects (`signal_mismatch`). Rationale: certificate
-   freshness binds `H_c(σ)` for the signal used DURING CALIBRATION — a
-   threshold calibrated against signal A gating signal B would be
-   **vacuously fresh**. This rule is static (both sides are declared
-   identifiers) and is distinct from `missing_composite_parent`: parent
-   coverage binds tuned-TVAR freshness; this rule binds the measured
-   signal semantics of the threshold itself.
+   namespace as named signals. **The lint fires at the composite USE SITE**:
+   it is the `composites:` construct that references `θ` (as a gate, accept,
+   or stop threshold) which obliges `θ` to declare
+   `calibration.signal = sig(construct)`. It NEVER fires on a `cvars` or
+   `policies` block in isolation — a CVAR whose `calibration.signal` is
+   absent or differs is well-formed on its own (RFC 0001 leaves
+   `calibration.signal` OPTIONAL), and a legacy `policies:` cascade keeps
+   RFC 0001 semantics untouched. Only when a composite USES `θ` as a
+   threshold does the binding become an obligation of that composite: a
+   missing `calibration.signal` on a composite-referenced `θ` rejects
+   (`missing_calibration_signal`); a differing one rejects
+   (`signal_mismatch`). Rationale: certificate freshness binds `H_c(σ)` for
+   the signal used DURING CALIBRATION — a threshold calibrated against
+   signal A gating signal B would be **vacuously fresh**. This rule is
+   static (both sides are declared identifiers) and is distinct from
+   `missing_composite_parent`: parent coverage binds tuned-TVAR freshness;
+   this rule binds the measured signal semantics of the threshold itself.
+   Because the obligation lives on the composite use site, it is one of the
+   two intended composite-only ratchets over RFC 0001 (the other being the
+   empty-`tuned_params` parent-coverage ratchet, §4); a TVL 1.1 module
+   declares no composites, so the lint never fires on it (P1 preserved, §4).
+
+   **Use-site signal inputs are freshness-bound** (cross-model fresh pass):
+   a `SignalUse.inputs` list changes the runtime scoring semantics of the
+   signal (it selects which keys/features the scoring function reads), so a
+   recalibration that held inputs fixed must be invalidated when the
+   composite changes them. TVL 1.2 adds a NEW optional freshness-context
+   **extension** key, `signal_inputs`, to the RFC 0001 §3.5 `ctx_ext`
+   registry (conservative: an optional extension key; `ctx_core` is
+   untouched, so all TVL 1.1 freshness behavior is unchanged). The rule,
+   composite-use-site-scoped exactly like the signal-id binding above: when
+   a composite-bound threshold's governing `SignalUse` has `inputs ≠ []`,
+   the threshold CVAR `θ`'s
+   `promotion_policy.require_calibration.hash_covered_context` MUST include
+   `signal_inputs`, AND the value covered under `signal_inputs` MUST equal
+   the use-site ordered input list; either failure rejects
+   (`unbound_signal_inputs`). This is static — both the use-site `inputs`
+   list and the covered context value are declared identifiers. When
+   `inputs = []` the signal reads no use-site-selected keys and no coverage
+   of `signal_inputs` is required. Isolated `cvars`/`policies` are
+   unaffected (the obligation is the composite's, not the CVAR's).
 
 **Execution semantics.**
 
@@ -280,7 +342,7 @@ SignalUse ::= ⟨ signal : Ident,       (* a NAMED signal reference into the SAM
   are evaluated LEFT TO RIGHT, first match wins:
 
   ```
-  route(x) = arm_j  where  j = min{ i < m : σ_i(x) ≥ θ_i } ∪ {m}
+  route(x) = arm_j  where  j = min({ i < m : σ_i(x) ≥ θ_i } ∪ {m})
   ```
 
   Gate `i` asks "is arm `i` adequate for x?" — adequate ⟺
@@ -323,6 +385,73 @@ SignalUse ::= ⟨ signal : Ident,       (* a NAMED signal reference into the SAM
   evaluation (no partial-iteration output), feeding the fail-closed law
   under strict modes.
 
+### 3.2.1 The result algebra (closed, total, deterministic)
+
+The per-construct sentences above each handle three outcomes — a produced
+output, an honest non-acceptance, and an evaluation failure. This subsection
+names that codomain once and gives the propagation rules through nesting, so
+the per-construct sentences are instances of one algebra rather than ad-hoc
+prose. Every arm and every composite evaluates to:
+
+```
+ArmResult ::= output(o, vote_stats?)    (* a produced output; vote_stats present
+                                           iff the producer is margin-bearing —
+                                           a stage or a majority_vote ensemble *)
+            | no_accept                 (* ran, but no result met the construct's
+                                           acceptance condition — an HONEST
+                                           no-output outcome, NOT an error *)
+            | error                     (* evaluation failed — exception, judge
+                                           contract violation with no survivor,
+                                           non-finite threshold comparison, etc. *)
+```
+
+The three kinds are disjoint and exhaustive: every evaluation lands in exactly
+one. Propagation is **total and deterministic** — defined for every kind in
+every construct:
+
+- **`error` is absorbing.** An `error` from any arm/body/gate/judge/stop fails
+  the enclosing item's evaluation in every construct, propagating outward to the
+  root (where, under strict modes, it feeds the RFC 0001 §3.6 fail-closed law).
+  This unifies the per-construct exception sentences above (post-cascade stage
+  exception, pre-cascade signal exception, all-judge-excluded, loop body/stop
+  exception, non-finite threshold) — those sentences are retained for locality
+  but are each an instance of this single rule.
+- **`no_accept` propagation** (per construct):
+  - *post-cascade*: a `no_accept` from arm `i` escalates to arm `i+1` when
+    `i < m`; if the last arm (`i = m`) yields `no_accept`, the cascade yields
+    `no_accept`.
+  - *pre-cascade (dispatch)*: the routed arm's result is the cascade's result;
+    if the single routed arm yields `no_accept`, the cascade yields `no_accept`
+    (routing selects the arm; it does not re-route on non-acceptance).
+  - *loop*: a `no_accept` body result completes the iteration unaccepted and the
+    loop **continues** to the next iteration; a loop that reaches `max_iters`
+    without acceptance (no `signal_accept` fired), or whose final body result is
+    `no_accept` (the `exhausted` case), yields `no_accept`.
+  - *ensemble (committee `majority_vote`)*: a committee arm yielding `no_accept`
+    is a candidate **excluded** from the vote; if ALL candidates are excluded by
+    `no_accept`, the ensemble yields `no_accept` — DISTINCT from the
+    all-excluded-**by-error** case (judge contract violations), which is an
+    `error` and FAILS.
+  - *ensemble (aggregate accept)*: when an `accept` decl is present, an
+    aggregate that runs but fails `stat ≥ θ` yields `no_accept`.
+- **`output` propagation.** An arm/body producing `output(o, vote_stats?)`
+  contributes `o` (and its `vote_stats` where margin-bearing) as the construct's
+  selected output per the construct's selection rule (escalation stop, route,
+  vote/judge winner, accepted loop state).
+
+**Root-level `no_accept`.** A `no_accept` that reaches the composite root is an
+honest no-output evaluation. Under strict modes it feeds the RFC 0001 §3.6
+fail-closed law exactly as the other no-certified-selection verdicts do (no
+winner-by-objective fallback). Under non-strict modes it surfaces as an honest
+no-output evaluation result; how operational scoring treats a no-output item
+(skip, penalty, abstain) is **runtime-defined** and outside this RFC.
+
+**Vote abstention is not a result kind.** Abstention stays INTERNAL to voting:
+an empty/abstain-only vote yields `margin = 0` (RFC 0001's rule, carried over),
+which the gate/accept inequality then consumes — it never escapes the voting
+step as an `ArmResult`. The only result kinds are `output`, `no_accept`, and
+`error`.
+
 ### 3.3 Calibratable surface
 
 Each constructor *defines* which members admit calibration and with what
@@ -339,13 +468,19 @@ The §3.2 item-11 binding rule makes these target-property shapes
 well-posed: the certificate's `H_c(σ)` covers the very signal the gate
 evaluates at runtime, never a different one.
 
-The **claim scope** paragraph of RFC 0001 §3.5 (2026-06-06 clarification)
-applies verbatim: each certificate is a per-variable, procedural claim about
-the conditional, component-level property the variable controls under the
-documented assumptions. **A composite's end-to-end metrics remain
-observations** under the promotion judgment; nothing in this RFC creates a
-config-level guarantee, and user-facing copy MUST NOT present a composite as
-one.
+The **Claim scope** paragraph added to RFC 0001 §3.5 (the 2026-06-06
+post-acceptance owner wording-audit clarification, recorded as the
+`post-acceptance` row of RFC 0001's §10 review log; no semantic rule changed)
+applies verbatim here: each certificate is a per-variable, procedural claim —
+the declared calibration procedure ran over the declared evidence pool under
+the hashed freshness context, and, where the `TargetProperty` carries a
+statistical bound, that bound's subject is the conditional, component-level
+property the variable controls — valid only under the documented assumptions.
+A "certified selection" is the **conjunction** of the §3.6 promotion win on
+observed metrics AND per-CVAR certificate coverage; neither subsumes the
+other. **A composite's end-to-end metrics remain observations** under the
+promotion judgment; nothing in this RFC creates a config-level guarantee, and
+user-facing copy MUST NOT present a composite as one.
 
 ### 3.4 Cost models and compositionality
 
@@ -381,7 +516,22 @@ parameterizing that stage (the author's knowledge; possibly empty). Define:
 ```
 leafT(stage(s, ps))     = ps
 leafT(composite(x))     = ⋃_{a ∈ arms/body/judge(x)} leafT(a)
+                          ∪ ({cardinality(x)} ∩ N_T)    (* iff x is an Ensemble in
+                                                           sampling form whose
+                                                           cardinality is bound Tuned;
+                                                           ∅ otherwise — folds in
+                                                           recursively through nesting *)
 ```
+
+The `({cardinality} ∩ N_T)` term makes a composite's leaf set include its
+ensemble's tuned sample count: a sampling-form ensemble whose `cardinality`
+is a TVAR is parameterized by that TVAR exactly as a stage is parameterized
+by its `tuned_params`, so swapping `k` must read stale through the same
+parent-coverage cascade. The intersection with `N_T` keeps the codomain
+TVAR-only (C6): a Calibrated or absent cardinality contributes nothing to
+`leafT` (it is instead a member of `Cal`, §3.6). Because `leafT(composite(x))`
+recurses over `arms/body/judge(x)`, nested ensembles' tuned cardinalities
+fold up to every enclosing threshold's obligation.
 
 The compilation then emits **coverage OBLIGATIONS over the EXISTING
 `depends_on` mechanism** (never automatic edge insertion, never a new
@@ -395,7 +545,9 @@ required_parents(θ_i in Cascade_pre)   = leafT(a_i)            (the arm the gat
                                                                  CVAR's own calibration
                                                                  context as in RFC 0001)
 required_parents(θ in Ensemble.accept) = ⋃_j leafT(a_j) ∪ leafT(judge if present)
-                                          ∪ ({cardinality} ∩ N_T)
+                                          ∪ ({cardinality} ∩ N_T)   (* this ensemble's
+                                                                       own k; nested arms'
+                                                                       k flow in via leafT *)
 required_parents(θ in Loop.stop)       = leafT(body)
 ```
 
@@ -437,6 +589,18 @@ fold is **fail-closed** (claim C3): any uncertified or stale member ⇒ no
 certified selection — never a partial pass, never a silent skip of a nested
 level.
 
+**Scope of the fold (honest, per-member).** The fold is exact **per-member**
+coverage: it guarantees that *each member CVAR* carries its own valid, fresh
+certificate (its own §3.5 freshness context, including its own `t|π` parent
+values). It does NOT establish a cross-level value-dependency: an OUTER
+certificate is not bound to the *values* of INNER CVARs. Concretely, a nested
+composite's inner threshold may be re-calibrated to a new value while the
+outer construct's certificate stays fresh — because RFC 0001's freshness core
+hashes tuned parents (`t|π`), not the resolved values of sibling/child CVARs,
+and CVAR→CVAR dependencies remain deferred (§2). This limitation is named as
+§6 assumption 8, with a recommended conservative practice (re-issue outer
+certificates when any member of the subtree's `Cal` set is re-calibrated).
+
 ### 3.7 The pattern catalog contract
 
 ```
@@ -463,6 +627,14 @@ pattern param must never appear in serialized provenance/metadata) is part
 of the admission contract. Adding a pattern is an SDK release, not a
 language or schema change.
 
+**Surface vs. expansion-output.** The full closed `Provenance` object above
+is **expansion-output metadata produced by `expand` (SDK-internal)** — it is
+NEVER surface syntax. The only provenance the `composites:` surface accepts
+is the flat `pattern: <name>` **sugar key**, which maps to `Provenance.pattern`
+on the emitted root node; the surface author never writes
+`pattern_version`/`param_hash`/`node_path` (those are stamped by the
+expander). The surface accepts ONLY the sugar key.
+
 **Admission contract** — a pattern enters the catalog only with ALL of:
 
 1. an expansion into the sealed algebra (no pattern-private node kinds);
@@ -483,19 +655,40 @@ language or schema change.
 | `n_cascade` | `Cascade(arms=[stage(a₁)..stage(a_m)], gates=[θ₁..θ_{m−1}], post)` | ordered escalation |
 | `self_consistency` | `Ensemble(arms=[stage(a)], cardinality=k, majority_vote, accept: stat_at_least(vote_margin, θ)?)` | k tuned or calibrated |
 | `best_of_n` | `Ensemble(arms=[stage(a)], cardinality=k, judge_max(stage(judge)))` | judge output contract §3.2 |
-| `self_debug` | `Loop(body=stage(a), state_keys=[attempt, critique], stop=external_accept(tests), max_iters=K)` | "2-step knob" at K=1 |
-| `self_refine` | `Loop(body=stage(a), state_keys=[draft], stop=signal_accept(σ, θ), max_iters=K)` | calibrated stop |
+| `self_debug` | `Loop(body=stage(a), state_keys=[attempt, critique], stop=external_accept(tests), max_iters=K)` | "2-step knob" at K=1; `external_accept` stop ⇒ **NO unroll** (§3.8) |
+| `self_refine` | `Loop(body=stage(a), state_keys=[draft], stop=signal_accept(σ, θ), max_iters=K)` | calibrated `signal_accept` stop ⇒ unroll-eligible (§3.8) |
 
 The catalog is curated in-repo; growth follows the admission contract, never
 ad-hoc (the documented failure mode of open chain taxonomies).
 
-### 3.8 Loop → NCascade: a compilation relation
+### 3.8 Loop → K-chain: a semantic compilation (not a surface map)
 
-For a bounded loop, define the unrolling
-`Unroll(Loop(b, S, stop, K)) = Cascade_post(arms=[b₍₁₎..b₍K₎], gates=[¬stop₍₁₎..¬stop₍K−1₎])`
+`Unroll` is a **semantic compilation into an internal K-chain execution
+form** (an SDK intermediate representation), NOT a syntactic rewrite into the
+surface algebra (cross-model fresh pass). It is deliberately NOT a map into a
+surface `Cascade_post`: the v1 gate registry has only `margin_below` and
+`signal_below`, and **neither is a state-predicate gate** — there is no
+surface gate kind whose decision is `¬stop = σ(state) < θ` over the loop's
+threaded state. Writing `Unroll` as a surface `Cascade_post` with
+`¬stop` gates would therefore require a gate kind that does not exist; the
+compilation target is instead the internal K-chain, whose escalation
+predicate the SDK IR carries directly.
+
+The unroll offer exists **only for `signal_accept` loops**. For such a loop
+the chain of length `K` is:
+
+```
+KChain(Loop(b, S, signal_accept(σ, θ), K))
+   = ⟨ stages = [b₍₁₎ .. b₍K₎],
+       escalate after stage i  ⟺  ¬stop₍ᵢ₎  =  σ(state₍ᵢ₎) < θ ⟩
+```
+
 where `b₍ᵢ₎` is the body specialized to iteration `i`'s threaded state over
-the declared `state_keys`, and each gate escalates exactly when the stop
-rule does NOT accept.
+the declared `state_keys`, and the chain escalates to stage `i+1` exactly
+when the `signal_accept` stop has NOT fired (`σ(state₍ᵢ₎) < θ`, the
+acceptance-direction complement). `external_accept` loops (opaque runtime
+predicate — no declared state predicate to chain) and `exhausted` loops (no
+acceptance predicate at all) offer **no unroll**.
 
 This is a **compilation relation, not semantic equality** (design review,
 codex): it is meaning-preserving **only under all of**:
@@ -503,22 +696,24 @@ codex): it is meaning-preserving **only under all of**:
 1. the body's state flows exclusively through the declared `state_keys`
    (`state_keys = []` ⟺ pure body) — no ambient mutation;
 2. the stop rule is a deterministic function of the declared state
-   (structurally enforced for `signal_accept` by
-   `stop_signal_outside_state`; asserted-by-contract for
-   `external_accept`);
+   (structurally enforced for `signal_accept` by `stop_signal_outside_state`
+   — the only stop kind that offers unroll, so condition 2 is structural
+   here, not contract-asserted);
 3. iterations are bounded by `max_iters` (always true in this algebra —
    `max_iters` is required);
 4. telemetry and side effects are observationally accounted:
-   `iterations_used` maps to "index of the selected arm", `stop_reason`
-   maps to the final gate decision, and per-iteration effects are declared
-   effects of the corresponding arm.
+   `iterations_used` maps to "index of the selected chain stage",
+   `stop_reason` maps to the final escalation decision, and per-iteration
+   effects are declared effects of the corresponding chain stage.
 
-Implementations MAY offer the unrolled compilation (e.g. `unroll=K` on loop
-patterns). Verification is split by mechanism (claim C5): the model checker
-verifies output/selection preservation under conditions 1–3 at small
-scopes; the telemetry/effect accounting of condition 4 is verified by the
-golden expansion fixtures and SDK property tests for every pattern that
-offers `unroll`. Outside the conditions no equivalence is claimed.
+Implementations MAY offer the unrolled compilation (e.g. `unroll=K` on
+`signal_accept` loop patterns). Verification is split by mechanism (claim
+C5): the model checker compares the **execution traces** of the `Loop` and of
+its `KChain` under conditions 1–3 at small scopes (output/selection
+preservation); the telemetry/effect accounting of condition 4 is verified by
+the golden expansion fixtures and SDK property tests for every pattern that
+offers `unroll`. Outside the conditions, and for non-`signal_accept` loops,
+no equivalence is claimed.
 
 ### 3.9 Surface syntax (draft normative for the validators packet)
 
@@ -558,7 +753,7 @@ composites:
     gates:
       - kind: margin_below
         threshold: router.margin_threshold     # CVAR of type float
-    pattern: binary_cascade  # provenance annotation (closed shape §3.7)
+    pattern: binary_cascade  # the ONLY surface provenance key (sugar → Provenance.pattern, §3.7)
 
   - name: coder
     kind: loop
@@ -568,6 +763,12 @@ composites:
     max_iters: 3
     pattern: self_debug
 ```
+
+The surface `pattern:` field is a flat **sugar key** mapping to
+`Provenance.pattern` (§3.7); the full closed `Provenance` object is
+expansion-output metadata stamped by the expander (SDK-internal) and is never
+surface syntax — the surface accepts ONLY the sugar key, never
+`pattern_version`/`param_hash`/`node_path`.
 
 Closed shapes with exact diagnostics throughout (RFC 0001 grammar
 discipline); the EBNF and `tvl.schema.json` deltas land in the validators
@@ -589,23 +790,51 @@ enums, finite numbers only — nothing content-typed; P8 discipline):
 ### 3.11 Error-code surface (exact diagnostics)
 
 New codes introduced by this RFC (each with a happy + rejecting conformance
-fixture in the validators packet):
+fixture in the validators packet). The list and the well-formedness /
+execution rules above are in **1:1 correspondence** — every code below is
+emitted by exactly the cited rule, and every rule that rejects cites exactly
+one of these codes (or the reused RFC 0001 `missing_ref` family):
 
-`unknown_composite_kind` · `composite_binds_value` ·
-`composite_shadows_name` · `duplicate_composite` · `empty_arms` ·
-`ambiguous_arm` · `missing_composite_ref` · `composite_cycle` ·
-`pre_gate_requires_signal` · `cardinality_arity_mismatch` ·
-`invalid_cardinality_type` · `invalid_cardinality_value` (R9) ·
-`missing_judge` · `unknown_aggregate_kind` · `unknown_stop_kind` ·
-`missing_stop_threshold` · `missing_stop_predicate` ·
-`stop_signal_outside_state` · `invalid_max_iters` ·
-`missing_composite_parent` · `invalid_tuned_param` ·
-`invalid_threshold_type` · `invalid_arm_shape` · `invalid_signal_use` ·
-`signal_mismatch` · `missing_calibration_signal` ·
-`duplicate_stage` (extended scope) — plus the RFC 0001 `missing_ref`
-family reused unchanged for every CVAR/threshold reference, and rejection
-**R9** (`invalid_cardinality_value`) extending the §3.4 acceptance algebra
-as `Accept₁.₂` (§3.2 item 7).
+| Code | Emitted by |
+|---|---|
+| `unknown_composite_kind` | item 1 — `kind` outside the closed registry |
+| `composite_binds_value` | §3.1 — a value bound on a composite |
+| `composite_shadows_name` | §3.1 — `N_X` name shadows another class |
+| `duplicate_composite` | §3.1 — duplicate name within `N_X` |
+| `empty_arms` | item 2 — `arms` empty for any constructor |
+| `ambiguous_arm` | item 3 — bare arm id collides with a composite name |
+| `missing_composite_ref` | item 3 — `composite(x)` resolves to no `N_X` member |
+| `composite_cycle` | item 4 — the `N_X` reference graph is cyclic |
+| `gate_arm_incompatible` | item 5 — `margin_below` gating a non-margin-bearing arm |
+| `gate_kind_placement_mismatch` | item 5 — `margin_below` in `pre`, or `signal_below` in `post` (both directions; subsumes the former `pre_gate_requires_signal`) |
+| `missing_gate_signal` | item 5 / `GateDecl` — `signal_below` gate missing its `signal` |
+| `duplicate_stage` (extended scope) | item 6 — duplicate `stage(·)` within one composite |
+| `cardinality_arity_mismatch` | item 7 — `cardinality` present iff `|arms| = 1` violated |
+| `invalid_cardinality_type` | item 7 — `cardinality` ref not int-typed |
+| `invalid_cardinality_value` (R9) | item 7 — resolution-time `k < 1` (extends the §3.4 acceptance algebra as `Accept₁.₂`) |
+| `stop_signal_outside_state` | item 8 / `StopDecl` — `stop.signal.inputs ⊄ state_keys` |
+| `missing_stop_signal` | `StopDecl` — `signal_accept` stop missing its `signal` |
+| `missing_stop_threshold` | `StopDecl` — `signal_accept` stop missing its `threshold` |
+| `missing_stop_predicate` | `StopDecl` — `external_accept` stop missing its `predicate` |
+| `unknown_stop_kind` | `StopDecl` — `stop.kind` outside the closed registry |
+| `invalid_max_iters` | item 8 — `max_iters < 1` |
+| `missing_judge` | `AggregateDecl` — `judge_max` aggregate missing its `judge` |
+| `unknown_aggregate_kind` | `AggregateDecl` — `aggregate.kind` outside the closed registry |
+| `invalid_tuned_param` | item 9 — a `tuned_params` entry not resolving to a TVAR |
+| `invalid_threshold_type` | item 10 — a gate/accept/stop threshold CVAR not int/float |
+| `missing_calibration_signal` | item 11 — composite-referenced `θ` missing `calibration.signal` |
+| `signal_mismatch` | item 11 — composite-referenced `θ`'s `calibration.signal ≠ sig(construct)` |
+| `unbound_signal_inputs` | item 11 — use-site `SignalUse.inputs ≠ []` not covered by `signal_inputs`, or covered value ≠ the use-site list |
+| `missing_composite_parent` | §3.5 — `required_parents(θ) ⊄ depends_on(θ)` |
+| `invalid_arm_shape` | §3.9 — unknown keys in an `ArmSurface` object form |
+| `invalid_signal_use` | §3.2 / §3.9 — malformed `SignalUse` object (missing `signal`, unknown keys, non-list `inputs`) |
+
+Plus the RFC 0001 `missing_ref` family, reused unchanged for every
+CVAR/threshold namespace reference (gate/accept/stop thresholds, item 6), and
+rejection **R9** (`invalid_cardinality_value`) extending the §3.4 acceptance
+algebra as `Accept₁.₂` (§3.2 item 7). The former `pre_gate_requires_signal`
+code is RETIRED into `gate_kind_placement_mismatch`, which now covers both
+directions of gate-kind/placement misuse (cross-model fresh pass).
 
 ## 4. Compatibility and migration (P1 argument)
 
@@ -625,14 +854,35 @@ PolicyDecl⟨name, "policy", "cascade", stages = s₁..s_m,
               placement = post, parameters?, scope?⟩
 ```
 
-`stages` map to stage-tagged arms with empty `tuned_params` (the policy form
-never declared parentage — the obligation lint §3.5 is vacuous on migrated
-forms until authors declare per-arm `tuned_params`, an explicit and intended
-ratchet); `parameters?` and `scope?` carry over verbatim with identical
-semantics and the identical outside-P8 categorization. StageRef opacity, the
-gate→CVAR rule, and execution semantics are unchanged (§3.2 incorporates
-RFC 0001 §3.8 by reference). `policies` with `strategy: cascade` remains
-VALID in TVL 1.2 (no deprecation this increment); the
+**Subsumption is exact on EXECUTION SEMANTICS, with two intended composite
+ratchets on the lint surface** (cross-model fresh pass — the `≡` above is the
+execution-semantics identity, not a lint identity). The mapping is exact on
+StageRef opacity, the gate→CVAR rule, and execution semantics, which are
+unchanged (§3.2 incorporates RFC 0001 §3.8 by reference). The composite form
+ADDITIONALLY enforces two static lints that the RFC 0001 `policies:` form does
+NOT — both deliberate, explicit ratchets, fired only at the composite use
+site:
+
+- **`stages` → empty `tuned_params`** (§3.5): the policy form never declared
+  parentage, so the obligation lint is vacuous on migrated forms until authors
+  declare per-arm `tuned_params`.
+- **signal/threshold binding** (§3.2 item 11): a gate threshold CVAR used by a
+  composite must declare `calibration.signal = sig(construct)` (and, when its
+  `SignalUse.inputs ≠ []`, cover `signal_inputs`). RFC 0001 leaves
+  `calibration.signal` OPTIONAL, so a legacy `policies:` cascade is unaffected;
+  only the composite use site adds this obligation.
+
+`parameters?` and `scope?` carry over verbatim with identical semantics and
+the identical outside-P8 categorization.
+
+**P1 is preserved.** Because a TVL 1.1 module declares no `composites:` block,
+neither ratchet can fire on it — both lints are use-site obligations of a
+`composites:` construct, of which a 1.1 module has none. A valid TVL 1.1
+cascade `policies:` block whose threshold CVAR omits `calibration.signal` (or
+covers no `signal_inputs`) therefore remains valid under TVL 1.2 with RFC 0001
+semantics untouched; the ratchets are an opt-in cost of MOVING to the composite
+form, not a retroactive invalidation. `policies` with `strategy: cascade`
+remains VALID in TVL 1.2 (no deprecation this increment); the
 `binary_cascade`/`n_cascade` patterns are its forward form, and a future
 increment may add a migration lint. The SDK's shipped `CascadePolicy` is
 the execution target for cascade composites; the binary `Router` (unmerged)
@@ -645,10 +895,10 @@ API.
 |---|---|---|
 | **C1** Constructor disjointness | every composite node has exactly one kind from the closed registry; cross-kind/unknown fields reject | model checking (kind partition); lints with exact diagnostics (§3.11) |
 | **C2** Nesting well-formedness | the `N_X` reference graph is acyclic; expansion terminates; depth finite; arm resolution unambiguous (tag-driven + `ambiguous_arm`) | model checking (acyclicity + a MUST-BE-SAT cyclic counterexample); `composite_cycle`/`ambiguous_arm` lints |
-| **C3** Coverage-fold soundness | `Cal` over all roots collects EXACTLY the calibratable members of the whole expansion (no over-, no under-collection, judge and nested levels included); strict selection fails closed on any gap | model checking (fold vs. ground-truth member walk + a MUST-BE-SAT uncertified-gate violation); red-first SDK tests |
-| **C4** Cost compositionality | the cost forms close over nesting: substituting an arm's cost form yields the composite's, for all five forms (§3.4) | model checking at small scopes (structural induction skeleton); SDK property tests |
-| **C5** Loop→NCascade compilation | under §3.8 conditions 1–3, `Unroll` preserves the selected output at small scopes (model-checked); condition 4's telemetry accounting holds for every catalog pattern offering `unroll` (golden fixtures + SDK property tests) | split by mechanism as stated |
-| **C6** Dependency-compilation soundness | `required_parents` obligations land in `N_T` only and are checkable statically; no rule of this RFC can emit or require a non-TVAR `depends_on` entry; `missing_ref` remains the single entry-validity authority | model checking (codomain check + MUST-BE-SAT violation transition); `missing_composite_parent` lint tests |
+| **C3** Coverage-fold soundness (PER-MEMBER) | `Cal` over all roots collects EXACTLY the calibratable members (the CVARs) of the whole expansion (no over-, no under-collection, judge and nested levels included); strict selection requires a valid fresh certificate for EACH such member and fails closed on any gap. **Scope:** this is exact PER-MEMBER coverage — each member CVAR's own freshness — and is explicitly NOT a cross-level value-dependency guarantee: an outer certificate is not bound to inner CVAR values (a nested composite's inner threshold may recalibrate while the outer certificate stays fresh; §6 assumption 8, riding the §2 CVAR→CVAR deferral) | model checking (fold vs. ground-truth member walk + a MUST-BE-SAT uncertified-gate violation); red-first SDK tests |
+| **C4** Cost compositionality | the cost forms close over nesting: substituting an arm's cost form yields the composite's, for all five forms (§3.4) | model checking at small scopes (structural induction of FORM closure only); operational estimate quality is OUT OF SCOPE (§6 assumption 3); cross-implementation compatibility of `c(agg)` and the cost forms pinned by SHARED golden cost fixtures (the cross-SDK fixture convention) |
+| **C5** Loop→K-chain compilation (`signal_accept` only) | for `signal_accept` loops, under §3.8 conditions 1–3, `Unroll` into the internal K-chain preserves the selected output / execution trace at small scopes (model-checked, trace comparison Loop vs. K-chain); condition 4's telemetry accounting holds for every catalog pattern offering `unroll` (golden fixtures + SDK property tests); `external_accept`/`exhausted` loops offer no unroll and claim nothing | split by mechanism as stated |
+| **C6** Dependency-compilation soundness (TVAR-ONLY obligations) | `required_parents` obligations land in `N_T` only and are checkable statically; no rule of this RFC can emit or require a non-TVAR `depends_on` entry; `missing_ref` remains the single entry-validity authority. **Scope:** the obligations bind tuned-TVAR freshness only; they do NOT establish CVAR→CVAR (cross-level value-dependency) freshness, which stays deferred (§2; §6 assumption 8) | model checking (codomain check + MUST-BE-SAT violation transition); `missing_composite_parent` lint tests |
 
 Model-checking discipline: every UNSAT assertion is paired with a
 deliberately-broken transition that MUST be SAT (vacuity teeth — program
@@ -682,6 +932,20 @@ The claims above hold under, and only under:
    fail-closed), not prevented.
 7. **Pattern determinism** — `expand` is a pure function of validated
    params; catalog entries violating this are rejected at admission.
+8. **Nested-certificate freshness is per-member, not cross-level**
+   (cross-model fresh pass) — the §3.6 coverage fold and the §3.5
+   parent-coverage obligations bind *each member CVAR's own* freshness; they
+   do NOT make an OUTER certificate depend on the *values* of INNER CVARs.
+   An inner threshold can be re-calibrated to a new value while an outer
+   construct's certificate remains fresh, because RFC 0001's freshness core
+   hashes tuned parents (`t|π`), not sibling/child CVAR values, and
+   **CVAR→CVAR dependencies remain deferred** (§2). This is the direct
+   consequence of that deferral; closing it is the work of the deferred
+   CVAR→CVAR dependency mechanism. *Recommended conservative practice
+   (non-normative):* implementations **SHOULD** re-issue an outer construct's
+   certificate whenever any member of that subtree's `Cal` set (§3.6) is
+   re-calibrated, so that an outer "fresh" verdict never outlives an inner
+   recalibration in practice.
 
 ## 7. Field categorization (P8 alignment)
 
@@ -723,11 +987,16 @@ increment (§2).
 2. Model-checking packet green for C1–C6, including every paired MUST-BE-SAT
    vacuity check, on a re-run executed by the integrating agent.
 3. The §3.9 surface syntax validated against the §4 subsumption mapping (the
-   policy form and its composite form lint identically on the shared
-   examples), with explicit degenerate fixtures: `m=1` cascade, `k=1`
-   sampling ensemble, committee ensemble, `max_iters=1` loop, empty-arms
-   rejection, tagged-nesting under an ensemble judge, and an
-   `ambiguous_arm` rejection.
+   policy form and its composite form have **identical execution semantics**
+   and lint identically on the shared examples **except** for the two intended
+   composite-only ratchets — the empty-`tuned_params` parent-coverage
+   obligation (§3.5) and the signal/threshold binding (§3.2 item 11, incl.
+   `signal_inputs` coverage) — which fire only on the composite form, never on
+   the legacy `policies:` form), with explicit degenerate fixtures: `m=1`
+   cascade, `k=1` sampling ensemble, committee ensemble, `max_iters=1` loop,
+   empty-arms rejection, tagged-nesting under an ensemble judge, an
+   `ambiguous_arm` rejection, and a `gate_arm_incompatible` /
+   `gate_kind_placement_mismatch` rejection pair.
 4. Owner acceptance recorded in this header and §10 (human-only gate).
 5. No semantic change to any RFC 0001 construct: the RFC 0001 conformance
    fixtures pass unchanged.
@@ -743,6 +1012,8 @@ increment (§2).
 | 3 | codex (gpt-5.5, xhigh, read-only) — 2026-06-06 | **REJECT** — 3 findings (1 model choice + 2 wording residue); rounds 1–2 dispositions confirmed closed (incl. judge-arm coverage via ArmSurface and §3.11 completeness) | All addressed in Draft v4: (1) the signal model is CHOSEN explicitly — `SignalUse.signal` is a named Ident into the SAME registry namespace as RFC 0001's module-facing `calibration.signal` (one signal model across the language; the closed SignalSpec shape enters only through H_c(σ)); SignalSurface grammar added to §3.9 and `invalid_signal_use` to §3.11; (2) stale `arm_params` wording in §4 corrected to per-arm `tuned_params`; (3) §7 terminology fixed (signal ids + opaque input-feature ids; sources reserved for evidence pools). |
 
 | 4 | codex (gpt-5.5, xhigh, read-only) — 2026-06-06 | **REJECT** — 1 blocking (round-3 deltas confirmed closed): the signal/threshold calibration binding was not normative | Addressed in Draft v5: §3.2 item 11 — every thresholded construct determines a signal id (explicit `SignalUse.signal` for `signal_below`/`signal_accept`; canonical stat ids `vote_margin`/`vote_agreement` for `margin_below`/`stat_at_least`); `θ.calibration.signal` MUST equal it; static lints `signal_mismatch` + `missing_calibration_signal`; rationale recorded (a threshold calibrated against signal A gating signal B is vacuously fresh); §3.3 notes the rule makes the target-property shapes well-posed. |
+
+| 5 | codex (gpt-5.5, xhigh, read-only, FRESH unanchored) — 2026-06-06 | **REJECT** — 8 blocking + 4 non-blocking | All addressed in Draft v6. Blocking: (FB1) §3.2 item-11 signal binding broke P1 (RFC 0001 leaves `calibration.signal` OPTIONAL) → rule re-scoped to COMPOSITES ONLY, fires at the composite USE SITE, never on `cvars`/`policies`; §4 subsumption narrowed to exact-on-execution-semantics + two intended composite-only ratchets (empty-`tuned_params`, signal binding); §4 P1-preserved sentence added (1.1 modules declare no composites); §9 criterion 3 "lint identically" carved out for the two ratchets. (FB2) use-site `SignalUse.inputs` not freshness-bound → `signal_inputs` added to the RFC 0001 §3.5 `ctx_ext` extension registry (conservative); item-11 rule requires `hash_covered_context ⊇ {signal_inputs}` AND covered value = use-site list when `inputs ≠ []`, else `unbound_signal_inputs`. (FB3) nested-certificate freshness honestly scoped → C3/C6 reworded to per-member coverage / TVAR-only obligations, explicitly NOT cross-level value-dependency freshness; §6 assumption 8 added (riding the §2 CVAR→CVAR deferral) with non-normative SHOULD to re-issue outer certificates on inner recalibration; §2 deferral bullet gains a revisit trigger; §3.6 fold scope note added. (FB4) `leafT` extended so a sampling ensemble's tuned `cardinality` (`{cardinality} ∩ N_T`) is in its leaf set, recursively through nesting. (FB5) post-cascade gate typing with strict placement symmetry — `margin_below` POST-only + gated arm must be margin-bearing (stage / `majority_vote` ensemble) else `gate_arm_incompatible`; `signal_below` PRE-only; `gate_kind_placement_mismatch` covers both misuse directions (retiring `pre_gate_requires_signal`); `missing_gate_signal` for signal-less `signal_below`; future output-signal post-gate noted deferred. (FB6) §3.2.1 closed result algebra `ArmResult ::= output(o, vote_stats?) | no_accept | error` with total/deterministic propagation rules unifying the per-construct exception/no-accept sentences; root no_accept → §3.6 fail-closed under strict / honest no-output (runtime-defined scoring) under non-strict; vote abstention stays internal. (FB7) §3.8 + C5 rewritten — `Unroll` is a SEMANTIC compilation into an internal K-chain IR (no surface state-predicate gate exists), `signal_accept` loops only; `external_accept`/`exhausted` offer no unroll; catalog table made honest (`self_debug` external_accept ⇒ no unroll). (FB8) §3.7/§3.9 — surface `pattern:` is sugar → `Provenance.pattern`; the full closed `Provenance` object is expansion-output (SDK-internal), never surface syntax. Non-blocking: (NB9) §3.3 cross-ref now cites the RFC 0001 §3.5 *Claim scope* paragraph accurately (2026-06-06 post-acceptance owner wording-audit clarification, §10 `post-acceptance` row); (NB10) pre-cascade route fixed to `j = min({ i < m : σ_i(x) ≥ θ_i } ∪ {m})`; (NB11) §3.11 restated as a 1:1 code↔rule table incl. `missing_gate_signal`, `missing_stop_signal`, `unbound_signal_inputs`, `gate_arm_incompatible`, `gate_kind_placement_mismatch`; (NB12) C4 verification narrowed — structural induction validates FORM closure only, operational estimate quality out of scope (assumption 3), cross-impl `c(agg)`/cost forms pinned by SHARED golden cost fixtures. |
 
 Design pre-review (before Draft v1): Option E architecture ACCEPTed by
 codex (gpt-5.5 xhigh — 4 hard constraints + terminology edits, all

--- a/formalization/rfc-0002-composite-knobs.md
+++ b/formalization/rfc-0002-composite-knobs.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Status** | **DRAFT v4** — under cross-model review; owner acceptance pending |
+| **Status** | **DRAFT v5** — under cross-model review; owner acceptance pending |
 | **Target language version** | TVL 1.2 (conservative extension of 1.1) |
 | **Tracking** | `FR-TVL-COMPOSITE-KNOBS-V1` · ChangeSession `cs_aef1b9d2edfa5200` |
 | **Builds on** | RFC 0001 (ACCEPTED): one-Knob model, cvars, certificates, policies, strict promotion |
@@ -246,6 +246,27 @@ SignalUse ::= ⟨ signal : Ident,       (* a NAMED signal reference into the SAM
    the execution comparisons (`margin < θ`, `σ ≥ θ`, `stat ≥ θ`) are over
    finite numbers; a non-finite resolved value fails the item's evaluation
    per the existing exception rules (never a silent comparison).
+11. **Signal/threshold calibration binding** (cross-model round 4): every
+   thresholded construct determines a signal id —
+
+   ```
+   sig(signal_below g)        = g.signal.signal        (explicit SignalUse)
+   sig(signal_accept stop)    = stop.signal.signal     (explicit SignalUse)
+   sig(margin_below g)        = vote_margin            (canonical stat id)
+   sig(stat_at_least a)       = a.stat                 (vote_margin │ vote_agreement)
+   ```
+
+   where the canonical vote-statistic ids live in the SAME registry
+   namespace as named signals. The threshold CVAR `θ` of every such
+   construct MUST declare `calibration.signal = sig(construct)`: a missing
+   `calibration.signal` on `θ` rejects (`missing_calibration_signal`); a
+   differing one rejects (`signal_mismatch`). Rationale: certificate
+   freshness binds `H_c(σ)` for the signal used DURING CALIBRATION — a
+   threshold calibrated against signal A gating signal B would be
+   **vacuously fresh**. This rule is static (both sides are declared
+   identifiers) and is distinct from `missing_composite_parent`: parent
+   coverage binds tuned-TVAR freshness; this rule binds the measured
+   signal semantics of the threshold itself.
 
 **Execution semantics.**
 
@@ -313,6 +334,10 @@ target-property shape — this is the machine-facing payoff of sealing:
 | `cascade` (pre) | each routing threshold `θ_i` | conditional property of the ROUTE the signal induces (e.g. `P(arm_i adequate │ σ_i ≥ θ_i) ≥ p`) |
 | `ensemble` | `accept.threshold`; `cardinality` when bound Calibrated | acceptance: `P(aggregate correct │ stat ≥ θ) ≥ p`; cardinality: cost-bounded sufficiency |
 | `loop` | `stop.threshold` (signal_accept) | stop adequacy: `P(accepted state meets target │ σ ≥ θ) ≥ p` |
+
+The §3.2 item-11 binding rule makes these target-property shapes
+well-posed: the certificate's `H_c(σ)` covers the very signal the gate
+evaluates at runtime, never a different one.
 
 The **claim scope** paragraph of RFC 0001 §3.5 (2026-06-06 clarification)
 applies verbatim: each certificate is a per-variable, procedural claim about
@@ -576,6 +601,7 @@ fixture in the validators packet):
 `stop_signal_outside_state` · `invalid_max_iters` ·
 `missing_composite_parent` · `invalid_tuned_param` ·
 `invalid_threshold_type` · `invalid_arm_shape` · `invalid_signal_use` ·
+`signal_mismatch` · `missing_calibration_signal` ·
 `duplicate_stage` (extended scope) — plus the RFC 0001 `missing_ref`
 family reused unchanged for every CVAR/threshold reference, and rejection
 **R9** (`invalid_cardinality_value`) extending the §3.4 acceptance algebra
@@ -715,6 +741,8 @@ increment (§2).
 | 2 | codex (gpt-5.5, xhigh, read-only) — 2026-06-06 | **REJECT** — 5 blocking (all on the NEW round-1 machinery); round-1 dispositions confirmed closed | All addressed in Draft v3: (1) R9 integrated into the acceptance algebra — explicit `Accept₁.₂ ⟺ ¬(R1∨…∨R9) ∧ calibrators ≠ ⊥` with P3/P4 carrying over and a conservativity note (R9 unreachable on 1.1 modules); (2) `tuned_params` entries now have a static TVAR-only resolution rule (`invalid_tuned_param`, well-formedness item 9) making C6 hold by construction; (3) `arm_params` map REPLACED by a single ArmSurface form declared ON the arm (bare Ident │ {stage, tuned_params?} │ {composite}) used identically for cascade arms, loop body, ensemble arms and judge — `invalid_arm_shape` for unknown keys; (4) `SignalSourceRef` (a source id) replaced by `SignalUse ⟨spec: SignalSpec, inputs⟩` preserving RFC 0001's source/signal split — the spec is the §3.5 closed signal shape hashed H_c(σ); stop inputs MUST ⊆ state_keys making `stop_signal_outside_state` precisely checkable; (5) numeric threshold type rule (`invalid_threshold_type`: thresholds are int/float CVARs; non-finite resolved values fail evaluation). |
 
 | 3 | codex (gpt-5.5, xhigh, read-only) — 2026-06-06 | **REJECT** — 3 findings (1 model choice + 2 wording residue); rounds 1–2 dispositions confirmed closed (incl. judge-arm coverage via ArmSurface and §3.11 completeness) | All addressed in Draft v4: (1) the signal model is CHOSEN explicitly — `SignalUse.signal` is a named Ident into the SAME registry namespace as RFC 0001's module-facing `calibration.signal` (one signal model across the language; the closed SignalSpec shape enters only through H_c(σ)); SignalSurface grammar added to §3.9 and `invalid_signal_use` to §3.11; (2) stale `arm_params` wording in §4 corrected to per-arm `tuned_params`; (3) §7 terminology fixed (signal ids + opaque input-feature ids; sources reserved for evidence pools). |
+
+| 4 | codex (gpt-5.5, xhigh, read-only) — 2026-06-06 | **REJECT** — 1 blocking (round-3 deltas confirmed closed): the signal/threshold calibration binding was not normative | Addressed in Draft v5: §3.2 item 11 — every thresholded construct determines a signal id (explicit `SignalUse.signal` for `signal_below`/`signal_accept`; canonical stat ids `vote_margin`/`vote_agreement` for `margin_below`/`stat_at_least`); `θ.calibration.signal` MUST equal it; static lints `signal_mismatch` + `missing_calibration_signal`; rationale recorded (a threshold calibrated against signal A gating signal B is vacuously fresh); §3.3 notes the rule makes the target-property shapes well-posed. |
 
 Design pre-review (before Draft v1): Option E architecture ACCEPTed by
 codex (gpt-5.5 xhigh — 4 hard constraints + terminology edits, all

--- a/formalization/rfc-0002-composite-knobs.md
+++ b/formalization/rfc-0002-composite-knobs.md
@@ -2,7 +2,7 @@
 
 | | |
 |---|---|
-| **Status** | **DRAFT v3** — under cross-model review; owner acceptance pending |
+| **Status** | **DRAFT v4** — under cross-model review; owner acceptance pending |
 | **Target language version** | TVL 1.2 (conservative extension of 1.1) |
 | **Tracking** | `FR-TVL-COMPOSITE-KNOBS-V1` · ChangeSession `cs_aef1b9d2edfa5200` |
 | **Builds on** | RFC 0001 (ACCEPTED): one-Knob model, cvars, certificates, policies, strict promotion |
@@ -169,19 +169,26 @@ StopDecl  ::= ⟨ kind : signal_accept | external_accept | exhausted,
                                                     OPAQUE runtime predicate id,
                                                     StageRef-style — outside P8 *)
 
-SignalUse ::= ⟨ spec : SignalSpec,    (* RFC 0001 §3.5's closed signal shape —
-                                         id, version, score function + version,
-                                         comparator + version — hashed H_c(σ)
-                                         exactly as calibration.signal is. NOT a
-                                         calibration SOURCE id: sources identify
-                                         evidence pools; specs identify the signal
-                                         FUNCTION (the RFC 0001 source/signal
-                                         split is preserved) *)
+SignalUse ::= ⟨ signal : Ident,       (* a NAMED signal reference into the SAME
+                                         signal namespace RFC 0001's module-facing
+                                         calibration.signal uses (an Ident,
+                                         operationally resolved by the runtime's
+                                         signal registry — NOT a module-namespace
+                                         declaration, and NOT a calibration SOURCE:
+                                         sources identify evidence pools; signals
+                                         identify the scoring FUNCTION. The full
+                                         closed SignalSpec shape enters the formal
+                                         model only through its canonical hash
+                                         H_c(σ), exactly as in RFC 0001 §3.5 —
+                                         one signal model across the language) *)
                 inputs : Ident* ⟩     (* the declared input keys the signal reads:
                                          for stops, MUST ⊆ the loop's state_keys
                                          (statically checked); for pre-gates,
                                          opaque input-feature identifiers
-                                         (environment.bindings precedent) *)
+                                         (environment.bindings precedent).
+                                         Malformed SignalUse objects (missing
+                                         signal, unknown keys, non-list inputs)
+                                         reject: invalid_signal_use *)
 ```
 
 **Well-formedness (statically checked; error codes in §3.11):**
@@ -504,6 +511,17 @@ Unknown keys in the object forms reject (`invalid_arm_shape`); absent
 `arm_params` map — parentage is declared ON the arm, so body/judge/nested
 arms are expressed identically.
 
+**The signal surface form** (everywhere a `SignalUse` appears —
+`signal_below` gates and `signal_accept` stops):
+
+```
+SignalSurface ::= { signal: Ident, inputs?: [Ident*] }   (* inputs default [] *)
+```
+
+`signal` names a registry signal exactly as `calibration.signal` does
+(operationally resolved; one signal model across the language); malformed
+objects reject (`invalid_signal_use`).
+
 ```yaml
 composites:
   - name: answerer
@@ -557,7 +575,7 @@ fixture in the validators packet):
 `missing_stop_threshold` · `missing_stop_predicate` ·
 `stop_signal_outside_state` · `invalid_max_iters` ·
 `missing_composite_parent` · `invalid_tuned_param` ·
-`invalid_threshold_type` · `invalid_arm_shape` ·
+`invalid_threshold_type` · `invalid_arm_shape` · `invalid_signal_use` ·
 `duplicate_stage` (extended scope) — plus the RFC 0001 `missing_ref`
 family reused unchanged for every CVAR/threshold reference, and rejection
 **R9** (`invalid_cardinality_value`) extending the §3.4 acceptance algebra
@@ -583,7 +601,7 @@ PolicyDecl⟨name, "policy", "cascade", stages = s₁..s_m,
 
 `stages` map to stage-tagged arms with empty `tuned_params` (the policy form
 never declared parentage — the obligation lint §3.5 is vacuous on migrated
-forms until authors declare `arm_params`, an explicit and intended
+forms until authors declare per-arm `tuned_params`, an explicit and intended
 ratchet); `parameters?` and `scope?` carry over verbatim with identical
 semantics and the identical outside-P8 categorization. StageRef opacity, the
 gate→CVAR rule, and execution semantics are unchanged (§3.2 incorporates
@@ -642,8 +660,9 @@ The claims above hold under, and only under:
 ## 7. Field categorization (P8 alignment)
 
 Composites introduce **no content-typed fields**: kinds, placements, arity,
-identifiers (names, StageRefs, predicate ids, state keys, signal-source
-ids), one required integer (`max_iters`), and namespace references.
+identifiers (names, StageRefs, predicate ids, state keys, signal ids from
+the `calibration.signal` namespace, opaque input-feature ids), one required
+integer (`max_iters`), and namespace references.
 `Provenance` is a CLOSED shape (identifiers + one canonical hash; raw
 pattern params never serialize — admission-contract canary). Telemetry
 (§3.10) is counts/rates/enums/finite numbers. The opaque escape hatches
@@ -694,6 +713,8 @@ increment (§2).
 | 1 | codex (gpt-5.5, xhigh, read-only) — 2026-06-06 | **REJECT** — 10 blocking, 5 non-blocking | All addressed in Draft v2: (1) arm resolution made tag-driven (`stage`/`composite` tags; bare = stage always; `ambiguous_arm` rejection); (2) pre-cascade made total (first-match-wins routing with fallback arm, per-gate signals + per-gate cost, absent-signal routes onward, `pre_gate_requires_signal`); (3) ensemble cardinality: required iff single-arm, int-typed, R9 rejection for k<1, both cost forms; (4) judge output contract (finite numeric score, exclusion rules, all-excluded fails, deterministic tie-break); (5) loop state formalized (`state_keys` + `stop_signal_outside_state`; pure ⟺ empty); (6) dependency compilation rebuilt as DECLARED parentage (`tuned_params` on stage arms) + static coverage obligations (`missing_composite_parent`), `missing_ref` stays single authority, judge/signal parents included; (7) root-consumption rule (all N_X roots, conservative fail-closed; selective consumption deferred); (8) subsumption made exact (scope?/parameters? carried onto Composite verbatim; empty tuned_params on migrated stages stated as intended ratchet); (9) Provenance closed shape (param_hash only, canary in admission contract); (10) C5 verification split by mechanism incl. condition 4. Non-blocking: full error-code surface §3.11; SignalSourceRef clarified as the RFC 0001 calibration-source registry (no new declaration surface); degenerate fixtures added to §9; AcceptDecl separated from GateDecl with opposite inequality; P6 note absorbed. |
 
 | 2 | codex (gpt-5.5, xhigh, read-only) — 2026-06-06 | **REJECT** — 5 blocking (all on the NEW round-1 machinery); round-1 dispositions confirmed closed | All addressed in Draft v3: (1) R9 integrated into the acceptance algebra — explicit `Accept₁.₂ ⟺ ¬(R1∨…∨R9) ∧ calibrators ≠ ⊥` with P3/P4 carrying over and a conservativity note (R9 unreachable on 1.1 modules); (2) `tuned_params` entries now have a static TVAR-only resolution rule (`invalid_tuned_param`, well-formedness item 9) making C6 hold by construction; (3) `arm_params` map REPLACED by a single ArmSurface form declared ON the arm (bare Ident │ {stage, tuned_params?} │ {composite}) used identically for cascade arms, loop body, ensemble arms and judge — `invalid_arm_shape` for unknown keys; (4) `SignalSourceRef` (a source id) replaced by `SignalUse ⟨spec: SignalSpec, inputs⟩` preserving RFC 0001's source/signal split — the spec is the §3.5 closed signal shape hashed H_c(σ); stop inputs MUST ⊆ state_keys making `stop_signal_outside_state` precisely checkable; (5) numeric threshold type rule (`invalid_threshold_type`: thresholds are int/float CVARs; non-finite resolved values fail evaluation). |
+
+| 3 | codex (gpt-5.5, xhigh, read-only) — 2026-06-06 | **REJECT** — 3 findings (1 model choice + 2 wording residue); rounds 1–2 dispositions confirmed closed (incl. judge-arm coverage via ArmSurface and §3.11 completeness) | All addressed in Draft v4: (1) the signal model is CHOSEN explicitly — `SignalUse.signal` is a named Ident into the SAME registry namespace as RFC 0001's module-facing `calibration.signal` (one signal model across the language; the closed SignalSpec shape enters only through H_c(σ)); SignalSurface grammar added to §3.9 and `invalid_signal_use` to §3.11; (2) stale `arm_params` wording in §4 corrected to per-arm `tuned_params`; (3) §7 terminology fixed (signal ids + opaque input-feature ids; sources reserved for evidence pools). |
 
 Design pre-review (before Draft v1): Option E architecture ACCEPTed by
 codex (gpt-5.5 xhigh — 4 hard constraints + terminology edits, all

--- a/python/tvl/lints.py
+++ b/python/tvl/lints.py
@@ -841,7 +841,11 @@ def _check_arms(decl: Dict[str, Any], kind: str, ctx: _CompositeCtx) -> None:
             return
         has_stage = "stage" in arm
         has_composite = "composite" in arm
-        unknown = set(arm) - {"stage", "tuned_params", "composite"}
+        # §3.9 ArmSurface: the stage form allows {stage, tuned_params?}; the
+        # nesting form allows {composite} ONLY — tuned_params on a
+        # composite-tagged arm is a closure bypass (codex P4 round 1).
+        allowed = {"stage", "tuned_params"} if has_stage and not has_composite else {"composite"}
+        unknown = set(arm) - allowed
         if unknown or (has_stage and has_composite) or not (has_stage or has_composite):
             ctx.add(
                 "invalid_arm_shape",
@@ -1147,7 +1151,23 @@ def _check_signal_use(
             path,
         )
         return (False, signal_name if isinstance(signal_name, str) else None, ())
-    inputs_list = [i for i in inputs if isinstance(i, str)]
+    # §3.9 SignalSurface: inputs is Ident* — a non-string or non-Ident
+    # element REJECTS (silent filtering would also suppress
+    # unbound_signal_inputs by emptying the effective list — codex P4
+    # round 1).
+    bad_inputs = [
+        i for i in inputs
+        if not isinstance(i, str) or not _NORMATIVE_IDENT_RE.match(i)
+    ]
+    if bad_inputs:
+        ctx.add(
+            "invalid_signal_use",
+            f"composite '{ctx.name}' signal use has non-Ident 'inputs' "
+            f"elements (inputs is Ident*)",
+            path + ["inputs"],
+        )
+        return (False, signal_name, ())
+    inputs_list = list(inputs)
     if in_state is not None:
         outside = [i for i in inputs_list if i not in in_state]
         if outside:

--- a/python/tvl/lints.py
+++ b/python/tvl/lints.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
 from .structural_parser import Literal, StructuralParseError, clause_to_string, parse_expression
@@ -39,7 +39,14 @@ _IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_.-]*$")
 # empty segments, no leading/trailing dots, no hyphens. Enforced on the NEW
 # surfaces (cvars/policies/scope) as errors; legacy tvar names are untouched.
 _NORMATIVE_IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$")
-_CTX_EXT_KEYS = {"stage_versions", "model_versions", "budget_assumptions", "cost_assumptions"}
+_CTX_EXT_KEYS = {
+    "stage_versions",
+    "model_versions",
+    "budget_assumptions",
+    "cost_assumptions",
+    # TVL 1.2 (RFC 0002 §3.2 item 11): use-site SignalUse.inputs freshness.
+    "signal_inputs",
+}
 _CVAR_TYPE_RE = re.compile(r"^(bool|int|float|enum\[(str|int|float)\])$")
 _IDENTIFIER_TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_.-]*")
 _NON_LINEAR_TOKENS_STRUCTURAL = {"*", "/", "^"}
@@ -60,6 +67,7 @@ def lint_module(doc: Dict[str, Any], precision: int = 1000) -> List[Issue]:
     _lint_duplicate_tvars(doc, issues)
     _lint_cvars(doc, issues)
     _lint_policies(doc, issues)
+    _lint_composites(doc, issues)
     _lint_namespace(doc, issues)
     _lint_environment(doc, issues)
     context = _build_type_context(doc)
@@ -414,6 +422,1010 @@ def _lint_policies(doc: Dict[str, Any], issues: List[Issue]) -> None:
                         }
                     )
         _check_scope(decl, ["policies", idx], name, issues)
+
+
+# ---------------------------------------------------------------------------
+# TVL 1.2 (RFC 0002) — the sealed composite-knob algebra.
+#
+# Sealed registries (§3.2). A fourth member is a NEW RFC, not a registry entry.
+# ---------------------------------------------------------------------------
+_COMPOSITE_KINDS = {"cascade", "ensemble", "loop"}
+_GATE_KINDS = {"margin_below", "signal_below"}
+_AGGREGATE_KINDS = {"majority_vote", "judge_max"}
+_ACCEPT_STATS = {"vote_margin", "vote_agreement"}
+_STOP_KINDS = {"signal_accept", "external_accept", "exhausted"}
+_NUMERIC_CVAR_TYPES = {"int", "float"}
+
+# The canonical vote-statistic ids that live in the SAME registry namespace as
+# named signals (§3.2 item 11): sig(margin_below) = "vote_margin".
+_CANONICAL_VOTE_MARGIN = "vote_margin"
+
+# Exactly the body fields admissible per kind (§3.2 item 1: closed shapes).
+# 'name'/'kind' and the universal optional keys are allowed for every kind.
+_COMPOSITE_COMMON_FIELDS = {"name", "kind", "pattern", "parameters", "scope"}
+_COMPOSITE_KIND_FIELDS = {
+    "cascade": {"placement", "arms", "gates"},
+    "ensemble": {"arms", "cardinality", "aggregate"},
+    "loop": {"body", "state_keys", "stop", "max_iters"},
+}
+
+
+def _is_arm_object(arm: Any, key: str) -> bool:
+    return isinstance(arm, dict) and key in arm
+
+
+def _lint_composites(doc: Dict[str, Any], issues: List[Issue]) -> None:
+    """RFC 0002 §3 — the composite-knob algebra (cascade | ensemble | loop).
+
+    Implements the §3.11 1:1 code↔rule table. Every rejection here fires at the
+    composite USE SITE only — a 1.1 module declares no composites, so none of
+    these lints can fire on it (P1 preserved, §4). The reused RFC 0001 codes
+    (``cascade_arity``, ``unknown_gate_kind``, ``missing_ref``) carry identical
+    semantics onto the composite construct.
+    """
+    composites = doc.get("composites")
+    if composites is None:
+        return
+    if not isinstance(composites, list):
+        issues.append(
+            {
+                "code": "invalid_composites",
+                "message": "composites must be a list of declarations",
+                "path": ["composites"],
+                "severity": "error",
+            }
+        )
+        return
+
+    # Declared identifiers from the other namespace classes (§3.1: composites
+    # join the SAME scoped namespace). Types are tracked for the threshold /
+    # cardinality kind-and-type checks (items 6, 7, 10).
+    tvar_types: Dict[str, str] = {}
+    for d in (doc.get("tvars") or []):
+        if isinstance(d, dict) and isinstance(d.get("name"), str):
+            kind = _normalize_kind(d.get("type")) if isinstance(d.get("type"), str) else None
+            tvar_types[d["name"]] = kind if kind is not None else ""
+    tvar_names = set(tvar_types)
+    cvar_decls: Dict[str, Dict[str, Any]] = {
+        d["name"]: d
+        for d in (doc.get("cvars") or [])
+        if isinstance(d, dict) and isinstance(d.get("name"), str)
+    }
+    cvar_names = set(cvar_decls)
+    other_class_names = set(tvar_names) | cvar_names | {
+        d.get("name")
+        for d in (doc.get("policies") or [])
+        if isinstance(d, dict) and isinstance(d.get("name"), str)
+    }
+
+    # Pass 1: the N_X membership + duplicate/shadow discipline (§3.1).
+    composite_names: Set[str] = set()
+    seen: Set[str] = set()
+    for idx, decl in enumerate(composites):
+        if not isinstance(decl, dict):
+            issues.append(
+                {
+                    "code": "invalid_composite_decl",
+                    "message": "composite declarations must be objects",
+                    "path": ["composites", idx],
+                    "severity": "error",
+                }
+            )
+            continue
+        name = decl.get("name")
+        if not isinstance(name, str) or not _NORMATIVE_IDENT_RE.match(name):
+            issues.append(
+                {
+                    "code": "invalid_composite_name",
+                    "message": "composite declarations require a valid identifier name",
+                    "path": ["composites", idx, "name"],
+                    "severity": "error",
+                }
+            )
+            continue
+        if name in seen:
+            issues.append(
+                {
+                    "code": "duplicate_composite",
+                    "message": f"composite '{name}' is declared multiple times",
+                    "path": ["composites", idx, "name"],
+                    "severity": "error",
+                }
+            )
+        seen.add(name)
+        if name in other_class_names:
+            issues.append(
+                {
+                    "code": "composite_shadows_name",
+                    "message": (
+                        f"composite '{name}' shadows a name already declared as a "
+                        "tvar/cvar/policy — tvars, cvars, policies, and composites "
+                        "share one namespace (N_X)"
+                    ),
+                    "path": ["composites", idx, "name"],
+                    "severity": "error",
+                }
+            )
+        composite_names.add(name)
+
+    composites_by_name: Dict[str, Dict[str, Any]] = {
+        d["name"]: d
+        for d in composites
+        if isinstance(d, dict) and isinstance(d.get("name"), str)
+    }
+
+    # The N_X reference DAG over composite(·) arms, for acyclicity (item 4) and
+    # the leafT/Cal recursive folds (§3.5 / §3.6). Built once over all decls.
+    child_refs = _composite_child_refs(composites, composite_names)
+    cyclic_nodes = _composite_cyclic_nodes(child_refs)
+
+    # Module-level freshness coverage for the §3.2 item-11 signal_inputs rule.
+    ctx_keys, covered_signal_inputs = _doc_calibration_coverage(doc)
+
+    # Pass 2: per-composite well-formedness.
+    for idx, decl in enumerate(composites):
+        if not isinstance(decl, dict) or not isinstance(decl.get("name"), str):
+            continue
+        _lint_one_composite(
+            decl,
+            idx,
+            issues,
+            composite_names=composite_names,
+            composites_by_name=composites_by_name,
+            tvar_names=tvar_names,
+            tvar_types=tvar_types,
+            cvar_decls=cvar_decls,
+            cyclic_nodes=cyclic_nodes,
+            ctx_keys=ctx_keys,
+            covered_signal_inputs=covered_signal_inputs,
+        )
+
+
+def _doc_calibration_coverage(doc: Dict[str, Any]) -> Tuple[Set[str], Optional[List[Any]]]:
+    """The module's freshness-context coverage (RFC 0001 §3.5 / RFC 0002 §3.2
+    item 11). Returns (a) the set of hash_covered_context EXTENSION keys and
+    (b) the ordered value covered under 'signal_inputs'
+    (``require_calibration.signal_inputs``). The item-11 ``unbound_signal_inputs``
+    check is static — both the use-site inputs list and this covered value are
+    declared identifier lists."""
+    policy = doc.get("promotion_policy")
+    if not isinstance(policy, dict):
+        return set(), None
+    spec = policy.get("require_calibration")
+    if not isinstance(spec, dict):
+        return set(), None
+    keys = spec.get("hash_covered_context")
+    if not isinstance(keys, list):
+        return set(), None
+    ctx_keys = {k for k in keys if isinstance(k, str)}
+    covered = spec.get("signal_inputs") if "signal_inputs" in spec else None
+    return ctx_keys, covered if isinstance(covered, list) else None
+
+
+def _composite_child_refs(
+    composites: List[Any], composite_names: Set[str]
+) -> Dict[str, Set[str]]:
+    """The N_X reference graph: composite name → set of composite names it
+    references via tagged ``composite(x)`` arms (in arms / body / judge)."""
+    refs: Dict[str, Set[str]] = {}
+    for decl in composites:
+        if not isinstance(decl, dict) or not isinstance(decl.get("name"), str):
+            continue
+        name = decl["name"]
+        out: Set[str] = refs.setdefault(name, set())
+        for arm in _all_arms_of(decl):
+            if isinstance(arm, dict) and isinstance(arm.get("composite"), str):
+                ref = arm["composite"]
+                if ref in composite_names:
+                    out.add(ref)
+    return refs
+
+
+def _all_arms_of(decl: Dict[str, Any]) -> List[Any]:
+    """Every arm surface a composite carries: cascade/ensemble arms, the loop
+    body, and the ensemble judge — the positions an ``Arm`` may appear (§3.9)."""
+    arms: List[Any] = []
+    raw_arms = decl.get("arms")
+    if isinstance(raw_arms, list):
+        arms.extend(raw_arms)
+    body = decl.get("body")
+    if body is not None:
+        arms.append(body)
+    aggregate = decl.get("aggregate")
+    if isinstance(aggregate, dict):
+        judge = aggregate.get("judge")
+        if judge is not None:
+            arms.append(judge)
+    return arms
+
+
+def _composite_cyclic_nodes(child_refs: Dict[str, Set[str]]) -> Set[str]:
+    """Names that participate in any cycle of the N_X reference graph (item 4).
+
+    Returns every node on a cycle OR reaching one, so the ``composite_cycle``
+    diagnostic fires on each declaration whose expansion would not terminate.
+    """
+    WHITE, GREY, BLACK = 0, 1, 2
+    color: Dict[str, int] = {n: WHITE for n in child_refs}
+    on_cycle: Set[str] = set()
+
+    def visit(node: str, stack: List[str]) -> bool:
+        color[node] = GREY
+        stack.append(node)
+        hit = False
+        for nxt in child_refs.get(node, set()):
+            if color.get(nxt, WHITE) == GREY:
+                # Back-edge: every node from nxt's stack position onward is on a cycle.
+                start = stack.index(nxt)
+                on_cycle.update(stack[start:])
+                hit = True
+            elif color.get(nxt, WHITE) == WHITE:
+                if visit(nxt, stack):
+                    on_cycle.add(node)
+                    hit = True
+            elif nxt in on_cycle:
+                on_cycle.add(node)
+                hit = True
+        stack.pop()
+        color[node] = BLACK
+        return hit
+
+    for n in list(child_refs):
+        if color.get(n, WHITE) == WHITE:
+            visit(n, [])
+    return on_cycle
+
+
+def _lint_one_composite(
+    decl: Dict[str, Any],
+    idx: int,
+    issues: List[Issue],
+    *,
+    composite_names: Set[str],
+    composites_by_name: Dict[str, Dict[str, Any]],
+    tvar_names: Set[str],
+    tvar_types: Dict[str, str],
+    cvar_decls: Dict[str, Dict[str, Any]],
+    cyclic_nodes: Set[str],
+    ctx_keys: Set[str],
+    covered_signal_inputs: Optional[List[Any]],
+) -> None:
+    name = decl["name"]
+    base = ["composites", idx]
+
+    # §3.1 — a composite never binds a value. These value-binding keys carry the
+    # PRECISE composite_binds_value diagnostic (not the generic unknown field one).
+    value_keys = [k for k in ("value", "default", "binding") if k in decl]
+    for offending in value_keys:
+        issues.append(
+            {
+                "code": "composite_binds_value",
+                "message": (
+                    f"composite '{name}' binds a value ('{offending}') — a composite "
+                    "is a namespace/expansion unit, never a binding kind (§3.1)"
+                ),
+                "path": base + [offending],
+                "severity": "error",
+            }
+        )
+
+    # Item 1 — kind registry.
+    kind = decl.get("kind")
+    if kind not in _COMPOSITE_KINDS:
+        issues.append(
+            {
+                "code": "unknown_composite_kind",
+                "message": (
+                    f"composite '{name}' kind '{kind}' is not in the sealed v1 "
+                    "registry (cascade | ensemble | loop)"
+                ),
+                "path": base + ["kind"],
+                "severity": "error",
+            }
+        )
+        # Without a known kind the body fields cannot be checked further.
+        return
+
+    # Item 1 — closed shapes: exactly the body fields of the declared kind.
+    # Value-binding keys are excluded here (carried by composite_binds_value).
+    allowed = _COMPOSITE_COMMON_FIELDS | _COMPOSITE_KIND_FIELDS[kind] | set(value_keys)
+    for field_name in decl:
+        if field_name not in allowed:
+            issues.append(
+                {
+                    "code": "unknown_composite_field",
+                    "message": (
+                        f"composite '{name}' (kind '{kind}') has field '{field_name}' "
+                        "which is unknown or belongs to another constructor (closed shapes)"
+                    ),
+                    "path": base + [field_name],
+                    "severity": "error",
+                }
+            )
+
+    # Item 4 — acyclic N_X reference graph.
+    if name in cyclic_nodes:
+        issues.append(
+            {
+                "code": "composite_cycle",
+                "message": (
+                    f"composite '{name}' participates in a cycle of the composite "
+                    "reference graph; nesting must be acyclic so expansion terminates (§3.2 item 4)"
+                ),
+                "path": base + ["name"],
+                "severity": "error",
+            }
+        )
+
+    ctx = _CompositeCtx(
+        name=name,
+        base=base,
+        issues=issues,
+        composite_names=composite_names,
+        composites_by_name=composites_by_name,
+        tvar_names=tvar_names,
+        tvar_types=tvar_types,
+        cvar_decls=cvar_decls,
+        ctx_keys=ctx_keys,
+        covered_signal_inputs=covered_signal_inputs,
+    )
+
+    # Items 3, 6, 9 — arm resolution + stage-duplicate + tuned_params, over
+    # EVERY arm position (arms / body / judge). Shared so duplicate_stage spans
+    # the whole composite (extended scope, §3.11).
+    _check_arms(decl, kind, ctx)
+
+    if kind == "cascade":
+        _check_cascade(decl, ctx)
+    elif kind == "ensemble":
+        _check_ensemble(decl, ctx)
+    elif kind == "loop":
+        _check_loop(decl, ctx)
+
+    # §3.5 — required_parents(θ) ⊆ depends_on(θ) for every threshold CVAR
+    # (missing_composite_parent). Skip cyclic composites: leafT would not
+    # terminate and the cycle is already reported.
+    if name not in cyclic_nodes:
+        _check_composite_parents(decl, kind, ctx)
+
+
+@dataclass
+class _CompositeCtx:
+    name: str
+    base: List[Any]
+    issues: List[Issue]
+    composite_names: Set[str]
+    composites_by_name: Dict[str, Dict[str, Any]]
+    tvar_names: Set[str]
+    tvar_types: Dict[str, str]
+    cvar_decls: Dict[str, Dict[str, Any]]
+    # Module-level freshness-context coverage (§3.2 item 11 / RFC 0001 §3.5):
+    # the promotion_policy.require_calibration.hash_covered_context keys and the
+    # value covered under 'signal_inputs', resolved once for the whole module.
+    ctx_keys: Set[str] = field(default_factory=set)
+    covered_signal_inputs: Optional[List[Any]] = None
+
+    def add(self, code: str, message: str, path: List[Any], severity: str = "error") -> None:
+        self.issues.append(
+            {"code": code, "message": message, "path": path, "severity": severity}
+        )
+
+
+def _check_arms(decl: Dict[str, Any], kind: str, ctx: _CompositeCtx) -> None:
+    """Items 3/6/9 — arm shape, resolution, stage duplicates, tuned_params,
+    over every arm position in the composite (§3.9 one-shape rule)."""
+    stage_paths: Dict[str, List[Any]] = {}
+
+    def visit_arm(arm: Any, path: List[Any]) -> None:
+        if isinstance(arm, str):
+            # Bare identifier is ALWAYS a stage (§3.2 item 3). A bare id that
+            # collides with a composite name is ambiguous_arm (not silent resolve).
+            if arm in ctx.composite_names:
+                ctx.add(
+                    "ambiguous_arm",
+                    f"composite '{ctx.name}' bare arm '{arm}' collides with a declared "
+                    "composite name; use the tagged {{composite: ...}} form to nest, or "
+                    "rename the stage",
+                    path,
+                )
+            else:
+                _record_stage(arm, path, stage_paths, ctx)
+            return
+        if not isinstance(arm, dict):
+            ctx.add(
+                "invalid_arm_shape",
+                f"composite '{ctx.name}' arm must be a bare stage identifier, "
+                "{{stage, tuned_params?}}, or {{composite}}",
+                path,
+            )
+            return
+        has_stage = "stage" in arm
+        has_composite = "composite" in arm
+        unknown = set(arm) - {"stage", "tuned_params", "composite"}
+        if unknown or (has_stage and has_composite) or not (has_stage or has_composite):
+            ctx.add(
+                "invalid_arm_shape",
+                f"composite '{ctx.name}' arm has an unknown or ambiguous shape; expected "
+                "exactly one of a stage form {{stage, tuned_params?}} or a nesting form "
+                "{{composite}}",
+                path,
+            )
+            return
+        if has_stage:
+            stage_id = arm.get("stage")
+            if isinstance(stage_id, str):
+                _record_stage(stage_id, path + ["stage"], stage_paths, ctx)
+            tuned = arm.get("tuned_params")
+            if tuned is None:
+                tuned = []
+            if isinstance(tuned, list):
+                for tp_idx, tp in enumerate(tuned):
+                    if tp not in ctx.tvar_names:
+                        ctx.add(
+                            "invalid_tuned_param",
+                            f"composite '{ctx.name}' tuned_params entry '{tp}' does not "
+                            "resolve to a declared TVAR (exact match; cvars/policies/"
+                            "composites are not tuned parents)",
+                            path + ["tuned_params", tp_idx],
+                        )
+        else:  # has_composite
+            ref = arm.get("composite")
+            if not isinstance(ref, str) or ref not in ctx.composite_names:
+                ctx.add(
+                    "missing_composite_ref",
+                    f"composite '{ctx.name}' nests composite('{ref}') which does not "
+                    "resolve to any declared composite (exact match into N_X)",
+                    path + ["composite"],
+                )
+
+    # cascade/ensemble arms
+    raw_arms = decl.get("arms")
+    if isinstance(raw_arms, list):
+        for a_idx, arm in enumerate(raw_arms):
+            visit_arm(arm, ctx.base + ["arms", a_idx])
+    # loop body
+    if kind == "loop" and decl.get("body") is not None:
+        visit_arm(decl.get("body"), ctx.base + ["body"])
+    # ensemble judge
+    aggregate = decl.get("aggregate")
+    if isinstance(aggregate, dict) and aggregate.get("judge") is not None:
+        visit_arm(aggregate.get("judge"), ctx.base + ["aggregate", "judge"])
+
+
+def _record_stage(
+    stage_id: str, path: List[Any], stage_paths: Dict[str, List[Any]], ctx: _CompositeCtx
+) -> None:
+    if stage_id in stage_paths:
+        ctx.add(
+            "duplicate_stage",
+            f"composite '{ctx.name}' declares duplicate stage '{stage_id}'",
+            path,
+        )
+    else:
+        stage_paths[stage_id] = path
+
+
+def _threshold_cvar_checks(
+    threshold: Any,
+    path: List[Any],
+    ctx: _CompositeCtx,
+    *,
+    sig_expected: Optional[str],
+    sig_inputs: Sequence[str],
+) -> None:
+    """Items 6, 10, 11 — a gate/accept/stop threshold reference.
+
+    - resolves to a declared CVAR (item 6, reused ``missing_ref``);
+    - that CVAR is int/float-typed (item 10, ``invalid_threshold_type``);
+    - the composite-use-site signal binding (item 11): the CVAR's
+      ``calibration.signal`` MUST equal ``sig_expected``
+      (``missing_calibration_signal`` / ``signal_mismatch``); when the governing
+      ``SignalUse.inputs`` is non-empty the CVAR's promotion-policy
+      ``hash_covered_context`` MUST include ``signal_inputs`` and its covered
+      value MUST equal the use-site list (``unbound_signal_inputs``).
+    """
+    if not isinstance(threshold, str) or threshold not in ctx.cvar_decls:
+        ctx.add(
+            "missing_ref",
+            f"composite '{ctx.name}' threshold '{threshold}' must resolve to a declared "
+            "CVAR (kind-checked namespace ref)",
+            path,
+        )
+        return
+    cvar = ctx.cvar_decls[threshold]
+    cvar_type = cvar.get("type")
+    if cvar_type not in _NUMERIC_CVAR_TYPES:
+        ctx.add(
+            "invalid_threshold_type",
+            f"composite '{ctx.name}' threshold CVAR '{threshold}' has type "
+            f"'{cvar_type}'; gate/accept/stop thresholds must be int or float (§3.2 item 10)",
+            path,
+        )
+
+    # Item 11 — signal/threshold calibration binding (composite use site only).
+    if sig_expected is not None:
+        calibration = cvar.get("calibration")
+        declared_signal = (
+            calibration.get("signal") if isinstance(calibration, dict) else None
+        )
+        if declared_signal is None:
+            ctx.add(
+                "missing_calibration_signal",
+                f"composite '{ctx.name}' uses CVAR '{threshold}' as a threshold but it "
+                f"declares no calibration.signal; the composite obliges it to declare "
+                f"calibration.signal = '{sig_expected}' (§3.2 item 11)",
+                path,
+            )
+        elif declared_signal != sig_expected:
+            ctx.add(
+                "signal_mismatch",
+                f"composite '{ctx.name}' threshold CVAR '{threshold}' is calibrated "
+                f"against signal '{declared_signal}' but the construct measures "
+                f"'{sig_expected}'; a threshold calibrated against one signal gating "
+                "another is vacuously fresh (§3.2 item 11)",
+                path,
+            )
+
+        # Item 11 (cont.) — use-site signal-inputs freshness coverage.
+        if sig_inputs:
+            covered = ctx.covered_signal_inputs
+            covered_list = covered if isinstance(covered, list) else []
+            if "signal_inputs" not in ctx.ctx_keys or list(covered_list) != list(sig_inputs):
+                ctx.add(
+                    "unbound_signal_inputs",
+                    f"composite '{ctx.name}' threshold CVAR '{threshold}' has a governing "
+                    f"SignalUse.inputs {list(sig_inputs)} that is not freshness-bound: its "
+                    "promotion_policy.require_calibration.hash_covered_context must include "
+                    "'signal_inputs' AND the covered value must equal the use-site input "
+                    "list (§3.2 item 11)",
+                    path,
+                )
+
+
+def _check_cascade(decl: Dict[str, Any], ctx: _CompositeCtx) -> None:
+    arms = decl.get("arms")
+    arms_list = arms if isinstance(arms, list) else []
+    if not arms_list:
+        ctx.add("empty_arms", f"composite '{ctx.name}' cascade has no arms", ctx.base + ["arms"])
+    gates = decl.get("gates") or []
+    gates_list = gates if isinstance(gates, list) else []
+
+    # Item 2 — cascade arity |gates| = |arms| − 1 (reused code).
+    if arms_list and len(gates_list) != max(len(arms_list) - 1, 0):
+        ctx.add(
+            "cascade_arity",
+            f"composite '{ctx.name}' declares {len(gates_list)} gate(s) for "
+            f"{len(arms_list)} arm(s); |gates| must equal |arms| - 1",
+            ctx.base + ["gates"],
+        )
+
+    placement = decl.get("placement", "post")  # DEFAULT post
+    for g_idx, gate in enumerate(gates_list):
+        if not isinstance(gate, dict):
+            continue
+        gpath = ctx.base + ["gates", g_idx]
+        _check_gate(gate, g_idx, gpath, placement, arms_list, ctx)
+
+
+def _arm_is_margin_bearing(arm: Any, composites_by_name: Dict[str, Dict[str, Any]]) -> bool:
+    """§3.2 item 5: the gated arm must be margin-bearing — either a stage arm
+    (RFC 0001 vote semantics) or an ensemble arm whose aggregate.kind =
+    majority_vote (committee vote statistics). A loop arm, a judge_max ensemble,
+    or any nested cascade (pre OR post) is NOT margin-bearing."""
+    if isinstance(arm, str):
+        return True  # bare = stage
+    if not isinstance(arm, dict):
+        return False
+    if "stage" in arm:
+        return True
+    if "composite" in arm:
+        ref = arm.get("composite")
+        target = composites_by_name.get(ref) if isinstance(ref, str) else None
+        if not isinstance(target, dict):
+            return False  # unresolved — missing_composite_ref already fired
+        if target.get("kind") != "ensemble":
+            return False
+        aggregate = target.get("aggregate")
+        return (
+            isinstance(aggregate, dict)
+            and aggregate.get("kind") == "majority_vote"
+        )
+    return False
+
+
+def _check_gate(
+    gate: Dict[str, Any],
+    g_idx: int,
+    gpath: List[Any],
+    placement: Any,
+    arms_list: List[Any],
+    ctx: _CompositeCtx,
+) -> None:
+    """Items 5, 6, 10, 11 — a composite cascade gate."""
+    gkind = gate.get("kind")
+    if gkind not in _GATE_KINDS:
+        ctx.add(
+            "unknown_gate_kind",
+            f"composite '{ctx.name}' gate kind '{gkind}' is not in the v1 registry "
+            "(margin_below | signal_below)",
+            gpath + ["kind"],
+        )
+        # Unknown kind: still kind-check the threshold ref below, but skip the
+        # placement/typing rules that are keyed on the (now unknown) kind.
+
+    signal_use = gate.get("signal")
+    sig_inputs: Sequence[str] = ()
+    sig_expected: Optional[str] = None
+
+    if gkind == "margin_below":
+        # margin_below is POST-only and gates a margin-bearing arm.
+        if placement == "pre":
+            ctx.add(
+                "gate_kind_placement_mismatch",
+                f"composite '{ctx.name}' uses a margin_below gate under placement 'pre'; "
+                "margin_below is POST-only (§3.2 item 5)",
+                gpath + ["kind"],
+            )
+        else:
+            # The gated arm of g_i (1-indexed gate i) is arm i, i.e. arms_list[g_idx].
+            gated = arms_list[g_idx] if g_idx < len(arms_list) else None
+            if gated is not None and not _arm_is_margin_bearing(gated, ctx.composites_by_name):
+                ctx.add(
+                    "gate_arm_incompatible",
+                    f"composite '{ctx.name}' margin_below gate {g_idx} reads vote statistics "
+                    "from a non-margin-bearing arm; the gated arm must be a stage or a "
+                    "majority_vote ensemble (§3.2 item 5)",
+                    gpath,
+                )
+        sig_expected = _CANONICAL_VOTE_MARGIN  # sig(margin_below) = vote_margin
+    elif gkind == "signal_below":
+        # signal_below is PRE-only and requires a declared signal.
+        if placement != "pre":
+            ctx.add(
+                "gate_kind_placement_mismatch",
+                f"composite '{ctx.name}' uses a signal_below gate under placement 'post'; "
+                "signal_below is PRE-only (§3.2 item 5)",
+                gpath + ["kind"],
+            )
+        ok, sig_name, sig_inputs = _check_signal_use(
+            signal_use, gpath + ["signal"], ctx, required=True, in_state=None
+        )
+        if not ok and signal_use is None:
+            ctx.add(
+                "missing_gate_signal",
+                f"composite '{ctx.name}' signal_below gate {g_idx} is missing its required "
+                "signal field (§3.2 item 5)",
+                gpath,
+            )
+        sig_expected = sig_name  # sig(signal_below g) = g.signal.signal
+
+    _threshold_cvar_checks(
+        gate.get("threshold"),
+        gpath + ["threshold"],
+        ctx,
+        sig_expected=sig_expected,
+        sig_inputs=sig_inputs,
+    )
+
+
+def _check_signal_use(
+    signal_use: Any,
+    path: List[Any],
+    ctx: _CompositeCtx,
+    *,
+    required: bool,
+    in_state: Optional[Set[str]],
+) -> Tuple[bool, Optional[str], Sequence[str]]:
+    """§3.2/§3.9 SignalUse. Returns (well_formed, signal_name, inputs).
+
+    A malformed SignalUse object (missing signal, unknown keys, non-list inputs)
+    rejects ``invalid_signal_use``. When ``in_state`` is provided (loop stop),
+    ``inputs ⊄ state_keys`` rejects ``stop_signal_outside_state`` (item 8).
+    """
+    if signal_use is None:
+        return (False, None, ())
+    if not isinstance(signal_use, dict):
+        ctx.add(
+            "invalid_signal_use",
+            f"composite '{ctx.name}' signal use must be an object {{signal, inputs?}}",
+            path,
+        )
+        return (False, None, ())
+    unknown = set(signal_use) - {"signal", "inputs"}
+    signal_name = signal_use.get("signal")
+    inputs = signal_use.get("inputs", [])
+    malformed = (
+        unknown
+        or not isinstance(signal_name, str)
+        or not isinstance(inputs, list)
+    )
+    if malformed:
+        ctx.add(
+            "invalid_signal_use",
+            f"composite '{ctx.name}' signal use is malformed (missing 'signal', unknown "
+            "keys, or non-list 'inputs')",
+            path,
+        )
+        return (False, signal_name if isinstance(signal_name, str) else None, ())
+    inputs_list = [i for i in inputs if isinstance(i, str)]
+    if in_state is not None:
+        outside = [i for i in inputs_list if i not in in_state]
+        if outside:
+            ctx.add(
+                "stop_signal_outside_state",
+                f"composite '{ctx.name}' stop signal reads input keys {outside} that are "
+                "not declared in the loop's state_keys (§3.2 item 8)",
+                path + ["inputs"],
+            )
+    return (True, signal_name, tuple(inputs_list))
+
+
+def _check_ensemble(decl: Dict[str, Any], ctx: _CompositeCtx) -> None:
+    arms = decl.get("arms")
+    arms_list = arms if isinstance(arms, list) else []
+    if not arms_list:
+        ctx.add("empty_arms", f"composite '{ctx.name}' ensemble has no arms", ctx.base + ["arms"])
+
+    cardinality = decl.get("cardinality")
+    # Item 7 — cardinality present iff |arms| = 1.
+    if len(arms_list) == 1 and cardinality is None:
+        ctx.add(
+            "cardinality_arity_mismatch",
+            f"composite '{ctx.name}' sampling-form ensemble (|arms| = 1) requires a "
+            "cardinality reference (§3.2 item 7)",
+            ctx.base + ["arms"],
+        )
+    elif len(arms_list) > 1 and cardinality is not None:
+        ctx.add(
+            "cardinality_arity_mismatch",
+            f"composite '{ctx.name}' committee-form ensemble (|arms| > 1) must NOT declare "
+            "a cardinality (§3.2 item 7)",
+            ctx.base + ["cardinality"],
+        )
+    if cardinality is not None:
+        # Cardinality must reference a TVAR or CVAR of TVL type int.
+        card_type = _ref_type(cardinality, ctx)
+        if card_type is None:
+            ctx.add(
+                "missing_ref",
+                f"composite '{ctx.name}' cardinality '{cardinality}' must resolve to a "
+                "declared TVAR or CVAR (kind-checked namespace ref)",
+                ctx.base + ["cardinality"],
+            )
+        elif card_type != "int":
+            ctx.add(
+                "invalid_cardinality_type",
+                f"composite '{ctx.name}' cardinality '{cardinality}' has TVL type "
+                f"'{card_type}'; the sample count must be int-typed (§3.2 item 7)",
+                ctx.base + ["cardinality"],
+            )
+
+    aggregate = decl.get("aggregate")
+    if not isinstance(aggregate, dict):
+        return
+    apath = ctx.base + ["aggregate"]
+    akind = aggregate.get("kind")
+    if akind not in _AGGREGATE_KINDS:
+        ctx.add(
+            "unknown_aggregate_kind",
+            f"composite '{ctx.name}' aggregate kind '{akind}' is not in the v1 registry "
+            "(majority_vote | judge_max)",
+            apath + ["kind"],
+        )
+    if akind == "judge_max" and aggregate.get("judge") is None:
+        ctx.add(
+            "missing_judge",
+            f"composite '{ctx.name}' judge_max aggregate is missing its required judge arm "
+            "(§3.2)",
+            apath,
+        )
+
+    accept = aggregate.get("accept")
+    if isinstance(accept, dict):
+        cpath = apath + ["accept"]
+        stat = accept.get("stat")
+        if stat not in _ACCEPT_STATS:
+            ctx.add(
+                "unknown_aggregate_kind",
+                f"composite '{ctx.name}' accept stat '{stat}' is not in the v1 registry "
+                "(vote_margin | vote_agreement)",
+                cpath + ["stat"],
+            )
+        # sig(stat_at_least a) = a.stat (canonical vote-statistic id).
+        sig_expected = stat if stat in _ACCEPT_STATS else None
+        _threshold_cvar_checks(
+            accept.get("threshold"),
+            cpath + ["threshold"],
+            ctx,
+            sig_expected=sig_expected,
+            sig_inputs=(),  # accept carries no SignalUse; no use-site inputs
+        )
+
+
+def _check_loop(decl: Dict[str, Any], ctx: _CompositeCtx) -> None:
+    # Item 8 — max_iters ≥ 1 (totality). The schema pins it to an integer.
+    max_iters = decl.get("max_iters")
+    if isinstance(max_iters, bool) or not isinstance(max_iters, int) or max_iters < 1:
+        ctx.add(
+            "invalid_max_iters",
+            f"composite '{ctx.name}' loop max_iters must be an integer ≥ 1 (totality, §3.2 item 8)",
+            ctx.base + ["max_iters"],
+        )
+
+    state_keys_raw = decl.get("state_keys") or []
+    state_keys = {k for k in state_keys_raw if isinstance(k, str)}
+
+    stop = decl.get("stop")
+    if not isinstance(stop, dict):
+        return
+    spath = ctx.base + ["stop"]
+    skind = stop.get("kind")
+    if skind not in _STOP_KINDS:
+        ctx.add(
+            "unknown_stop_kind",
+            f"composite '{ctx.name}' stop kind '{skind}' is not in the v1 registry "
+            "(signal_accept | external_accept | exhausted)",
+            spath + ["kind"],
+        )
+
+    if skind == "signal_accept":
+        if stop.get("threshold") is None:
+            ctx.add(
+                "missing_stop_threshold",
+                f"composite '{ctx.name}' signal_accept stop is missing its required threshold "
+                "(§3.2)",
+                spath,
+            )
+        signal_use = stop.get("signal")
+        ok, sig_name, sig_inputs = _check_signal_use(
+            signal_use, spath + ["signal"], ctx, required=True, in_state=state_keys
+        )
+        if signal_use is None:
+            ctx.add(
+                "missing_stop_signal",
+                f"composite '{ctx.name}' signal_accept stop is missing its required signal "
+                "(§3.2)",
+                spath,
+            )
+        # sig(signal_accept stop) = stop.signal.signal.
+        if stop.get("threshold") is not None:
+            _threshold_cvar_checks(
+                stop.get("threshold"),
+                spath + ["threshold"],
+                ctx,
+                sig_expected=sig_name,
+                sig_inputs=sig_inputs,
+            )
+    elif skind == "external_accept":
+        if stop.get("predicate") is None:
+            ctx.add(
+                "missing_stop_predicate",
+                f"composite '{ctx.name}' external_accept stop is missing its required "
+                "predicate (§3.2)",
+                spath,
+            )
+
+
+def _ref_type(ref: Any, ctx: _CompositeCtx) -> Optional[str]:
+    """The declared TVL type of a TVAR/CVAR namespace reference, or None if it
+    resolves to neither. CVAR types carry through verbatim; TVAR types are
+    normalized to the base kind (int/float/bool/enum)."""
+    if not isinstance(ref, str):
+        return None
+    if ref in ctx.cvar_decls:
+        return ctx.cvar_decls[ref].get("type")
+    if ref in ctx.tvar_names:
+        return ctx.tvar_types.get(ref)
+    return None
+
+
+def _arm_leaf_tvars(
+    arm: Any, ctx: _CompositeCtx, seen: Set[str]
+) -> Set[str]:
+    """leafT over a single arm (§3.5). stage → its tuned_params ∩ N_T;
+    composite(x) → ⋃ leafT(arms/body/judge(x)) ∪ ({cardinality(x)} ∩ N_T),
+    recursively. Only TVAR-resolving identifiers are kept (C6 codomain)."""
+    if isinstance(arm, str):
+        return set()  # bare stage, empty tuned_params
+    if not isinstance(arm, dict):
+        return set()
+    if "stage" in arm:
+        tuned = arm.get("tuned_params") or []
+        return {t for t in tuned if isinstance(t, str) and t in ctx.tvar_names}
+    if "composite" in arm:
+        ref = arm.get("composite")
+        if not isinstance(ref, str) or ref in seen:
+            return set()
+        target = ctx.composites_by_name.get(ref)
+        if not isinstance(target, dict):
+            return set()
+        return _composite_leaf_tvars(target, ctx, seen | {ref})
+    return set()
+
+
+def _composite_leaf_tvars(
+    decl: Dict[str, Any], ctx: _CompositeCtx, seen: Set[str]
+) -> Set[str]:
+    """leafT(composite) — the union over its arms/body/judge plus a sampling
+    ensemble's Tuned cardinality (§3.5: ({cardinality} ∩ N_T))."""
+    leaves: Set[str] = set()
+    for arm in _all_arms_of(decl):
+        leaves |= _arm_leaf_tvars(arm, ctx, seen)
+    card = decl.get("cardinality")
+    if isinstance(card, str) and card in ctx.tvar_names:
+        leaves.add(card)
+    return leaves
+
+
+def _depends_on(threshold: Any, ctx: _CompositeCtx) -> Set[str]:
+    if not isinstance(threshold, str) or threshold not in ctx.cvar_decls:
+        return set()
+    calibration = ctx.cvar_decls[threshold].get("calibration")
+    if not isinstance(calibration, dict):
+        return set()
+    deps = calibration.get("depends_on") or []
+    return {d for d in deps if isinstance(d, str)}
+
+
+def _check_composite_parents(decl: Dict[str, Any], kind: str, ctx: _CompositeCtx) -> None:
+    """§3.5 — required_parents(θ) ⊆ depends_on(θ) for every threshold CVAR
+    (missing_composite_parent). Purely static: both sides are declared
+    TVAR-only identifier sets. Skipped for thresholds that do not resolve to a
+    CVAR (already reported by missing_ref)."""
+
+    def emit(threshold: Any, required: Set[str], path: List[Any]) -> None:
+        if not isinstance(threshold, str) or threshold not in ctx.cvar_decls:
+            return
+        missing = required - _depends_on(threshold, ctx)
+        if missing:
+            ctx.add(
+                "missing_composite_parent",
+                f"composite '{ctx.name}' threshold CVAR '{threshold}' omits required parent "
+                f"TVAR(s) {sorted(missing)} from its calibration.depends_on; the arm(s) the "
+                "gate observes are parameterized by them (§3.5)",
+                path,
+            )
+
+    if kind == "cascade":
+        arms = decl.get("arms")
+        arms_list = arms if isinstance(arms, list) else []
+        gates = decl.get("gates") or []
+        gates_list = gates if isinstance(gates, list) else []
+        placement = decl.get("placement", "post")
+        # leafT per arm (index-aligned).
+        arm_leaves = [_arm_leaf_tvars(a, ctx, set()) for a in arms_list]
+        for g_idx, gate in enumerate(gates_list):
+            if not isinstance(gate, dict):
+                continue
+            if placement == "pre":
+                # required_parents(θ_i) = leafT(a_i) — the arm the gate admits.
+                required = arm_leaves[g_idx] if g_idx < len(arm_leaves) else set()
+            else:
+                # required_parents(θ_i) = leafT(a₁) ∪ … ∪ leafT(a_i) — the
+                # observed prefix (gate g_i reads a_i and prior arms).
+                required = set().union(*arm_leaves[: g_idx + 1]) if arm_leaves else set()
+            emit(gate.get("threshold"), required, ctx.base + ["gates", g_idx, "threshold"])
+    elif kind == "ensemble":
+        aggregate = decl.get("aggregate")
+        if not isinstance(aggregate, dict):
+            return
+        accept = aggregate.get("accept")
+        if not isinstance(accept, dict):
+            return
+        # required_parents(θ) = ⋃_j leafT(a_j) ∪ leafT(judge) ∪ ({cardinality} ∩ N_T).
+        required = _composite_leaf_tvars(decl, ctx, set())
+        emit(
+            accept.get("threshold"),
+            required,
+            ctx.base + ["aggregate", "accept", "threshold"],
+        )
+    elif kind == "loop":
+        stop = decl.get("stop")
+        if not isinstance(stop, dict) or stop.get("kind") != "signal_accept":
+            return
+        # required_parents(θ in Loop.stop) = leafT(body).
+        required = _arm_leaf_tvars(decl.get("body"), ctx, set())
+        emit(stop.get("threshold"), required, ctx.base + ["stop", "threshold"])
 
 
 def _lint_namespace(doc: Dict[str, Any], issues: List[Issue]) -> None:

--- a/spec/examples/validation-phase7-composites/README.md
+++ b/spec/examples/validation-phase7-composites/README.md
@@ -1,0 +1,91 @@
+# Phase 7 Validation Examples — RFC 0002 (composite knobs)
+
+Conformance fixtures for the **composite-knob algebra** (TVL 1.2). They are the
+**executable acceptance bar for the validators packet (P4)**: the grammar /
+schema / lint changes are done when every fixture below produces exactly its
+expected diagnostic through `tvl-validate` and the conformance suite
+(`tests/test_composites.py`). One happy + one rejecting fixture per §3.11 error
+code, plus the degenerate-acceptance and §4 subsumption fixtures from RFC §9
+criterion 3.
+
+> **Status: EXECUTABLE.** The 1.2 composite surface landed in `tvl.schema.json`
+> / `tvl.ebnf` / `lints.py` (`_lint_composites`); every fixture below produces
+> exactly its expected ERROR code (and nothing else) through the real schema +
+> lint pipeline. The §3.11 diagnostics are NORMATIVE LINTS, not `schema_error`:
+> the schema checks shape only (the Composite envelope and the arm/signal
+> surfaces are deliberately open), so the closed-shape / registry / binding
+> diagnostics are the lints' own — the same shape-vs-registry layering RFC 0001
+> uses for `policy.strategy`, taken one step further.
+
+## Positive fixtures
+
+| Example | Expected |
+| --- | --- |
+| `composite-knobs-happy.tvl.yml` | VALID — governed post-cascade + sampling ensemble (tuned `k`) + signal_accept loop; signal binding + `signal_inputs` coverage + parent coverage all satisfied |
+| `composite-knobs-happy-pre-cascade.tvl.yml` | VALID — pre-cascade (dispatch) with a `signal_below` gate |
+| `composite-knobs-happy-m1-cascade.tvl.yml` | VALID — degenerate `m=1` cascade (no gates) |
+| `composite-knobs-happy-sampling-k1-ensemble.tvl.yml` | VALID — sampling-form `\|arms\|=1` ensemble with tuned cardinality |
+| `composite-knobs-happy-committee-majority.tvl.yml` | VALID — committee-form `\|arms\|>1` ensemble (no cardinality) |
+| `composite-knobs-happy-loop-max-iters-one.tvl.yml` | VALID — loop at `max_iters=1` |
+| `composite-knobs-happy-tagged-nesting-under-judge.tvl.yml` | VALID — tagged `{composite: ...}` nesting in a `judge_max` judge |
+| `composite-cascade-subsumes-policy.tvl.yml` | VALID — the composite form of the legacy cascade, with both ratchets satisfied |
+| `legacy-policy-cascade-unchanged.tvl.yml` | VALID — a legacy `policies:` cascade is unchanged (the two composite-only ratchets do NOT fire) |
+| `legacy-cvar-missing-signal-remains-valid.tvl.yml` | VALID — a CVAR with no `calibration.signal` is well-formed in isolation |
+| `invalid_cardinality_value-zero-resolved-k.tvl.yml` | VALID statically — `invalid_cardinality_value` (R9) is a RESOLUTION-TIME rejection (see boundary note) |
+
+## Rejecting fixtures — one per §3.11 code
+
+| Example | Expected ERROR |
+| --- | --- |
+| `unknown_composite_kind-fourth-kind.tvl.yml` | `unknown_composite_kind` (§3.2 item 1) |
+| `unknown_composite_field-cross-kind-field.tvl.yml` | `unknown_composite_field` (§3.2 item 1) |
+| `cascade_arity-no-gate-for-two-arms.tvl.yml` | `cascade_arity` — reused RFC 0001 (§3.2 item 2) |
+| `unknown_gate_kind-unregistered-gate.tvl.yml` | `unknown_gate_kind` — reused RFC 0001 (GateDecl) |
+| `composite_binds_value-value-field.tvl.yml` | `composite_binds_value` (§3.1) |
+| `composite_shadows_name-tvar-collision.tvl.yml` | `composite_shadows_name` (§3.1) |
+| `duplicate_composite-same-name.tvl.yml` | `duplicate_composite` (§3.1) |
+| `empty_arms-cascade-no-arms.tvl.yml` | `empty_arms` (§3.2 item 2) |
+| `ambiguous_arm-bare-collides-composite.tvl.yml` | `ambiguous_arm` (§3.2 item 3) |
+| `missing_composite_ref-tagged-nesting-ghost.tvl.yml` | `missing_composite_ref` (§3.2 item 3) |
+| `composite_cycle-two-node-cycle.tvl.yml` | `composite_cycle` (§3.2 item 4) |
+| `gate_arm_incompatible-margin-on-judge-max.tvl.yml` | `gate_arm_incompatible` (§3.2 item 5) |
+| `gate_kind_placement_mismatch-signal-below-post.tvl.yml` | `gate_kind_placement_mismatch` (§3.2 item 5) |
+| `missing_gate_signal-signal-below-no-signal.tvl.yml` | `missing_gate_signal` (§3.2 item 5) |
+| `duplicate_stage-stage-repeat.tvl.yml` | `duplicate_stage` — extended scope (§3.2 item 6) |
+| `cardinality_arity_mismatch-committee-has-cardinality.tvl.yml` | `cardinality_arity_mismatch` (§3.2 item 7) |
+| `invalid_cardinality_type-float-cardinality.tvl.yml` | `invalid_cardinality_type` (§3.2 item 7) |
+| `missing_judge-judge-max-without-judge.tvl.yml` | `missing_judge` (AggregateDecl) |
+| `unknown_aggregate_kind-weighted-vote.tvl.yml` | `unknown_aggregate_kind` (AggregateDecl) |
+| `unknown_stop_kind-unregistered.tvl.yml` | `unknown_stop_kind` (StopDecl) |
+| `missing_stop_threshold-signal-accept-no-threshold.tvl.yml` | `missing_stop_threshold` (StopDecl) |
+| `missing_stop_signal-signal-accept-no-signal.tvl.yml` | `missing_stop_signal` (StopDecl) |
+| `missing_stop_predicate-external-accept-no-predicate.tvl.yml` | `missing_stop_predicate` (StopDecl) |
+| `stop_signal_outside_state-undeclared-key.tvl.yml` | `stop_signal_outside_state` (§3.2 item 8) |
+| `invalid_max_iters-zero.tvl.yml` | `invalid_max_iters` (§3.2 item 8) |
+| `invalid_tuned_param-cvar-parent.tvl.yml` | `invalid_tuned_param` (§3.2 item 9) |
+| `invalid_threshold_type-enum-cvar.tvl.yml` | `invalid_threshold_type` (§3.2 item 10) |
+| `missing_calibration_signal-no-signal.tvl.yml` | `missing_calibration_signal` (§3.2 item 11) |
+| `signal_mismatch-wrong-signal.tvl.yml` | `signal_mismatch` (§3.2 item 11) |
+| `unbound_signal_inputs-not-covered.tvl.yml` | `unbound_signal_inputs` (§3.2 item 11) |
+| `missing_composite_parent-post-gate-omits-arm-tvar.tvl.yml` | `missing_composite_parent` (§3.5) |
+| `invalid_arm_shape-unknown-arm-key.tvl.yml` | `invalid_arm_shape` (§3.9) |
+| `invalid_signal_use-nonlist-inputs.tvl.yml` | `invalid_signal_use` (§3.2 / §3.9) |
+| `missing_ref-threshold-unknown-cvar.tvl.yml` | `missing_ref` — reused (gate threshold → no CVAR) |
+| `missing_ref-threshold-tvar-kind-mismatch.tvl.yml` | `missing_ref` — reused (gate threshold → TVAR, kind mismatch) |
+
+## R9 boundary — `invalid_cardinality_value`
+
+`invalid_cardinality_value` (R9, §3.2 item 7) is a **resolution-time** rejection:
+it fires when an ensemble cardinality reference resolves to `k < 1`, which is not
+knowable from the static module (the module declares only the namespace
+reference). The static lints own the two static cardinality checks
+(`cardinality_arity_mismatch`, `invalid_cardinality_type`); R9 itself is
+surfaced **exactly as R1–R8 are** — by the resolver / small-scope model-checking
+suite (`tests/model_checking/`, `R9_INVALID_CARDINALITY_VALUE`), which extends
+RFC 0001's acceptance algebra to
+`Accept₁.₂ ⟺ ¬(R1 ∨ … ∨ R8 ∨ R9) ∧ calibrators ≠ ⊥`. The static fixture
+`invalid_cardinality_value-zero-resolved-k.tvl.yml` is the statically-well-formed
+companion documenting this boundary (it has NO static error).
+
+This mirrors the phase-6 convention: dynamic resolver rejections are not
+expressible as static module fixtures and are verified by the model suite.

--- a/spec/examples/validation-phase7-composites/ambiguous_arm-bare-collides-composite.tvl.yml
+++ b/spec/examples/validation-phase7-composites/ambiguous_arm-bare-collides-composite.tvl.yml
@@ -1,0 +1,60 @@
+# Expected: ERROR ambiguous_arm — a bare arm id colliding with a composite name
+# is rejected (use the tagged {composite: ...} form to nest). §3.2 item 3.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: router.theta
+  type: float
+  calibration:
+    source: pool
+    signal: vote_margin
+    depends_on:
+    - cheap_model
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: expert
+  kind: ensemble
+  arms:
+  - stage: s
+  cardinality: k_samples
+  aggregate:
+    kind: majority_vote
+- name: answerer
+  kind: cascade
+  placement: post
+  arms:
+  - expert
+  - stage: strong_stage
+  gates:
+  - kind: margin_below
+    threshold: router.theta

--- a/spec/examples/validation-phase7-composites/cardinality_arity_mismatch-committee-has-cardinality.tvl.yml
+++ b/spec/examples/validation-phase7-composites/cardinality_arity_mismatch-committee-has-cardinality.tvl.yml
@@ -1,0 +1,45 @@
+# Expected: ERROR cardinality_arity_mismatch — cardinality is present iff
+# |arms| = 1; a committee (|arms| > 1) must not declare it. §3.2 item 7.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars: []
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: committee
+  kind: ensemble
+  arms:
+  - stage: s1
+  - stage: s2
+  cardinality: k_samples
+  aggregate:
+    kind: majority_vote

--- a/spec/examples/validation-phase7-composites/cascade_arity-no-gate-for-two-arms.tvl.yml
+++ b/spec/examples/validation-phase7-composites/cascade_arity-no-gate-for-two-arms.tvl.yml
@@ -1,0 +1,55 @@
+# Expected: ERROR cascade_arity — |gates| must equal |arms| - 1 (reused RFC 0001
+# code). §3.2 item 2.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: router.theta
+  type: float
+  calibration:
+    source: pool
+    signal: vote_margin
+    depends_on:
+    - cheap_model
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: answerer
+  kind: cascade
+  placement: post
+  arms:
+  - stage: cheap_stage
+    tuned_params:
+    - cheap_model
+  - stage: strong_stage
+    tuned_params:
+    - strong_model
+  gates: []

--- a/spec/examples/validation-phase7-composites/composite-cascade-subsumes-policy.tvl.yml
+++ b/spec/examples/validation-phase7-composites/composite-cascade-subsumes-policy.tvl.yml
@@ -1,0 +1,58 @@
+# Expected: VALID — the composite form of the legacy cascade above, with the two
+# intended ratchets satisfied (per-arm tuned_params declared; threshold CVAR's
+# calibration.signal = vote_margin). Execution semantics are identical to the
+# policies form (§4); the lints differ ONLY by the two composite-only ratchets.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: router.theta
+  type: float
+  calibration:
+    source: pool
+    signal: vote_margin
+    depends_on:
+    - cheap_model
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: cheap_strong
+  kind: cascade
+  placement: post
+  arms:
+  - stage: cheap
+    tuned_params:
+    - cheap_model
+  - stage: strong
+  gates:
+  - kind: margin_below
+    threshold: router.theta
+  pattern: binary_cascade

--- a/spec/examples/validation-phase7-composites/composite-knobs-happy-committee-majority.tvl.yml
+++ b/spec/examples/validation-phase7-composites/composite-knobs-happy-committee-majority.tvl.yml
@@ -1,0 +1,45 @@
+# Expected: VALID — a committee-form (|arms|>1) ensemble must NOT carry a
+# cardinality. §3.2 item 7.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars: []
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: committee
+  kind: ensemble
+  arms:
+  - stage: s1
+  - stage: s2
+  - stage: s3
+  aggregate:
+    kind: majority_vote

--- a/spec/examples/validation-phase7-composites/composite-knobs-happy-loop-max-iters-one.tvl.yml
+++ b/spec/examples/validation-phase7-composites/composite-knobs-happy-loop-max-iters-one.tvl.yml
@@ -1,0 +1,45 @@
+# Expected: VALID — a loop at max_iters=1 (the 2-step-knob degenerate). §3.2 item 8.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars: []
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: once
+  kind: loop
+  body:
+    stage: s
+  state_keys: []
+  stop:
+    kind: external_accept
+    predicate: run_unit_tests
+  max_iters: 1

--- a/spec/examples/validation-phase7-composites/composite-knobs-happy-m1-cascade.tvl.yml
+++ b/spec/examples/validation-phase7-composites/composite-knobs-happy-m1-cascade.tvl.yml
@@ -1,0 +1,44 @@
+# Expected: VALID — a degenerate m=1 cascade has no gates and always returns its
+# arm. §3.2 item 2.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars: []
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: single
+  kind: cascade
+  placement: post
+  arms:
+  - stage: only
+    tuned_params:
+    - cheap_model

--- a/spec/examples/validation-phase7-composites/composite-knobs-happy-pre-cascade.tvl.yml
+++ b/spec/examples/validation-phase7-composites/composite-knobs-happy-pre-cascade.tvl.yml
@@ -1,0 +1,54 @@
+# Phase 7 (RFC 0002): VALID — a pre-cascade (dispatch) with a signal_below gate.
+# signal_below is PRE-only and carries a SignalUse; sig(signal_below) = its
+# signal id, so the threshold CVAR's calibration.signal must equal it.
+# required_parents(θ_i in Cascade_pre) = leafT(a_i) — the arm the gate admits.
+# Expected: no errors.
+tvl:
+  module: corp.validation.composites_pre_cascade
+
+environment:
+  snapshot_id: "2026-06-06T00:00:00Z"
+
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+
+tvars:
+  - name: cheap_model
+    type: enum[str]
+    domain: ["gpt-4o-mini", "haiku"]
+  - name: strong_model
+    type: enum[str]
+    domain: ["gpt-4o", "sonnet"]
+
+cvars:
+  - name: dispatch.route_threshold
+    type: float
+    calibration:
+      source: route_pool
+      signal: route_confidence
+      depends_on: [cheap_model]
+
+composites:
+  - name: dispatcher
+    kind: cascade
+    placement: pre
+    arms:
+      - { stage: cheap_stage, tuned_params: [cheap_model] }
+      - { stage: strong_stage, tuned_params: [strong_model] }
+    gates:
+      - kind: signal_below
+        threshold: dispatch.route_threshold
+        signal: { signal: route_confidence }
+
+constraints:
+  structural: []
+
+objectives:
+  - name: quality
+    direction: maximize
+
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02

--- a/spec/examples/validation-phase7-composites/composite-knobs-happy-sampling-k1-ensemble.tvl.yml
+++ b/spec/examples/validation-phase7-composites/composite-knobs-happy-sampling-k1-ensemble.tvl.yml
@@ -1,0 +1,58 @@
+# Expected: VALID — a sampling-form (|arms|=1) ensemble with a tuned cardinality.
+# §3.2 item 7.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: vote.theta
+  type: float
+  calibration:
+    source: pool
+    signal: vote_margin
+    depends_on:
+    - cheap_model
+    - k_samples
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: voter
+  kind: ensemble
+  arms:
+  - stage: s
+    tuned_params:
+    - cheap_model
+  cardinality: k_samples
+  aggregate:
+    kind: majority_vote
+    accept:
+      kind: stat_at_least
+      stat: vote_margin
+      threshold: vote.theta

--- a/spec/examples/validation-phase7-composites/composite-knobs-happy-tagged-nesting-under-judge.tvl.yml
+++ b/spec/examples/validation-phase7-composites/composite-knobs-happy-tagged-nesting-under-judge.tvl.yml
@@ -1,0 +1,61 @@
+# Expected: VALID — tagged {composite: ...} nesting in the ensemble judge
+# position. §3.9.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: router.theta
+  type: float
+  calibration:
+    source: pool
+    signal: vote_margin
+    depends_on: []
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: inner
+  kind: cascade
+  placement: post
+  arms:
+  - stage: a
+  - stage: b
+  gates:
+  - kind: margin_below
+    threshold: router.theta
+- name: scored
+  kind: ensemble
+  arms:
+  - stage: s
+  cardinality: k_samples
+  aggregate:
+    kind: judge_max
+    judge:
+      composite: inner

--- a/spec/examples/validation-phase7-composites/composite-knobs-happy.tvl.yml
+++ b/spec/examples/validation-phase7-composites/composite-knobs-happy.tvl.yml
@@ -1,0 +1,115 @@
+# Phase 7 (RFC 0002): VALID 1.2 module — the conformance-positive composite module.
+# Exercises: a governed binary post-cascade with a margin-bearing stage arm and
+# the §3.2 item-11 signal binding; a sampling-form majority_vote ensemble with a
+# tuned cardinality (its TVAR in leafT, §3.5) and an accept threshold; a
+# signal_accept loop (max_iters=3) whose stop signal reads a declared state key
+# and whose use-site inputs are freshness-bound (signal_inputs covered).
+# Expected: no errors.
+tvl:
+  module: corp.validation.composites_happy
+
+environment:
+  snapshot_id: "2026-06-06T00:00:00Z"
+
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+
+tvars:
+  - name: cheap_model
+    type: enum[str]
+    domain: ["gpt-4o-mini", "haiku"]
+  - name: temperature
+    type: float
+    domain:
+      range: [0.0, 1.0]
+      resolution: 0.1
+  - name: strong_model
+    type: enum[str]
+    domain: ["gpt-4o", "sonnet"]
+  - name: k_samples
+    type: int
+    domain:
+      range: [1, 9]
+
+cvars:
+  # Post-cascade margin gate threshold: sig(margin_below) = vote_margin.
+  # required_parents(θ) = leafT(cheap arm) = {cheap_model, temperature}.
+  - name: router.margin_threshold
+    type: float
+    domain:
+      range: [0.0, 1.0]
+    calibration:
+      source: margin_eval_pool
+      signal: vote_margin
+      depends_on: [cheap_model, temperature]
+    governance:
+      require_calibration: true
+  # Ensemble accept threshold: sig(stat_at_least) = vote_margin.
+  # required_parents(θ) = leafT(arms) ∪ ({k_samples} ∩ N_T) = {cheap_model, k_samples}.
+  - name: vote.accept_threshold
+    type: float
+    calibration:
+      source: ensemble_pool
+      signal: vote_margin
+      depends_on: [cheap_model, k_samples]
+  # Loop stop threshold: sig(signal_accept) = the stop's SignalUse.signal.
+  # The use-site SignalUse.inputs = [draft] is freshness-bound (signal_inputs).
+  - name: refine.stop_threshold
+    type: float
+    calibration:
+      source: refine_pool
+      signal: draft_quality
+      depends_on: [strong_model]
+
+composites:
+  - name: answerer
+    kind: cascade
+    placement: post
+    arms:
+      - { stage: cheap_stage, tuned_params: [cheap_model, temperature] }
+      - { stage: strong_stage, tuned_params: [strong_model] }
+    gates:
+      - kind: margin_below
+        threshold: router.margin_threshold
+    pattern: binary_cascade
+
+  - name: voter
+    kind: ensemble
+    arms:
+      - { stage: cheap_stage, tuned_params: [cheap_model] }
+    cardinality: k_samples
+    aggregate:
+      kind: majority_vote
+      accept:
+        kind: stat_at_least
+        stat: vote_margin
+        threshold: vote.accept_threshold
+    pattern: self_consistency
+
+  - name: refiner
+    kind: loop
+    body: { stage: strong_stage, tuned_params: [strong_model] }
+    state_keys: [draft]
+    stop:
+      kind: signal_accept
+      threshold: refine.stop_threshold
+      signal: { signal: draft_quality, inputs: [draft] }
+    max_iters: 3
+    pattern: self_refine
+
+constraints:
+  structural: []
+
+objectives:
+  - name: quality
+    direction: maximize
+
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+  require_calibration:
+    enabled: true
+    hash_covered_context: [model_versions, signal_inputs]
+    signal_inputs: [draft]

--- a/spec/examples/validation-phase7-composites/composite_binds_value-value-field.tvl.yml
+++ b/spec/examples/validation-phase7-composites/composite_binds_value-value-field.tvl.yml
@@ -1,0 +1,58 @@
+# Expected: ERROR composite_binds_value — a composite never binds a value; it is
+# a namespace/expansion unit, not a binding kind. §3.1.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: router.theta
+  type: float
+  calibration:
+    source: pool
+    signal: vote_margin
+    depends_on:
+    - cheap_model
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: answerer
+  kind: cascade
+  placement: post
+  arms:
+  - stage: cheap_stage
+    tuned_params:
+    - cheap_model
+  - stage: strong_stage
+    tuned_params:
+    - strong_model
+  gates:
+  - kind: margin_below
+    threshold: router.theta
+  value: x

--- a/spec/examples/validation-phase7-composites/composite_cycle-two-node-cycle.tvl.yml
+++ b/spec/examples/validation-phase7-composites/composite_cycle-two-node-cycle.tvl.yml
@@ -1,0 +1,53 @@
+# Expected: ERROR composite_cycle — the N_X reference graph is cyclic; nesting
+# must be acyclic so expansion terminates. §3.2 item 4.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars: []
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: a
+  kind: loop
+  body:
+    composite: b
+  state_keys: []
+  stop:
+    kind: exhausted
+  max_iters: 2
+- name: b
+  kind: loop
+  body:
+    composite: a
+  state_keys: []
+  stop:
+    kind: exhausted
+  max_iters: 2

--- a/spec/examples/validation-phase7-composites/composite_shadows_name-tvar-collision.tvl.yml
+++ b/spec/examples/validation-phase7-composites/composite_shadows_name-tvar-collision.tvl.yml
@@ -1,0 +1,57 @@
+# Expected: ERROR composite_shadows_name — N_X name shadows a tvar/cvar/policy in
+# the shared namespace. §3.1.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: router.theta
+  type: float
+  calibration:
+    source: pool
+    signal: vote_margin
+    depends_on:
+    - cheap_model
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: cheap_model
+  kind: cascade
+  placement: post
+  arms:
+  - stage: cheap_stage
+    tuned_params:
+    - cheap_model
+  - stage: strong_stage
+    tuned_params:
+    - strong_model
+  gates:
+  - kind: margin_below
+    threshold: router.theta

--- a/spec/examples/validation-phase7-composites/duplicate_composite-same-name.tvl.yml
+++ b/spec/examples/validation-phase7-composites/duplicate_composite-same-name.tvl.yml
@@ -1,0 +1,69 @@
+# Expected: ERROR duplicate_composite — name declared twice within N_X. §3.1.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: router.theta
+  type: float
+  calibration:
+    source: pool
+    signal: vote_margin
+    depends_on:
+    - cheap_model
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: answerer
+  kind: cascade
+  placement: post
+  arms:
+  - stage: cheap_stage
+    tuned_params:
+    - cheap_model
+  - stage: strong_stage
+    tuned_params:
+    - strong_model
+  gates:
+  - kind: margin_below
+    threshold: router.theta
+- name: answerer
+  kind: cascade
+  placement: post
+  arms:
+  - stage: cheap_stage
+    tuned_params:
+    - cheap_model
+  - stage: strong_stage
+    tuned_params:
+    - strong_model
+  gates:
+  - kind: margin_below
+    threshold: router.theta

--- a/spec/examples/validation-phase7-composites/duplicate_stage-stage-repeat.tvl.yml
+++ b/spec/examples/validation-phase7-composites/duplicate_stage-stage-repeat.tvl.yml
@@ -1,0 +1,55 @@
+# Expected: ERROR duplicate_stage — duplicate stage(·) within one composite
+# (extended scope). §3.2 item 6.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: router.theta
+  type: float
+  calibration:
+    source: pool
+    signal: vote_margin
+    depends_on:
+    - cheap_model
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: answerer
+  kind: cascade
+  placement: post
+  arms:
+  - stage: dup
+    tuned_params:
+    - cheap_model
+  - stage: dup
+  gates:
+  - kind: margin_below
+    threshold: router.theta

--- a/spec/examples/validation-phase7-composites/empty_arms-cascade-no-arms.tvl.yml
+++ b/spec/examples/validation-phase7-composites/empty_arms-cascade-no-arms.tvl.yml
@@ -1,0 +1,41 @@
+# Expected: ERROR empty_arms — arms must be non-empty for every constructor.
+# §3.2 item 2.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars: []
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: x
+  kind: cascade
+  placement: post
+  arms: []

--- a/spec/examples/validation-phase7-composites/gate_arm_incompatible-margin-on-judge-max.tvl.yml
+++ b/spec/examples/validation-phase7-composites/gate_arm_incompatible-margin-on-judge-max.tvl.yml
@@ -1,0 +1,62 @@
+# Expected: ERROR gate_arm_incompatible — margin_below gates a non-margin-bearing
+# arm (a judge_max ensemble yields a score, not a vote margin). §3.2 item 5.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: router.theta
+  type: float
+  calibration:
+    source: pool
+    signal: vote_margin
+    depends_on:
+    - k_samples
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: scored
+  kind: ensemble
+  arms:
+  - stage: s
+  cardinality: k_samples
+  aggregate:
+    kind: judge_max
+    judge:
+      stage: judge_stage
+- name: answerer
+  kind: cascade
+  placement: post
+  arms:
+  - composite: scored
+  - stage: strong_stage
+  gates:
+  - kind: margin_below
+    threshold: router.theta

--- a/spec/examples/validation-phase7-composites/gate_kind_placement_mismatch-signal-below-post.tvl.yml
+++ b/spec/examples/validation-phase7-composites/gate_kind_placement_mismatch-signal-below-post.tvl.yml
@@ -1,0 +1,57 @@
+# Expected: ERROR gate_kind_placement_mismatch — signal_below is PRE-only; using
+# it under placement post is rejected. §3.2 item 5.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: router.theta
+  type: float
+  calibration:
+    source: pool
+    signal: route_confidence
+    depends_on:
+    - cheap_model
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: answerer
+  kind: cascade
+  placement: post
+  arms:
+  - stage: cheap_stage
+    tuned_params:
+    - cheap_model
+  - stage: strong_stage
+  gates:
+  - kind: signal_below
+    threshold: router.theta
+    signal:
+      signal: route_confidence

--- a/spec/examples/validation-phase7-composites/invalid_arm_shape-composite-with-tuned-params.tvl.yml
+++ b/spec/examples/validation-phase7-composites/invalid_arm_shape-composite-with-tuned-params.tvl.yml
@@ -1,0 +1,63 @@
+# Phase 7 (RFC 0002): a COMPOSITE-tagged arm may carry ONLY the 'composite'
+# key (§3.9 ArmSurface) — tuned_params belongs to stage arms.
+# Expected: invalid_arm_shape (codex P4 round-1 mutation probe).
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: router.theta
+  type: float
+  calibration:
+    source: pool
+    signal: vote_margin
+    depends_on: []
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: inner
+  kind: cascade
+  placement: post
+  arms:
+  - stage: a
+  - stage: b
+  gates:
+  - kind: margin_below
+    threshold: router.theta
+- name: scored
+  kind: ensemble
+  arms:
+  - stage: s
+  cardinality: k_samples
+  aggregate:
+    kind: judge_max
+    judge:
+      composite: inner
+      tuned_params: [cheap_model]

--- a/spec/examples/validation-phase7-composites/invalid_arm_shape-unknown-arm-key.tvl.yml
+++ b/spec/examples/validation-phase7-composites/invalid_arm_shape-unknown-arm-key.tvl.yml
@@ -1,0 +1,58 @@
+# Expected: ERROR invalid_arm_shape — unknown key in an ArmSurface object form.
+# §3.9.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: router.theta
+  type: float
+  calibration:
+    source: pool
+    signal: vote_margin
+    depends_on:
+    - cheap_model
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: answerer
+  kind: cascade
+  placement: post
+  arms:
+  - stage: cheap_stage
+    weight: 2
+    tuned_params:
+    - cheap_model
+  - stage: strong_stage
+    tuned_params:
+    - strong_model
+  gates:
+  - kind: margin_below
+    threshold: router.theta

--- a/spec/examples/validation-phase7-composites/invalid_cardinality_type-float-cardinality.tvl.yml
+++ b/spec/examples/validation-phase7-composites/invalid_cardinality_type-float-cardinality.tvl.yml
@@ -1,0 +1,51 @@
+# Expected: ERROR invalid_cardinality_type — the cardinality ref must be an
+# int-typed TVAR/CVAR. §3.2 item 7.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+- name: temp
+  type: float
+  domain:
+    range:
+    - 0.0
+    - 1.0
+    resolution: 0.1
+cvars: []
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: voter
+  kind: ensemble
+  arms:
+  - stage: s
+  cardinality: temp
+  aggregate:
+    kind: majority_vote

--- a/spec/examples/validation-phase7-composites/invalid_cardinality_value-zero-resolved-k.tvl.yml
+++ b/spec/examples/validation-phase7-composites/invalid_cardinality_value-zero-resolved-k.tvl.yml
@@ -1,0 +1,54 @@
+# Expected (RESOLUTION-TIME, R9): invalid_cardinality_value when k resolves < 1.
+# This module is STATICALLY well-formed (k's domain includes 0); R9 fires at
+# resolution, surfaced exactly as R1-R8 by the resolver / model-checking suite
+# (tests/model_checking R9_INVALID_CARDINALITY_VALUE), NOT by the static lints.
+# Static expectation here: NO errors. §3.2 item 7 / §3.11.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+- name: k_zero
+  type: int
+  domain:
+    set:
+    - 0
+    - 1
+    - 2
+cvars: []
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: voter
+  kind: ensemble
+  arms:
+  - stage: s
+  cardinality: k_zero
+  aggregate:
+    kind: majority_vote

--- a/spec/examples/validation-phase7-composites/invalid_max_iters-zero.tvl.yml
+++ b/spec/examples/validation-phase7-composites/invalid_max_iters-zero.tvl.yml
@@ -1,0 +1,44 @@
+# Expected: ERROR invalid_max_iters — max_iters must be ≥ 1 (totality). §3.2 item 8.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars: []
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: looper
+  kind: loop
+  body:
+    stage: s
+  state_keys: []
+  stop:
+    kind: exhausted
+  max_iters: 0

--- a/spec/examples/validation-phase7-composites/invalid_signal_use-non-ident-inputs.tvl.yml
+++ b/spec/examples/validation-phase7-composites/invalid_signal_use-non-ident-inputs.tvl.yml
@@ -1,0 +1,52 @@
+# Phase 7 (RFC 0002): SignalUse.inputs must be Ident* — a non-string element
+# rejects rather than being silently filtered (which would also suppress
+# unbound_signal_inputs). Expected: invalid_signal_use (codex mutation probe).
+tvl:
+  module: corp.validation.composites_pre_cascade
+
+environment:
+  snapshot_id: "2026-06-06T00:00:00Z"
+
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+
+tvars:
+  - name: cheap_model
+    type: enum[str]
+    domain: ["gpt-4o-mini", "haiku"]
+  - name: strong_model
+    type: enum[str]
+    domain: ["gpt-4o", "sonnet"]
+
+cvars:
+  - name: dispatch.route_threshold
+    type: float
+    calibration:
+      source: route_pool
+      signal: route_confidence
+      depends_on: [cheap_model]
+
+composites:
+  - name: dispatcher
+    kind: cascade
+    placement: pre
+    arms:
+      - { stage: cheap_stage, tuned_params: [cheap_model] }
+      - { stage: strong_stage, tuned_params: [strong_model] }
+    gates:
+      - kind: signal_below
+        threshold: dispatch.route_threshold
+        signal: { signal: route_confidence, inputs: [123] }
+
+constraints:
+  structural: []
+
+objectives:
+  - name: quality
+    direction: maximize
+
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02

--- a/spec/examples/validation-phase7-composites/invalid_signal_use-nonlist-inputs.tvl.yml
+++ b/spec/examples/validation-phase7-composites/invalid_signal_use-nonlist-inputs.tvl.yml
@@ -1,0 +1,58 @@
+# Expected: ERROR invalid_signal_use — a malformed SignalUse object (non-list
+# inputs). §3.2 / §3.9.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: router.theta
+  type: float
+  calibration:
+    source: pool
+    signal: route_confidence
+    depends_on:
+    - cheap_model
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: dispatcher
+  kind: cascade
+  placement: pre
+  arms:
+  - stage: cheap_stage
+    tuned_params:
+    - cheap_model
+  - stage: strong_stage
+  gates:
+  - kind: signal_below
+    threshold: router.theta
+    signal:
+      signal: route_confidence
+      inputs: draft

--- a/spec/examples/validation-phase7-composites/invalid_threshold_type-enum-cvar.tvl.yml
+++ b/spec/examples/validation-phase7-composites/invalid_threshold_type-enum-cvar.tvl.yml
@@ -1,0 +1,57 @@
+# Expected: ERROR invalid_threshold_type — a gate/accept/stop threshold CVAR must
+# be int or float. §3.2 item 10.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: router.theta
+  type: enum[str]
+  calibration:
+    source: pool
+    signal: vote_margin
+    depends_on:
+    - cheap_model
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: answerer
+  kind: cascade
+  placement: post
+  arms:
+  - stage: cheap_stage
+    tuned_params:
+    - cheap_model
+  - stage: strong_stage
+    tuned_params:
+    - strong_model
+  gates:
+  - kind: margin_below
+    threshold: router.theta

--- a/spec/examples/validation-phase7-composites/invalid_tuned_param-cvar-parent.tvl.yml
+++ b/spec/examples/validation-phase7-composites/invalid_tuned_param-cvar-parent.tvl.yml
@@ -1,0 +1,57 @@
+# Expected: ERROR invalid_tuned_param — a tuned_params entry must resolve to a
+# TVAR (here it names a CVAR). §3.2 item 9.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: router.theta
+  type: float
+  calibration:
+    source: pool
+    signal: vote_margin
+    depends_on:
+    - cheap_model
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: answerer
+  kind: cascade
+  placement: post
+  arms:
+  - stage: cheap_stage
+    tuned_params:
+    - router.theta
+  - stage: strong_stage
+    tuned_params:
+    - strong_model
+  gates:
+  - kind: margin_below
+    threshold: router.theta

--- a/spec/examples/validation-phase7-composites/legacy-cvar-missing-signal-remains-valid.tvl.yml
+++ b/spec/examples/validation-phase7-composites/legacy-cvar-missing-signal-remains-valid.tvl.yml
@@ -1,0 +1,43 @@
+# Expected: VALID — a CVAR whose calibration.signal is absent is well-formed on
+# its own; missing_calibration_signal / signal_mismatch / unbound_signal_inputs
+# fire ONLY at a composite use site, never on a cvars block in isolation. §3.2 item 11.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: lonely.theta
+  type: float
+  calibration:
+    source: pool
+    depends_on:
+    - cheap_model
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02

--- a/spec/examples/validation-phase7-composites/legacy-policy-cascade-unchanged.tvl.yml
+++ b/spec/examples/validation-phase7-composites/legacy-policy-cascade-unchanged.tvl.yml
@@ -1,0 +1,54 @@
+# Expected: VALID — a legacy policies: cascade is unchanged under TVL 1.2; the two
+# composite-only ratchets (empty-tuned_params parent coverage, signal binding)
+# do NOT fire on the policies form even though router.theta omits calibration.signal.
+# §4 subsumption / P1.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: router.theta
+  type: float
+  calibration:
+    source: pool
+    depends_on:
+    - cheap_model
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+policies:
+- name: cheap_strong
+  kind: policy
+  strategy: cascade
+  stages:
+  - cheap
+  - strong
+  gates:
+  - kind: margin_below
+    threshold: router.theta

--- a/spec/examples/validation-phase7-composites/missing_calibration_signal-no-signal.tvl.yml
+++ b/spec/examples/validation-phase7-composites/missing_calibration_signal-no-signal.tvl.yml
@@ -1,0 +1,56 @@
+# Expected: ERROR missing_calibration_signal — a composite-referenced threshold
+# CVAR must declare calibration.signal = sig(construct). §3.2 item 11.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: router.theta
+  type: float
+  calibration:
+    source: pool
+    depends_on:
+    - cheap_model
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: answerer
+  kind: cascade
+  placement: post
+  arms:
+  - stage: cheap_stage
+    tuned_params:
+    - cheap_model
+  - stage: strong_stage
+    tuned_params:
+    - strong_model
+  gates:
+  - kind: margin_below
+    threshold: router.theta

--- a/spec/examples/validation-phase7-composites/missing_composite_parent-post-gate-omits-arm-tvar.tvl.yml
+++ b/spec/examples/validation-phase7-composites/missing_composite_parent-post-gate-omits-arm-tvar.tvl.yml
@@ -1,0 +1,57 @@
+# Expected: ERROR missing_composite_parent — required_parents(θ) ⊄ depends_on(θ);
+# the gated arm's tuned TVAR is missing from the threshold's calibration.depends_on.
+# §3.5.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: router.theta
+  type: float
+  calibration:
+    source: pool
+    signal: vote_margin
+    depends_on: []
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: answerer
+  kind: cascade
+  placement: post
+  arms:
+  - stage: cheap_stage
+    tuned_params:
+    - cheap_model
+  - stage: strong_stage
+    tuned_params:
+    - strong_model
+  gates:
+  - kind: margin_below
+    threshold: router.theta

--- a/spec/examples/validation-phase7-composites/missing_composite_ref-tagged-nesting-ghost.tvl.yml
+++ b/spec/examples/validation-phase7-composites/missing_composite_ref-tagged-nesting-ghost.tvl.yml
@@ -1,0 +1,55 @@
+# Expected: ERROR missing_composite_ref — composite(ghost) resolves to no N_X
+# member. §3.2 item 3.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: router.theta
+  type: float
+  calibration:
+    source: pool
+    signal: vote_margin
+    depends_on:
+    - cheap_model
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: answerer
+  kind: cascade
+  placement: post
+  arms:
+  - stage: cheap_stage
+    tuned_params:
+    - cheap_model
+  - composite: ghost
+  gates:
+  - kind: margin_below
+    threshold: router.theta

--- a/spec/examples/validation-phase7-composites/missing_gate_signal-signal-below-no-signal.tvl.yml
+++ b/spec/examples/validation-phase7-composites/missing_gate_signal-signal-below-no-signal.tvl.yml
@@ -1,0 +1,55 @@
+# Expected: ERROR missing_gate_signal — a signal_below gate requires a declared
+# signal field. §3.2 item 5.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: router.theta
+  type: float
+  calibration:
+    source: pool
+    signal: route_confidence
+    depends_on:
+    - cheap_model
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: dispatcher
+  kind: cascade
+  placement: pre
+  arms:
+  - stage: cheap_stage
+    tuned_params:
+    - cheap_model
+  - stage: strong_stage
+  gates:
+  - kind: signal_below
+    threshold: router.theta

--- a/spec/examples/validation-phase7-composites/missing_judge-judge-max-without-judge.tvl.yml
+++ b/spec/examples/validation-phase7-composites/missing_judge-judge-max-without-judge.tvl.yml
@@ -1,0 +1,44 @@
+# Expected: ERROR missing_judge — a judge_max aggregate requires its judge arm.
+# §3.2 AggregateDecl.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars: []
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: scored
+  kind: ensemble
+  arms:
+  - stage: s
+  cardinality: k_samples
+  aggregate:
+    kind: judge_max

--- a/spec/examples/validation-phase7-composites/missing_ref-threshold-tvar-kind-mismatch.tvl.yml
+++ b/spec/examples/validation-phase7-composites/missing_ref-threshold-tvar-kind-mismatch.tvl.yml
@@ -1,0 +1,50 @@
+# Expected: ERROR missing_ref — gate threshold resolves to a TVAR, not a CVAR
+# (kind-checked). §3.2 item 6.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars: []
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: answerer
+  kind: cascade
+  placement: post
+  arms:
+  - stage: cheap_stage
+    tuned_params:
+    - cheap_model
+  - stage: strong_stage
+    tuned_params:
+    - strong_model
+  gates:
+  - kind: margin_below
+    threshold: cheap_model

--- a/spec/examples/validation-phase7-composites/missing_ref-threshold-unknown-cvar.tvl.yml
+++ b/spec/examples/validation-phase7-composites/missing_ref-threshold-unknown-cvar.tvl.yml
@@ -1,0 +1,50 @@
+# Expected: ERROR missing_ref — gate threshold does not resolve to a declared
+# CVAR (reused RFC 0001 code, kind-checked). §3.2 item 6.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars: []
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: answerer
+  kind: cascade
+  placement: post
+  arms:
+  - stage: cheap_stage
+    tuned_params:
+    - cheap_model
+  - stage: strong_stage
+    tuned_params:
+    - strong_model
+  gates:
+  - kind: margin_below
+    threshold: ghost.theta

--- a/spec/examples/validation-phase7-composites/missing_stop_predicate-external-accept-no-predicate.tvl.yml
+++ b/spec/examples/validation-phase7-composites/missing_stop_predicate-external-accept-no-predicate.tvl.yml
@@ -1,0 +1,45 @@
+# Expected: ERROR missing_stop_predicate — an external_accept stop requires its
+# predicate. §3.2 StopDecl.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars: []
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: looper
+  kind: loop
+  body:
+    stage: s
+  state_keys: []
+  stop:
+    kind: external_accept
+  max_iters: 3

--- a/spec/examples/validation-phase7-composites/missing_stop_signal-signal-accept-no-signal.tvl.yml
+++ b/spec/examples/validation-phase7-composites/missing_stop_signal-signal-accept-no-signal.tvl.yml
@@ -1,0 +1,53 @@
+# Expected: ERROR missing_stop_signal — a signal_accept stop requires its signal.
+# §3.2 StopDecl.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: stop.theta
+  type: float
+  calibration:
+    source: pool
+    signal: q
+    depends_on: []
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: looper
+  kind: loop
+  body:
+    stage: s
+  state_keys:
+  - d
+  stop:
+    kind: signal_accept
+    threshold: stop.theta
+  max_iters: 3

--- a/spec/examples/validation-phase7-composites/missing_stop_threshold-signal-accept-no-threshold.tvl.yml
+++ b/spec/examples/validation-phase7-composites/missing_stop_threshold-signal-accept-no-threshold.tvl.yml
@@ -1,0 +1,54 @@
+# Expected: ERROR missing_stop_threshold — a signal_accept stop requires its
+# threshold. §3.2 StopDecl.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: stop.theta
+  type: float
+  calibration:
+    source: pool
+    signal: q
+    depends_on: []
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: looper
+  kind: loop
+  body:
+    stage: s
+  state_keys:
+  - d
+  stop:
+    kind: signal_accept
+    signal:
+      signal: q
+  max_iters: 3

--- a/spec/examples/validation-phase7-composites/signal_mismatch-wrong-signal.tvl.yml
+++ b/spec/examples/validation-phase7-composites/signal_mismatch-wrong-signal.tvl.yml
@@ -1,0 +1,57 @@
+# Expected: ERROR signal_mismatch — the threshold CVAR's calibration.signal must
+# equal sig(construct) = vote_margin for margin_below. §3.2 item 11.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: router.theta
+  type: float
+  calibration:
+    source: pool
+    signal: some_other_signal
+    depends_on:
+    - cheap_model
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: answerer
+  kind: cascade
+  placement: post
+  arms:
+  - stage: cheap_stage
+    tuned_params:
+    - cheap_model
+  - stage: strong_stage
+    tuned_params:
+    - strong_model
+  gates:
+  - kind: margin_below
+    threshold: router.theta

--- a/spec/examples/validation-phase7-composites/stop_signal_outside_state-undeclared-key.tvl.yml
+++ b/spec/examples/validation-phase7-composites/stop_signal_outside_state-undeclared-key.tvl.yml
@@ -1,0 +1,63 @@
+# Expected: ERROR stop_signal_outside_state — stop.signal.inputs ⊄ state_keys.
+# §3.2 item 8.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: stop.theta
+  type: float
+  calibration:
+    source: pool
+    signal: q
+    depends_on: []
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+  require_calibration:
+    enabled: true
+    hash_covered_context:
+    - signal_inputs
+    signal_inputs:
+    - critique
+composites:
+- name: looper
+  kind: loop
+  body:
+    stage: s
+  state_keys:
+  - draft
+  stop:
+    kind: signal_accept
+    threshold: stop.theta
+    signal:
+      signal: q
+      inputs:
+      - critique
+  max_iters: 3

--- a/spec/examples/validation-phase7-composites/unbound_signal_inputs-not-covered.tvl.yml
+++ b/spec/examples/validation-phase7-composites/unbound_signal_inputs-not-covered.tvl.yml
@@ -1,0 +1,62 @@
+# Expected: ERROR unbound_signal_inputs — a non-empty use-site SignalUse.inputs
+# must be covered by signal_inputs in hash_covered_context AND the covered value
+# must equal the use-site list. §3.2 item 11.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: stop.theta
+  type: float
+  calibration:
+    source: pool
+    signal: q
+    depends_on: []
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+  require_calibration:
+    enabled: true
+    hash_covered_context:
+    - model_versions
+composites:
+- name: looper
+  kind: loop
+  body:
+    stage: s
+  state_keys:
+  - draft
+  stop:
+    kind: signal_accept
+    threshold: stop.theta
+    signal:
+      signal: q
+      inputs:
+      - draft
+  max_iters: 3

--- a/spec/examples/validation-phase7-composites/unknown_aggregate_kind-weighted-vote.tvl.yml
+++ b/spec/examples/validation-phase7-composites/unknown_aggregate_kind-weighted-vote.tvl.yml
@@ -1,0 +1,44 @@
+# Expected: ERROR unknown_aggregate_kind — aggregate kind outside the v1 registry
+# (majority_vote | judge_max). §3.2 AggregateDecl.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars: []
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: voter
+  kind: ensemble
+  arms:
+  - stage: s
+  cardinality: k_samples
+  aggregate:
+    kind: weighted_vote

--- a/spec/examples/validation-phase7-composites/unknown_composite_field-cross-kind-field.tvl.yml
+++ b/spec/examples/validation-phase7-composites/unknown_composite_field-cross-kind-field.tvl.yml
@@ -1,0 +1,58 @@
+# Expected: ERROR unknown_composite_field — 'max_iters' is a loop body field on
+# a cascade composite (closed shapes). §3.2 item 1.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: router.theta
+  type: float
+  calibration:
+    source: pool
+    signal: vote_margin
+    depends_on:
+    - cheap_model
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: answerer
+  kind: cascade
+  placement: post
+  arms:
+  - stage: cheap_stage
+    tuned_params:
+    - cheap_model
+  - stage: strong_stage
+    tuned_params:
+    - strong_model
+  gates:
+  - kind: margin_below
+    threshold: router.theta
+  max_iters: 3

--- a/spec/examples/validation-phase7-composites/unknown_composite_kind-fourth-kind.tvl.yml
+++ b/spec/examples/validation-phase7-composites/unknown_composite_kind-fourth-kind.tvl.yml
@@ -1,0 +1,50 @@
+# Expected: ERROR unknown_composite_kind — 'dag' is not in the sealed v1
+# registry (cascade | ensemble | loop). §3.2 item 1.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: router.theta
+  type: float
+  calibration:
+    source: pool
+    signal: vote_margin
+    depends_on:
+    - cheap_model
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: x
+  kind: dag
+  arms:
+  - stage: s
+  aggregate:
+    kind: majority_vote

--- a/spec/examples/validation-phase7-composites/unknown_gate_kind-unregistered-gate.tvl.yml
+++ b/spec/examples/validation-phase7-composites/unknown_gate_kind-unregistered-gate.tvl.yml
@@ -1,0 +1,57 @@
+# Expected: ERROR unknown_gate_kind — gate kind outside the v1 registry
+# (margin_below | signal_below). Reused RFC 0001 code. §3.2 GateDecl.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars:
+- name: router.theta
+  type: float
+  calibration:
+    source: pool
+    signal: vote_margin
+    depends_on:
+    - cheap_model
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: answerer
+  kind: cascade
+  placement: post
+  arms:
+  - stage: cheap_stage
+    tuned_params:
+    - cheap_model
+  - stage: strong_stage
+    tuned_params:
+    - strong_model
+  gates:
+  - kind: cost_above
+    threshold: router.theta

--- a/spec/examples/validation-phase7-composites/unknown_stop_kind-unregistered.tvl.yml
+++ b/spec/examples/validation-phase7-composites/unknown_stop_kind-unregistered.tvl.yml
@@ -1,0 +1,45 @@
+# Expected: ERROR unknown_stop_kind — stop.kind outside the v1 registry
+# (signal_accept | external_accept | exhausted). §3.2 StopDecl.
+tvl:
+  module: corp.validation.p7
+environment:
+  snapshot_id: '2026-06-06T00:00:00Z'
+evaluation_set:
+  dataset: s3://datasets/validation/dev.parquet
+tvars:
+- name: cheap_model
+  type: enum[str]
+  domain:
+  - a
+  - b
+- name: strong_model
+  type: enum[str]
+  domain:
+  - c
+  - d
+- name: k_samples
+  type: int
+  domain:
+    range:
+    - 1
+    - 9
+cvars: []
+constraints:
+  structural: []
+objectives:
+- name: quality
+  direction: maximize
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  min_effect:
+    quality: 0.02
+composites:
+- name: looper
+  kind: loop
+  body:
+    stage: s
+  state_keys: []
+  stop:
+    kind: converged
+  max_iters: 3

--- a/spec/grammar/tvl.ebnf
+++ b/spec/grammar/tvl.ebnf
@@ -1,7 +1,7 @@
 (* TVL — Abstract syntax oriented EBNF *)
 (* Formal specification for Tuned Variables Language *)
 
-module        = header, environment, evaluation_set, tvars, [ cvars ], constraints, objectives, promotion_policy, [ policies ], [exploration] ;
+module        = header, environment, evaluation_set, tvars, [ cvars ], constraints, objectives, promotion_policy, [ policies ], [ composites ], [exploration] ;
 
 header        = "tvl", ":", "{", "module", ":", ident, [",", "validation", ":", validation_opts], "}", [ "tvl_version", ":", string ] ;
 validation_opts = "{", [ "skip_budget_checks", ":", boolean ], [ ",", "skip_cost_estimation", ":", boolean ], "}" ;
@@ -50,6 +50,72 @@ policy_decl   = "{", "name", ":", ident, ",", "kind", ":", "policy",
                 [ ",", "parameters", ":", object ],
                 [ ",", scope_spec ], "}" ;
 gate_decl     = "{", "kind", ":", "margin_below", ",", "threshold", ":", ident, "}" ;
+
+(* TVL 1.2 (RFC 0002 §3.2/§3.9) — the sealed composite-knob algebra. A
+   composite is a namespace/expansion/provenance unit, NOT a binding kind: it
+   never enters Γ, the configuration space, or the dominance relation (§3.1).
+   The grammar is the closed surface; the kind/gate/aggregate/stop REGISTRIES,
+   arm resolution, acyclicity, threshold typing, and the signal/threshold
+   calibration binding are enforced by the normative lints (the same
+   shape-vs-registry layering RFC 0001 uses for policy strategy). A bare arm
+   identifier is ALWAYS a stage (back-compatible with policies.stages); nesting
+   REQUIRES the tagged { composite: ... } form. Modules with no composites block
+   parse byte-identically to TVL 1.1 (§4). *)
+composites    = "composites", ":", "[", [ composite_decl, { ",", composite_decl } ], "]" ;
+composite_decl= "{", "name", ":", ident, ",", "kind", ":", composite_kind,
+                ( cascade_body | ensemble_body | loop_body ),  (* discriminated by kind *)
+                [ ",", "pattern", ":", ident ],         (* the ONLY surface provenance key (§3.7 sugar) *)
+                [ ",", "parameters", ":", object ],      (* opaque operational map — OUTSIDE P8 *)
+                [ ",", scope_spec ], "}" ;
+composite_kind= "cascade" | "ensemble" | "loop" ;       (* SEALED registry *)
+
+(* Cascade body — |arms| = m ≥ 1, |gates| = m − 1, placement default post *)
+cascade_body  = [ ",", "placement", ":", ( "pre" | "post" ) ],
+                ",", "arms", ":", "[", arm_surface, { ",", arm_surface }, "]",
+                [ ",", "gates", ":", "[", [ composite_gate, { ",", composite_gate } ], "]" ] ;
+
+(* Ensemble body — cardinality REQUIRED iff |arms| = 1, FORBIDDEN if |arms| > 1 *)
+ensemble_body = ",", "arms", ":", "[", arm_surface, { ",", arm_surface }, "]",
+                [ ",", "cardinality", ":", ident ],     (* TVAR/CVAR of TVL type int; k ≥ 1 (R9) *)
+                ",", "aggregate", ":", aggregate_decl ;
+
+(* Loop body — max_iters REQUIRED bound (totality) *)
+loop_body     = ",", "body", ":", arm_surface,
+                [ ",", "state_keys", ":", "[", [ ident, { ",", ident } ], "]" ],
+                ",", "stop", ":", stop_decl,
+                ",", "max_iters", ":", integer ;
+
+(* The ONE arm surface form (§3.9): bare = stage(tuned_params []); tagged forms
+   are stage with explicit tuned_params, or { composite: ident } nesting. *)
+arm_surface   = ident
+              | "{", "stage", ":", ident, [ ",", "tuned_params", ":", "[", [ ident, { ",", ident } ], "]" ], "}"
+              | "{", "composite", ":", ident, "}" ;
+
+(* The signal surface form (§3.9): everywhere a SignalUse appears *)
+signal_surface= "{", "signal", ":", ident, [ ",", "inputs", ":", "[", [ ident, { ",", ident } ], "]" ], "}" ;
+
+(* Composite cascade gate — margin_below (POST-only) | signal_below (PRE-only) *)
+composite_gate= "{", "kind", ":", gate_kind, ",", "threshold", ":", ident,
+                [ ",", "signal", ":", signal_surface ], "}" ;  (* signal REQUIRED iff signal_below *)
+gate_kind     = "margin_below" | "signal_below" ;       (* v1 registry *)
+
+(* Ensemble aggregate — majority_vote | judge_max; judge REQUIRED iff judge_max *)
+aggregate_decl= "{", "kind", ":", aggregate_kind,
+                [ ",", "judge", ":", arm_surface ],
+                [ ",", "accept", ":", accept_decl ], "}" ;
+aggregate_kind= "majority_vote" | "judge_max" ;         (* v1 registry *)
+
+(* Optional ensemble acceptance — direction ≥, DISTINCT from cascade < *)
+accept_decl   = "{", "kind", ":", "stat_at_least",
+                ",", "stat", ":", ( "vote_margin" | "vote_agreement" ),
+                ",", "threshold", ":", ident, "}" ;
+
+(* Loop stop — signal_accept (unroll-eligible) | external_accept | exhausted *)
+stop_decl     = "{", "kind", ":", stop_kind,
+                [ ",", "threshold", ":", ident ],       (* REQUIRED iff signal_accept *)
+                [ ",", "signal", ":", signal_surface ], (* REQUIRED iff signal_accept; inputs ⊆ state_keys *)
+                [ ",", "predicate", ":", ident ], "}" ; (* REQUIRED iff external_accept; opaque, outside P8 *)
+stop_kind     = "signal_accept" | "external_accept" | "exhausted" ;  (* v1 registry *)
 
 (* Type grammar - complete specification *)
 type          = base_type | compound_type ;
@@ -127,8 +193,10 @@ promotion_policy = "promotion_policy", ":", "{",
 require_calibration_spec = "require_calibration", ":", "{",
                    "enabled", ":", boolean,
                    [ ",", "hash_covered_context", ":", "[", [ ctx_ext_key, { ",", ctx_ext_key } ], "]" ],
+                   [ ",", "signal_inputs", ":", "[", [ ident, { ",", ident } ], "]" ],  (* TVL 1.2: the ordered value covered under the signal_inputs key (§3.2 item 11) *)
                    "}" ;
-ctx_ext_key   = "stage_versions" | "model_versions" | "budget_assumptions" | "cost_assumptions" ;
+ctx_ext_key   = "stage_versions" | "model_versions" | "budget_assumptions" | "cost_assumptions"
+              | "signal_inputs" ;   (* TVL 1.2 (RFC 0002 §3.2 item 11): use-site SignalUse.inputs freshness *)
 
 exploration   = "exploration", ":", "{",
                 "strategy", ":", "{", "type", ":", ("random" | "grid" | "tpe" | "cmaes" | "nsga2" | "custom"), { "," key, ":", value }, "}",

--- a/spec/grammar/tvl.schema.json
+++ b/spec/grammar/tvl.schema.json
@@ -100,6 +100,11 @@
       "description": "TVL 1.1 (RFC 0001): named operational policy declarations (first strategy: cascade). Operational layer — never enters Γ, F^str, or the dominance relation.",
       "items": { "$ref": "#/$defs/PolicyDecl" }
     },
+    "composites": {
+      "type": "array",
+      "description": "TVL 1.2 (RFC 0002): the sealed composite-knob algebra — named bundles of member knobs and gate declarations under a declared control-flow shape (cascade | ensemble | loop). A composite is a namespace/expansion/provenance unit, NOT a binding kind: it never enters Γ, the configuration space, or the dominance relation (§3.1). Conservative extension — a module with no composites block parses byte-identically to TVL 1.1 (§4).",
+      "items": { "$ref": "#/$defs/Composite" }
+    },
     "constraints": {
       "type": "object",
       "description": "Constraint sets split between structural (TVAR formulas) and derived (linear constraints over numeric `env.context.*` symbols) clauses.",
@@ -226,10 +231,18 @@
             "enabled": { "type": "boolean" },
             "hash_covered_context": {
               "type": "array",
-              "description": "Optional extension keys added to the always-hashed ctx_core.",
+              "description": "Optional extension keys added to the always-hashed ctx_core. TVL 1.2 (RFC 0002 §3.2 item 11) adds 'signal_inputs' — the use-site SignalUse.inputs that select which keys the scoring function reads (conservative: an optional extension key; ctx_core is untouched).",
               "items": {
-                "enum": ["stage_versions", "model_versions", "budget_assumptions", "cost_assumptions"]
+                "enum": ["stage_versions", "model_versions", "budget_assumptions", "cost_assumptions", "signal_inputs"]
               }
+            },
+            "signal_inputs": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$"
+              },
+              "description": "TVL 1.2 (RFC 0002 §3.2 item 11): the ordered value covered under the 'signal_inputs' freshness-context key — the input-key list the calibration held fixed. A composite-bound threshold whose governing SignalUse has non-empty inputs requires this to be present (in hash_covered_context) AND equal to the use-site ordered input list (unbound_signal_inputs)."
             }
           }
         }
@@ -431,6 +444,160 @@
           "description": "Opaque operational map — explicitly OUTSIDE the P8 privacy guarantee."
         },
         "scope": { "$ref": "#/$defs/Scope" }
+      }
+    },
+    "Composite": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["name", "kind"],
+      "description": "TVL 1.2 (RFC 0002 §3.2/§3.9): a composite-knob declaration. The schema checks SHAPE only and is deliberately OPEN (additionalProperties:true): §3.11 makes the body-field discipline a NORMATIVE LINT (unknown_composite_field for unknown/cross-kind fields; composite_binds_value for a bound value), in 1:1 correspondence with the well-formedness rules. The kind REGISTRY (cascade|ensemble|loop), arm/gate/stop/aggregate registries, namespace references, threshold types, cardinality arity, acyclicity, and the signal/threshold calibration binding are likewise enforced by the lints — the same shape-vs-registry layering RFC 0001 uses for PolicyDecl.strategy, taken one step further so the closed-shape diagnostics are the lints' own (not generic schema_error).",
+      "properties": {
+        "name": {
+          "type": "string",
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$",
+          "description": "Unique name in the shared tvars ∪ cvars ∪ policies ∪ composites namespace (N_X). Shadowing/duplication enforced by the lints."
+        },
+        "kind": {
+          "type": "string",
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$",
+          "description": "Constructor discriminator. The schema checks SHAPE only; the SEALED v1 registry (cascade | ensemble | loop) is enforced by the lints (unknown_composite_kind) so a fourth kind reports the normative diagnostic rather than a generic schema error."
+        },
+        "placement": {
+          "type": "string",
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*$",
+          "description": "Cascade only; default post. SHAPE-checked here; the pre|post registry and the kind/placement gate symmetry are enforced by the lints."
+        },
+        "arms": {
+          "type": "array",
+          "description": "Cascade/ensemble arms. Non-emptiness (empty_arms) and arity (cascade_arity, cardinality_arity_mismatch) are enforced by the lints.",
+          "items": { "$ref": "#/$defs/ArmSurface" }
+        },
+        "gates": {
+          "type": "array",
+          "description": "Cascade gates. |gates| = |arms| − 1 (cascade_arity) enforced by the lints.",
+          "items": { "$ref": "#/$defs/CompositeGateDecl" }
+        },
+        "cardinality": {
+          "type": "string",
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$",
+          "description": "Ensemble sampling-form sample count: a namespace reference to a TVAR or CVAR of TVL type int. Required iff |arms| = 1, forbidden if |arms| > 1 (cardinality_arity_mismatch); int-typed (invalid_cardinality_type); k≥1 is resolution-time R9 (invalid_cardinality_value)."
+        },
+        "aggregate": {
+          "$ref": "#/$defs/AggregateDecl",
+          "description": "Ensemble aggregation declaration."
+        },
+        "body": {
+          "$ref": "#/$defs/ArmSurface",
+          "description": "Loop body — a single arm."
+        },
+        "state_keys": {
+          "type": "array",
+          "description": "Loop threaded-state keys (content-free identifiers; [] ⟺ pure body).",
+          "items": {
+            "type": "string",
+            "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$"
+          }
+        },
+        "stop": {
+          "$ref": "#/$defs/StopDecl",
+          "description": "Loop stop declaration."
+        },
+        "max_iters": {
+          "type": "integer",
+          "description": "Loop iteration bound (totality). max_iters ≥ 1 enforced by the lints (invalid_max_iters)."
+        },
+        "pattern": {
+          "type": "string",
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$",
+          "description": "The ONLY surface provenance key (RFC 0002 §3.7/§3.9): a flat sugar key mapping to Provenance.pattern. The full closed Provenance object is expansion-output metadata (SDK-internal) — never surface syntax."
+        },
+        "parameters": {
+          "type": "object",
+          "description": "Opaque operational map — explicitly OUTSIDE the P8 privacy guarantee, exactly as PolicyDecl.parameters (§3.2)."
+        },
+        "scope": { "$ref": "#/$defs/Scope" }
+      }
+    },
+    "ArmSurface": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Bare identifier = a stage arm with empty tuned_params (back-compatible with policies.stages). A bare id colliding with a composite name is rejected by the lints (ambiguous_arm)."
+        },
+        {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Object arm form: a stage arm {stage, tuned_params?} or a tagged nesting {composite}. The schema is OPEN (additionalProperties:true) and shape-permissive: §3.9 makes the closed-shape check a NORMATIVE LINT (invalid_arm_shape for unknown/ambiguous keys; missing_composite_ref for an unresolved nesting; invalid_tuned_param for non-TVAR tuned_params).",
+          "properties": {
+            "stage": { "type": "string" },
+            "composite": { "type": "string" },
+            "tuned_params": { "type": "array" }
+          }
+        }
+      ],
+      "description": "TVL 1.2 (RFC 0002 §3.9): the ONE arm surface form, used everywhere an Arm appears (cascade arms, loop body, ensemble arms and judge)."
+    },
+    "SignalSurface": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "TVL 1.2 (RFC 0002 §3.9): the SignalUse surface form (signal_below gates and signal_accept stops). signal names a registry signal exactly as calibration.signal does. The schema is OPEN: §3.2/§3.9 make the closed-shape check a NORMATIVE LINT — a malformed SignalUse (missing 'signal', unknown keys, non-list 'inputs') rejects invalid_signal_use, and stop inputs ⊄ state_keys rejects stop_signal_outside_state.",
+      "properties": {
+        "signal": { "type": "string" },
+        "inputs": {
+          "description": "Declared input keys the signal reads. For stops MUST ⊆ state_keys (stop_signal_outside_state); for pre-gates, opaque input-feature identifiers. A non-list value rejects invalid_signal_use (lint)."
+        }
+      }
+    },
+    "CompositeGateDecl": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "threshold"],
+      "description": "TVL 1.2 (RFC 0002 §3.2): a composite cascade gate. The gate-kind registry (margin_below | signal_below — unknown_gate_kind, reused from RFC 0001), kind/placement symmetry, margin-bearing arm typing, signal requirement, and threshold-as-CVAR/int-or-float are enforced by the lints.",
+      "properties": {
+        "kind": { "type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*$" },
+        "threshold": { "type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$" },
+        "signal": { "$ref": "#/$defs/SignalSurface" }
+      }
+    },
+    "AggregateDecl": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "description": "TVL 1.2 (RFC 0002 §3.2): ensemble aggregation. The aggregate-kind registry (majority_vote | judge_max — unknown_aggregate_kind), the judge requirement (missing_judge iff judge_max), and accept-threshold-as-CVAR are enforced by the lints.",
+      "properties": {
+        "kind": { "type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*$" },
+        "judge": {
+          "$ref": "#/$defs/ArmSurface",
+          "description": "REQUIRED iff kind=judge_max; stage- or composite-tagged (missing_judge)."
+        },
+        "accept": { "$ref": "#/$defs/AcceptDecl" }
+      }
+    },
+    "AcceptDecl": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "stat", "threshold"],
+      "description": "TVL 1.2 (RFC 0002 §3.2): optional ensemble acceptance (either aggregate kind). Acceptance direction is ≥ — deliberately DISTINCT from cascade escalation's <. kind=stat_at_least, stat ∈ {vote_margin, vote_agreement} (registries enforced by the lints); threshold MUST resolve to a CVAR.",
+      "properties": {
+        "kind": { "type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*$" },
+        "stat": { "type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$" },
+        "threshold": { "type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$" }
+      }
+    },
+    "StopDecl": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "description": "TVL 1.2 (RFC 0002 §3.2): loop stop. The stop-kind registry (signal_accept | external_accept | exhausted — unknown_stop_kind), the per-kind required fields (missing_stop_threshold / missing_stop_signal iff signal_accept; missing_stop_predicate iff external_accept), the signal-input ⊆ state_keys rule (stop_signal_outside_state), and threshold-as-CVAR/int-or-float are enforced by the lints.",
+      "properties": {
+        "kind": { "type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*$" },
+        "threshold": { "type": "string", "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$" },
+        "signal": { "$ref": "#/$defs/SignalSurface" },
+        "predicate": {
+          "type": "string",
+          "pattern": "^[A-Za-z_][A-Za-z0-9_]*(\\.[A-Za-z_][A-Za-z0-9_]*)*$",
+          "description": "REQUIRED iff kind=external_accept: OPAQUE runtime predicate id (StageRef-style — outside P8)."
+        }
       }
     },
     "DomainSpec": {

--- a/tests/model_checking/composites_model.py
+++ b/tests/model_checking/composites_model.py
@@ -1,0 +1,798 @@
+"""Finite abstraction of RFC 0002 §3 — the sealed composite-knob algebra.
+
+This is a MODEL, not the implementation: the value spaces are tiny and the
+derived functions transcribe the RFC clauses one-to-one so the property checks
+in ``test_composites_c1_c6.py`` read like the spec. It follows the RFC 0001
+house convention (``model.py``): small dataclasses + plain functions, no new
+dependencies, exhaustive enumeration in the tests.
+
+PINNED RFC REVISION: DRAFT v7 — formalization/rfc-0002-composite-knobs.md.
+Where the /tmp/p3-alloy-final.md skeleton (a conceptual map) conflicts with
+v7's final text, THE RFC WINS. In particular this model follows the v6/v7
+semantics the captain note flagged: closed ``ArmResult`` (§3.2.1),
+``gate_arm_incompatible`` / ``gate_kind_placement_mismatch`` /
+``missing_gate_signal`` gate typing (§3.2 item 5), ``signal_inputs`` freshness
+(§3.2 item 11), and the K-chain semantic compilation (§3.8).
+
+Section references are to that revision.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, FrozenSet, List, Optional, Sequence, Set, Tuple
+
+# ---------------------------------------------------------------------------
+# Sealed registries — §3.2. Each is a CLOSED enum: a fourth member is a new
+# RFC, not a registry entry (the sealing that buys the C1/C2 theorems).
+# ---------------------------------------------------------------------------
+
+
+class CompositeKind(Enum):
+    """SEALED constructor registry — §3.2. Exactly three kinds."""
+
+    CASCADE = "cascade"
+    ENSEMBLE = "ensemble"
+    LOOP = "loop"
+
+
+class Placement(Enum):
+    PRE = "pre"
+    POST = "post"
+
+
+class GateKind(Enum):
+    MARGIN_BELOW = "margin_below"  # POST-only, margin-bearing gated arm
+    SIGNAL_BELOW = "signal_below"  # PRE-only, requires a signal
+
+
+class AggregateKind(Enum):
+    MAJORITY_VOTE = "majority_vote"
+    JUDGE_MAX = "judge_max"
+
+
+class AcceptKind(Enum):
+    STAT_AT_LEAST = "stat_at_least"  # acceptance direction ≥ (distinct from < )
+
+
+class AcceptStat(Enum):
+    VOTE_MARGIN = "vote_margin"
+    VOTE_AGREEMENT = "vote_agreement"
+
+
+class StopKind(Enum):
+    SIGNAL_ACCEPT = "signal_accept"  # the only unroll-eligible kind (§3.8)
+    EXTERNAL_ACCEPT = "external_accept"
+    EXHAUSTED = "exhausted"
+
+
+# Canonical vote-statistic ids that live in the SAME registry namespace as
+# named signals (§3.2 item 11): sig(margin_below) = "vote_margin".
+CANONICAL_VOTE_MARGIN = "vote_margin"
+
+
+# ---------------------------------------------------------------------------
+# Sub-declarations — §3.2.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SignalUse:
+    """A named signal reference + its declared input keys (§3.2 / §3.9)."""
+
+    signal: str
+    inputs: Tuple[str, ...] = ()  # default [] ; for stops MUST ⊆ state_keys
+
+
+@dataclass(frozen=True)
+class GateDecl:
+    kind: GateKind
+    threshold: str  # MUST resolve to an int/float CVAR
+    signal: Optional[SignalUse] = None  # REQUIRED iff kind=signal_below
+
+
+@dataclass(frozen=True)
+class AcceptDecl:
+    stat: AcceptStat
+    threshold: str  # MUST resolve to a CVAR
+    kind: AcceptKind = AcceptKind.STAT_AT_LEAST
+
+
+@dataclass(frozen=True)
+class StopDecl:
+    kind: StopKind
+    threshold: Optional[str] = None  # REQUIRED iff signal_accept
+    signal: Optional[SignalUse] = None  # REQUIRED iff signal_accept
+    predicate: Optional[str] = None  # REQUIRED iff external_accept (opaque)
+
+
+# ---------------------------------------------------------------------------
+# Tagged Arm — §3.2. stage(name, tuned_params) | composite(name).
+# (The model uses two explicit tags; the surface "bare = stage" sugar of §3.9
+# is a parsing concern, not an algebra distinction — a bare arm is a
+# ``stage_arm`` with empty tuned_params here.)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Arm:
+    """A TAGGED arm. Exactly one of (stage, composite_ref) is populated."""
+
+    stage: Optional[str] = None
+    tuned_params: Tuple[str, ...] = ()  # TVAR refs parameterizing the stage
+    composite_ref: Optional[str] = None  # exact-match into N_X
+
+    @property
+    def is_stage(self) -> bool:
+        return self.stage is not None and self.composite_ref is None
+
+    @property
+    def is_composite(self) -> bool:
+        return self.composite_ref is not None and self.stage is None
+
+
+def stage_arm(name: str, tuned_params: Sequence[str] = ()) -> Arm:
+    return Arm(stage=name, tuned_params=tuple(tuned_params))
+
+
+def composite_arm(name: str) -> Arm:
+    return Arm(composite_ref=name)
+
+
+# ---------------------------------------------------------------------------
+# Constructor bodies — §3.2 (discriminated by kind).
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AggregateDecl:
+    kind: AggregateKind
+    judge: Optional[Arm] = None  # REQUIRED iff kind=judge_max
+    accept: Optional[AcceptDecl] = None
+
+
+@dataclass(frozen=True)
+class Cascade:
+    arms: Tuple[Arm, ...]  # |arms| = m ≥ 1
+    gates: Tuple[GateDecl, ...] = ()  # |gates| = m − 1
+    placement: Placement = Placement.POST
+
+
+@dataclass(frozen=True)
+class Ensemble:
+    arms: Tuple[Arm, ...]  # |arms| ≥ 1
+    aggregate: AggregateDecl = field(
+        default_factory=lambda: AggregateDecl(AggregateKind.MAJORITY_VOTE)
+    )
+    cardinality: Optional[str] = None  # REQUIRED iff |arms|==1, FORBIDDEN if >1
+
+
+@dataclass(frozen=True)
+class Loop:
+    body: Arm
+    stop: StopDecl
+    max_iters: int  # REQUIRED bound ≥ 1
+    state_keys: Tuple[str, ...] = ()  # [] ⟺ body treated pure
+
+
+@dataclass(frozen=True)
+class Composite:
+    """A CompositeKnob — §3.2. ``binds_value`` models the §3.1 rejection.
+
+    Exactly one body field matches ``kind`` for a well-formed node (C1).
+    """
+
+    name: str
+    kind: CompositeKind
+    cascade: Optional[Cascade] = None
+    ensemble: Optional[Ensemble] = None
+    loop: Optional[Loop] = None
+    binds_value: bool = False  # §3.1: a value bound on a composite -> reject
+
+
+# A module-level environment for resolving names (TVARs / CVARs / N_X).
+@dataclass(frozen=True)
+class Env:
+    n_t: FrozenSet[str] = frozenset()  # declared TVAR names
+    n_c: FrozenSet[str] = frozenset()  # declared CVAR names
+    composites: Tuple[Composite, ...] = ()
+
+    @property
+    def n_x(self) -> Dict[str, Composite]:
+        return {c.name: c for c in self.composites}
+
+
+# ===========================================================================
+# C1 — Kind partition. Exactly one body matches the kind, no value bound.
+# ===========================================================================
+
+
+def body_fields(c: Composite) -> List[str]:
+    """Names of the populated body fields (for partition checking)."""
+    present = []
+    if c.cascade is not None:
+        present.append("cascade")
+    if c.ensemble is not None:
+        present.append("ensemble")
+    if c.loop is not None:
+        present.append("loop")
+    return present
+
+
+_KIND_TO_FIELD = {
+    CompositeKind.CASCADE: "cascade",
+    CompositeKind.ENSEMBLE: "ensemble",
+    CompositeKind.LOOP: "loop",
+}
+
+
+def well_formed_kind(c: Composite) -> bool:
+    """C1 / §3.2 item 1: exactly the one body field of the declared kind is
+    present, and no value is bound (§3.1)."""
+    if c.binds_value:
+        return False
+    present = body_fields(c)
+    return present == [_KIND_TO_FIELD[c.kind]]
+
+
+# --- The closed, total, deterministic result algebra — §3.2.1. -------------
+
+
+class ArmResultKind(Enum):
+    OUTPUT = "output"
+    NO_ACCEPT = "no_accept"
+    ERROR = "error"
+
+
+@dataclass(frozen=True)
+class ArmResult:
+    """``output(o, vote_stats?) | no_accept | error`` — §3.2.1.
+
+    ``out`` present iff OUTPUT; ``vote_stats`` (a margin) present iff the
+    producer is margin-bearing (stage or majority_vote ensemble).
+    """
+
+    kind: ArmResultKind
+    out: Optional[str] = None
+    vote_stats: Optional[float] = None  # margin, iff margin-bearing
+
+
+def result_well_formed(r: ArmResult) -> bool:
+    """§3.2.1: the three kinds are disjoint & exhaustive; ``out`` present iff
+    OUTPUT. (vote_stats is an optional annotation on OUTPUT only.)"""
+    if r.kind == ArmResultKind.OUTPUT:
+        return r.out is not None
+    # non-output carries neither an output nor vote stats
+    return r.out is None and r.vote_stats is None
+
+
+def output(o: str, vote_stats: Optional[float] = None) -> ArmResult:
+    return ArmResult(ArmResultKind.OUTPUT, out=o, vote_stats=vote_stats)
+
+
+NO_ACCEPT = ArmResult(ArmResultKind.NO_ACCEPT)
+ERROR = ArmResult(ArmResultKind.ERROR)
+
+
+# ===========================================================================
+# C2 — Nesting acyclicity & finite expansion. §3.2 item 4.
+# ===========================================================================
+
+
+def child_refs(c: Composite) -> List[str]:
+    """The composite names ``c`` references as nested arms (§3.2 item 4).
+
+    Covers cascade arms, ensemble arms + judge, and loop body — every Arm
+    position. ``stage(·)`` is opaque and never consults the namespace.
+    """
+    refs: List[str] = []
+    arms: List[Arm] = []
+    if c.cascade is not None:
+        arms.extend(c.cascade.arms)
+    if c.ensemble is not None:
+        arms.extend(c.ensemble.arms)
+        if c.ensemble.aggregate.judge is not None:
+            arms.append(c.ensemble.aggregate.judge)
+    if c.loop is not None:
+        arms.append(c.loop.body)
+    for a in arms:
+        if a.is_composite:
+            refs.append(a.composite_ref)  # type: ignore[arg-type]
+    return refs
+
+
+def reachable(env: Env, start: str) -> Set[str]:
+    """Transitive closure of ``child_refs`` from ``start`` (may be missing)."""
+    seen: Set[str] = set()
+    stack = [start]
+    while stack:
+        cur = stack.pop()
+        comp = env.n_x.get(cur)
+        if comp is None:
+            continue
+        for ref in child_refs(comp):
+            if ref not in seen:
+                seen.add(ref)
+                stack.append(ref)
+    return seen
+
+
+def has_cycle(env: Env) -> bool:
+    """C2 / §3.2 item 4: is the ``composite(·)`` reference graph over N_X
+    cyclic? DFS with a recursion stack (catches self-loops and k-cycles)."""
+    WHITE, GREY, BLACK = 0, 1, 2
+    color: Dict[str, int] = {c.name: WHITE for c in env.composites}
+
+    def visit(name: str) -> bool:
+        color[name] = GREY
+        for ref in child_refs(env.n_x[name]):
+            if ref not in color:
+                continue  # dangling ref — a different lint (missing_composite_ref)
+            if color[ref] == GREY:
+                return True
+            if color[ref] == WHITE and visit(ref):
+                return True
+        color[name] = BLACK
+        return False
+
+    return any(color[c.name] == WHITE and visit(c.name) for c in env.composites)
+
+
+def missing_composite_refs(env: Env) -> List[Tuple[str, str]]:
+    """§3.2 item 3: ``composite(x)`` that resolves to no N_X member."""
+    gaps: List[Tuple[str, str]] = []
+    for c in env.composites:
+        for ref in child_refs(c):
+            if ref not in env.n_x:
+                gaps.append((c.name, ref))
+    return gaps
+
+
+def roots(env: Env) -> List[Composite]:
+    """§3.6 root consumption: every declared composite NOT referenced as a
+    nested arm of another. (Computed over the whole N_X graph.)"""
+    referenced: Set[str] = set()
+    for c in env.composites:
+        referenced.update(child_refs(c))
+    return [c for c in env.composites if c.name not in referenced]
+
+
+# ===========================================================================
+# C6 — leafT (§3.5) and required_parents (§3.5). TVAR-only codomain.
+# ===========================================================================
+
+
+def _arms_body_judge(c: Composite) -> List[Arm]:
+    """The arms/body/judge over which leafT(composite(x)) recurses (§3.5)."""
+    arms: List[Arm] = []
+    if c.cascade is not None:
+        arms.extend(c.cascade.arms)
+    if c.ensemble is not None:
+        arms.extend(c.ensemble.arms)
+        if c.ensemble.aggregate.judge is not None:
+            arms.append(c.ensemble.aggregate.judge)
+    if c.loop is not None:
+        arms.append(c.loop.body)
+    return arms
+
+
+def leaf_t_arm(env: Env, a: Arm) -> FrozenSet[str]:
+    """leafT over an Arm — §3.5.
+
+    leafT(stage(s, ps)) = ps  (intersected with N_T — declared TVARs only)
+    leafT(composite(x)) = ⋃ leafT(arms/body/judge) ∪ ({cardinality} ∩ N_T)
+    """
+    if a.is_stage:
+        # tuned_params resolve to TVARs only (§3.2 item 9); the intersection
+        # keeps the codomain TVAR-only even if an entry is malformed.
+        return frozenset(p for p in a.tuned_params if p in env.n_t)
+    if a.is_composite:
+        comp = env.n_x.get(a.composite_ref)  # type: ignore[arg-type]
+        if comp is None:
+            return frozenset()
+        return leaf_t_composite(env, comp)
+    return frozenset()
+
+
+def leaf_t_composite(env: Env, c: Composite) -> FrozenSet[str]:
+    """leafT(composite(x)) — §3.5, folding in the tuned ensemble cardinality."""
+    acc: Set[str] = set()
+    for a in _arms_body_judge(c):
+        acc |= leaf_t_arm(env, a)
+    # ({cardinality} ∩ N_T): a sampling-form ensemble whose k is a TVAR.
+    if c.ensemble is not None and c.ensemble.cardinality is not None:
+        if c.ensemble.cardinality in env.n_t:
+            acc.add(c.ensemble.cardinality)
+    return frozenset(acc)
+
+
+def required_parents(env: Env, c: Composite) -> Dict[str, FrozenSet[str]]:
+    """required_parents(θ) per §3.5, keyed by threshold CVAR name.
+
+    Post-cascade θ_i : leafT(a₁) ∪ … ∪ leafT(a_i)
+    Pre-cascade  θ_i : leafT(a_i)            (the arm the gate admits)
+    Ensemble.accept θ: ⋃_j leafT(a_j) ∪ leafT(judge?) ∪ ({cardinality} ∩ N_T)
+    Loop.stop θ      : leafT(body)
+    """
+    out: Dict[str, FrozenSet[str]] = {}
+    if c.cascade is not None:
+        casc = c.cascade
+        if casc.placement == Placement.POST:
+            # gate g_i (0-based i) reads arms a_1..a_{i+1}; in the post form
+            # the gated arm i (1-based) is arms[i], so the obligation accrues
+            # leafT(a_1)..leafT(a_i). Gate j (0-based) gates arm index j+1.
+            prefix: Set[str] = set()
+            for j, gate in enumerate(casc.gates):
+                # accumulate through the arm the gate guards (arms[0..j+1])
+                for k in range(j + 2):
+                    if k < len(casc.arms):
+                        prefix |= leaf_t_arm(env, casc.arms[k])
+                out[gate.threshold] = frozenset(prefix)
+        else:  # PRE: each routing gate i admits arm a_i (the arm the gate guards)
+            for j, gate in enumerate(casc.gates):
+                arm = casc.arms[j] if j < len(casc.arms) else None
+                out[gate.threshold] = (
+                    leaf_t_arm(env, arm) if arm is not None else frozenset()
+                )
+    if c.ensemble is not None:
+        ens = c.ensemble
+        if ens.aggregate.accept is not None:
+            acc: Set[str] = set()
+            for a in ens.arms:
+                acc |= leaf_t_arm(env, a)
+            if ens.aggregate.judge is not None:
+                acc |= leaf_t_arm(env, ens.aggregate.judge)
+            if ens.cardinality is not None and ens.cardinality in env.n_t:
+                acc.add(ens.cardinality)
+            out[ens.aggregate.accept.threshold] = frozenset(acc)
+    if c.loop is not None:
+        loop = c.loop
+        if loop.stop.kind == StopKind.SIGNAL_ACCEPT and loop.stop.threshold:
+            out[loop.stop.threshold] = leaf_t_arm(env, loop.body)
+    return out
+
+
+def missing_composite_parent(
+    env: Env, depends_on: Dict[str, FrozenSet[str]]
+) -> List[Tuple[str, FrozenSet[str]]]:
+    """§3.5 lint: required_parents(θ) ⊆ depends_on(θ) for every threshold CVAR
+    over all roots. Returns the (θ, missing-set) gaps."""
+    gaps: List[Tuple[str, FrozenSet[str]]] = []
+    for r in roots(env):
+        for theta, req in required_parents(env, r).items():
+            have = depends_on.get(theta, frozenset())
+            missing = req - have
+            if missing:
+                gaps.append((theta, missing))
+    return gaps
+
+
+# ===========================================================================
+# C3 — Certificate coverage fold Cal (§3.6) + a ground-truth member walk.
+# ===========================================================================
+
+
+def cal_aggregate(env: Env, agg: AggregateDecl) -> FrozenSet[str]:
+    acc: Set[str] = set()
+    if agg.judge is not None:
+        # Cal(agg.judge if present): a stage judge contributes ∅; a composite
+        # judge contributes Cal(body(judge)).
+        acc |= cal_arm(env, agg.judge)
+    if agg.accept is not None:
+        acc.add(agg.accept.threshold)
+    return frozenset(acc)
+
+
+def cal_arm(env: Env, a: Arm) -> FrozenSet[str]:
+    """Cal(stage) = ∅ ; Cal(composite(x)) = Cal(body(x)) — §3.6."""
+    if a.is_composite:
+        comp = env.n_x.get(a.composite_ref)  # type: ignore[arg-type]
+        if comp is None:
+            return frozenset()
+        return cal_composite(env, comp)
+    return frozenset()
+
+
+def cal_composite(env: Env, c: Composite) -> FrozenSet[str]:
+    """Cal : Composite → ℘(N_C) — §3.6 (the fold under test)."""
+    acc: Set[str] = set()
+    if c.cascade is not None:
+        for a in c.cascade.arms:
+            acc |= cal_arm(env, a)
+        for g in c.cascade.gates:
+            acc.add(g.threshold)
+    if c.ensemble is not None:
+        for a in c.ensemble.arms:
+            acc |= cal_arm(env, a)
+        acc |= cal_aggregate(env, c.ensemble.aggregate)
+        # ({k} ∩ N_C): a calibrated cardinality is a member of Cal.
+        if c.ensemble.cardinality is not None and c.ensemble.cardinality in env.n_c:
+            acc.add(c.ensemble.cardinality)
+    if c.loop is not None:
+        acc |= cal_arm(env, c.loop.body)
+        if c.loop.stop.kind == StopKind.SIGNAL_ACCEPT and c.loop.stop.threshold:
+            acc.add(c.loop.stop.threshold)
+    return frozenset(acc)
+
+
+def cal_roots(env: Env) -> FrozenSet[str]:
+    """⋃_{r ∈ roots(M)} Cal(r) — the strict-selection coverage set (§3.6)."""
+    acc: Set[str] = set()
+    for r in roots(env):
+        acc |= cal_composite(env, r)
+    return frozenset(acc)
+
+
+def member_walk_cal(env: Env, c: Composite, _seen: Optional[Set[str]] = None) -> FrozenSet[str]:
+    """INDEPENDENT ground-truth: walk every member of the whole expansion and
+    collect every gate/accept/stop threshold + calibrated cardinality, through
+    nesting incl. judge arms. Implemented differently from ``cal_composite``
+    (explicit recursive descent over expanded members) so the C3 equality is a
+    real cross-check, not a tautology."""
+    seen = set() if _seen is None else _seen
+    found: Set[str] = set()
+
+    def descend_arm(a: Arm) -> None:
+        if a.is_composite:
+            ref = a.composite_ref
+            if ref is None or ref in seen:
+                return
+            comp = env.n_x.get(ref)
+            if comp is None:
+                return
+            seen.add(ref)
+            found.update(member_walk_cal(env, comp, seen))
+
+    if c.cascade is not None:
+        for g in c.cascade.gates:
+            found.add(g.threshold)
+        for a in c.cascade.arms:
+            descend_arm(a)
+    if c.ensemble is not None:
+        for a in c.ensemble.arms:
+            descend_arm(a)
+        agg = c.ensemble.aggregate
+        if agg.accept is not None:
+            found.add(agg.accept.threshold)
+        if agg.judge is not None:
+            descend_arm(agg.judge)
+        if c.ensemble.cardinality is not None and c.ensemble.cardinality in env.n_c:
+            found.add(c.ensemble.cardinality)
+    if c.loop is not None:
+        descend_arm(c.loop.body)
+        if c.loop.stop.kind == StopKind.SIGNAL_ACCEPT and c.loop.stop.threshold:
+            found.add(c.loop.stop.threshold)
+    return frozenset(found)
+
+
+def calibration_pass(certified_fresh: FrozenSet[str], coverage: FrozenSet[str]) -> bool:
+    """Strict selection — §3.6: every CVAR in ``coverage`` must carry a valid,
+    fresh certificate. Fail-closed: any gap ⇒ no certified selection."""
+    return coverage <= certified_fresh
+
+
+# A deliberately-broken fold variant (C3 teeth): drops judge arms. The
+# ground-truth walk must CATCH the difference.
+def cal_composite_drop_judge(env: Env, c: Composite) -> FrozenSet[str]:
+    acc: Set[str] = set()
+    if c.cascade is not None:
+        for a in c.cascade.arms:
+            acc |= cal_arm_drop_judge(env, a)
+        for g in c.cascade.gates:
+            acc.add(g.threshold)
+    if c.ensemble is not None:
+        for a in c.ensemble.arms:
+            acc |= cal_arm_drop_judge(env, a)
+        if c.ensemble.aggregate.accept is not None:
+            acc.add(c.ensemble.aggregate.accept.threshold)
+        # BUG: judge arm's Cal is dropped entirely.
+        if c.ensemble.cardinality is not None and c.ensemble.cardinality in env.n_c:
+            acc.add(c.ensemble.cardinality)
+    if c.loop is not None:
+        acc |= cal_arm_drop_judge(env, c.loop.body)
+        if c.loop.stop.kind == StopKind.SIGNAL_ACCEPT and c.loop.stop.threshold:
+            acc.add(c.loop.stop.threshold)
+    return frozenset(acc)
+
+
+def cal_arm_drop_judge(env: Env, a: Arm) -> FrozenSet[str]:
+    if a.is_composite:
+        comp = env.n_x.get(a.composite_ref)  # type: ignore[arg-type]
+        if comp is None:
+            return frozenset()
+        return cal_composite_drop_judge(env, comp)
+    return frozenset()
+
+
+# ===========================================================================
+# C4 — Cost forms (§3.4). Structural FORM closure only — symbolic terms.
+# ===========================================================================
+
+
+class CostForm(Enum):
+    """The five §3.4 cost forms (symbolic — no arithmetic)."""
+
+    STAGE = "stage"  # cost(stage s) = c(s)
+    CASCADE_POST = "cascade_post"  # cost(a1) + Σ P·cost(a_{i+1})
+    CASCADE_PRE = "cascade_pre"  # Σ P·c(σ) + Σ P·cost(a_i)
+    ENSEMBLE_SAMPLING = "ensemble_sampling"  # k·cost(a) + c(agg)
+    ENSEMBLE_COMMITTEE = "ensemble_committee"  # Σ cost(a_j) + c(agg)
+    LOOP = "loop"  # E[iters]·(cost(b)+c(stop))
+
+
+@dataclass(frozen=True)
+class CostTerm:
+    """A symbolic cost term. ``kids`` are the sub-terms (arms' own forms).
+
+    A well-formed (closed) cost term has NO unexpanded composite reference in
+    its subtree — the §3.4 equations close over the algebra (C4)."""
+
+    form: CostForm
+    kids: Tuple["CostTerm", ...] = ()
+    composite_ref: Optional[str] = None  # set only on an UNEXPANDED ref (teeth)
+
+
+def cost_of_arm(env: Env, a: Arm, _seen: Optional[Set[str]] = None) -> CostTerm:
+    """Substituting an arm's cost form: a stage arm is a STAGE term; a
+    composite arm IS the referenced composite's cost form (§3.4)."""
+    seen = set() if _seen is None else _seen
+    if a.is_stage:
+        return CostTerm(CostForm.STAGE)
+    if a.is_composite:
+        ref = a.composite_ref
+        comp = env.n_x.get(ref) if ref is not None else None
+        if comp is None or (ref is not None and ref in seen):
+            # dangling/cyclic — represent as an unexpanded reference (not used
+            # in WF instances; cycles are rejected by C2).
+            return CostTerm(CostForm.STAGE, composite_ref=ref)
+        return cost_of_composite(env, comp, seen | ({ref} if ref else set()))
+    return CostTerm(CostForm.STAGE)
+
+
+def cost_of_composite(env: Env, c: Composite, _seen: Optional[Set[str]] = None) -> CostTerm:
+    """The composite's cost term, recursing into arm cost forms (§3.4)."""
+    seen = set() if _seen is None else _seen
+    if c.cascade is not None:
+        kids = tuple(cost_of_arm(env, a, seen) for a in c.cascade.arms)
+        form = (
+            CostForm.CASCADE_POST
+            if c.cascade.placement == Placement.POST
+            else CostForm.CASCADE_PRE
+        )
+        return CostTerm(form, kids)
+    if c.ensemble is not None:
+        kids = tuple(cost_of_arm(env, a, seen) for a in c.ensemble.arms)
+        if c.ensemble.aggregate.judge is not None:
+            kids = kids + (cost_of_arm(env, c.ensemble.aggregate.judge, seen),)
+        form = (
+            CostForm.ENSEMBLE_SAMPLING
+            if len(c.ensemble.arms) == 1
+            else CostForm.ENSEMBLE_COMMITTEE
+        )
+        return CostTerm(form, kids)
+    if c.loop is not None:
+        return CostTerm(CostForm.LOOP, (cost_of_arm(env, c.loop.body, seen),))
+    return CostTerm(CostForm.STAGE)
+
+
+def cost_is_closed(t: CostTerm) -> bool:
+    """C4: no unexpanded composite reference anywhere in the term tree —
+    the cost forms close over the algebra."""
+    if t.composite_ref is not None:
+        return False
+    return all(cost_is_closed(k) for k in t.kids)
+
+
+# ===========================================================================
+# C5 — Loop → K-chain semantic compilation (§3.8). signal_accept ONLY.
+# ===========================================================================
+
+
+def signal_accept_unrollable(loop: Loop) -> bool:
+    """§3.8: the unroll offer exists ONLY for signal_accept loops; K ≤ 4 here
+    (the model checking scope). external_accept / exhausted offer NO unroll."""
+    return loop.stop.kind == StopKind.SIGNAL_ACCEPT and 1 <= loop.max_iters <= 4
+
+
+@dataclass(frozen=True)
+class IterStep:
+    """One modeled iteration: the body's result this iteration and whether the
+    signal_accept stop fired (σ(state) ≥ θ). ``ambient`` models a hidden state
+    mutation that condition 1 of §3.8 forbids."""
+
+    body_result: ArmResult  # output / no_accept / error
+    stop_accepts: bool  # σ(state) ≥ θ — acceptance fired
+    ambient: bool = False  # condition-1 violation if True
+
+
+def loop_execute(loop: Loop, steps: Sequence[IterStep]) -> Tuple[ArmResult, Optional[int]]:
+    """Reference Loop semantics — §3.2.1 / §3.2 loop sentence.
+
+    Returns (final_result, selected_iteration_index | None).
+    - error is absorbing (first error fails the loop);
+    - signal_accept: an OUTPUT body whose stop fired is the accepted result;
+    - no_accept body continues to next iteration;
+    - reaching max_iters without acceptance yields no_accept.
+    """
+    n = min(loop.max_iters, len(steps))
+    for i in range(n):
+        st = steps[i]
+        if st.body_result.kind == ArmResultKind.ERROR:
+            return ERROR, None
+        if (
+            loop.stop.kind == StopKind.SIGNAL_ACCEPT
+            and st.body_result.kind == ArmResultKind.OUTPUT
+            and st.stop_accepts
+        ):
+            return st.body_result, i
+        # no_accept (or output-without-acceptance): continue
+    return NO_ACCEPT, None
+
+
+def kchain_execute(loop: Loop, steps: Sequence[IterStep]) -> Tuple[ArmResult, Optional[int]]:
+    """Internal K-chain semantics — §3.8.
+
+    KChain stages b₍₁₎..b₍K₎; escalate after stage i ⟺ ¬stop₍ᵢ₎ (σ < θ). The
+    chain's selected link is the first stage whose stop FIRED on an output.
+    This is a SEPARATE implementation from ``loop_execute`` so the C5 trace
+    comparison is a genuine cross-check.
+    """
+    K = loop.max_iters
+    for i in range(min(K, len(steps))):
+        st = steps[i]
+        if st.body_result.kind == ArmResultKind.ERROR:
+            return ERROR, None
+        escalate = not st.stop_accepts
+        if not escalate and st.body_result.kind == ArmResultKind.OUTPUT:
+            return st.body_result, i  # stop fired -> selected link
+        # escalate to next link
+    return NO_ACCEPT, None
+
+
+# ---------------------------------------------------------------------------
+# Static well-formedness lints used by several claims (subset, §3.2 items).
+# Returns a sorted list of (code, composite-name) — house diagnostic shape.
+# ---------------------------------------------------------------------------
+
+
+def gate_typing_diagnostics(env: Env, c: Composite) -> List[Tuple[str, str]]:
+    """§3.2 item 5 gate typing for a cascade composite (the subset C-tests
+    exercise): placement/kind symmetry, signal_below needs a signal, and
+    margin_below gates a margin-bearing arm."""
+    diags: List[Tuple[str, str]] = []
+    if c.cascade is None:
+        return diags
+    casc = c.cascade
+    for j, g in enumerate(casc.gates):
+        # placement / kind symmetry (covers both directions)
+        if g.kind == GateKind.MARGIN_BELOW and casc.placement == Placement.PRE:
+            diags.append(("gate_kind_placement_mismatch", c.name))
+        if g.kind == GateKind.SIGNAL_BELOW and casc.placement == Placement.POST:
+            diags.append(("gate_kind_placement_mismatch", c.name))
+        # signal_below requires a declared signal
+        if g.kind == GateKind.SIGNAL_BELOW and g.signal is None:
+            diags.append(("missing_gate_signal", c.name))
+        # margin_below (post) gates the arm at index j+1 -> must be margin-bearing
+        if g.kind == GateKind.MARGIN_BELOW and casc.placement == Placement.POST:
+            gated_idx = j + 1
+            if gated_idx < len(casc.arms):
+                if not arm_is_margin_bearing(env, casc.arms[gated_idx]):
+                    diags.append(("gate_arm_incompatible", c.name))
+    return diags
+
+
+def arm_is_margin_bearing(env: Env, a: Arm) -> bool:
+    """§3.2 item 5: a stage arm, or an ensemble arm whose aggregate is
+    majority_vote, is margin-bearing. judge_max / loop / pre-cascade / nested
+    post-cascade are NOT."""
+    if a.is_stage:
+        return True
+    if a.is_composite:
+        comp = env.n_x.get(a.composite_ref)  # type: ignore[arg-type]
+        if comp is None:
+            return False
+        if comp.ensemble is not None:
+            return comp.ensemble.aggregate.kind == AggregateKind.MAJORITY_VOTE
+        return False
+    return False

--- a/tests/model_checking/model.py
+++ b/tests/model_checking/model.py
@@ -18,6 +18,7 @@ import json
 import math
 import unicodedata
 from dataclasses import dataclass, field
+from types import MappingProxyType
 from typing import Any, Dict, FrozenSet, List, Mapping, Optional, Sequence, Tuple
 
 # ---------------------------------------------------------------------------
@@ -307,6 +308,12 @@ R5_INFEASIBLE_VALUE = "infeasible_value"
 R6_STALE_CERTIFICATE = "stale_certificate"
 R7_EVIDENCE_LEAKAGE = "evidence_leakage"
 R8_INSUFFICIENT_EVIDENCE = "insufficient_evidence"
+# RFC 0002 §3.2 item 7: resolution-time ensemble cardinality value rejection
+# (k < 1). It extends RFC 0001's §3.4 acceptance algebra to
+# Accept₁.₂ ⟺ ¬(R1 ∨ … ∨ R8 ∨ R9) ∧ calibrators ≠ ⊥. Conservative: a TVL 1.1
+# module declares no composites, so R9 is unreachable and Accept₁.₂ coincides
+# with RFC 0001's Accept on all 1.1 modules.
+R9_INVALID_CARDINALITY_VALUE = "invalid_cardinality_value"
 NO_DECISION_VERDICT = "no_decision"
 
 ALL_REJECTIONS = (
@@ -318,6 +325,7 @@ ALL_REJECTIONS = (
     R6_STALE_CERTIFICATE,
     R7_EVIDENCE_LEAKAGE,
     R8_INSUFFICIENT_EVIDENCE,
+    R9_INVALID_CARDINALITY_VALUE,
 )
 
 
@@ -372,14 +380,25 @@ def resolve(
     contexts: Mapping[str, FreshnessContext],
     *,
     eval_items: frozenset = frozenset(),
+    cardinality_values: Mapping[str, int] = MappingProxyType({}),
 ) -> Resolution:
-    """Transcription of RFC §3.4: Accept ⟺ ¬(R1∨...∨R8) ∧ ∀ calibrators ≠ ⊥.
+    """Transcription of RFC §3.4 + RFC 0002 §3.2 item 7:
+    Accept₁.₂ ⟺ ¬(R1∨...∨R8∨R9) ∧ ∀ calibrators ≠ ⊥.
 
     The implementation collects EVERY applicable rejection (no short-circuit)
-    so the property checks can assert exact complementarity.
+    so the property checks can assert exact complementarity. ``cardinality_values``
+    maps an ensemble's resolved sample count to its integer value; a value k < 1
+    is the resolution-time R9 rejection (``invalid_cardinality_value``). When the
+    mapping is empty (every TVL 1.1 module, and any composite-free instance) R9
+    is unreachable — preserving RFC 0001's Accept on 1.1 modules.
     """
     rejections: List[str] = []
     n_t, n_c = module.n_t, module.n_c
+
+    # R9 (RFC 0002 §3.2 item 7): resolution-time ensemble cardinality k < 1.
+    for card_name, k in cardinality_values.items():
+        if not isinstance(k, int) or isinstance(k, bool) or k < 1:
+            rejections.append(R9_INVALID_CARDINALITY_VALUE)
 
     # R2: depends_on must resolve to a declared TVAR (exact match, §3.7(4)).
     for cvar in module.cvars:

--- a/tests/model_checking/test_composites_c1_c6.py
+++ b/tests/model_checking/test_composites_c1_c6.py
@@ -1,0 +1,990 @@
+"""Small-scope model checking for RFC 0002 "Composite Knobs", claims C1–C6.
+
+House convention (RFC 0001's 272 checks, ``test_partition_namespace.py`` /
+``test_promotion_cascade.py``): tiny finite universes, exhaustive ``itertools``
+enumeration, plain pytest, no new deps. Each claim is one class. Every
+UNSAT-style assertion ("no bad instance exists in the universe") is paired with
+its TEETH twin ("the deliberately-broken instance/variant EXISTS and is
+detected") — named ``test_*_teeth_*`` — so no check passes vacuously.
+
+The algebra under test lives in ``composites_model.py``; the derived functions
+(``leaf_t_*``, ``required_parents``, ``cal_*``, ``roots``, ``loop_execute`` vs.
+``kchain_execute``) transcribe RFC 0002 v7 §3.2–§3.8 one-to-one.
+"""
+
+from __future__ import annotations
+
+import itertools
+
+from .composites_model import (
+    NO_ACCEPT,
+    AcceptDecl,
+    AcceptStat,
+    AggregateDecl,
+    AggregateKind,
+    Arm,
+    ArmResult,
+    ArmResultKind,
+    Cascade,
+    Composite,
+    CompositeKind,
+    CostForm,
+    Ensemble,
+    Env,
+    ERROR,
+    GateDecl,
+    GateKind,
+    IterStep,
+    Loop,
+    Placement,
+    SignalUse,
+    StopDecl,
+    StopKind,
+    arm_is_margin_bearing,
+    body_fields,
+    cal_composite,
+    cal_composite_drop_judge,
+    cal_roots,
+    calibration_pass,
+    child_refs,
+    composite_arm,
+    cost_is_closed,
+    cost_of_arm,
+    cost_of_composite,
+    gate_typing_diagnostics,
+    has_cycle,
+    kchain_execute,
+    leaf_t_composite,
+    loop_execute,
+    member_walk_cal,
+    missing_composite_parent,
+    missing_composite_refs,
+    output,
+    required_parents,
+    result_well_formed,
+    roots,
+    signal_accept_unrollable,
+    stage_arm,
+    well_formed_kind,
+)
+
+# Tiny universes (2–4 atoms per sort), per the house scope discipline.
+ALL_KINDS = list(CompositeKind)
+BODY_FIELDS = ["cascade", "ensemble", "loop"]
+
+
+def _body(field_name: str):
+    """A minimal well-formed body object for the named field."""
+    if field_name == "cascade":
+        return Cascade(arms=(stage_arm("s"),))
+    if field_name == "ensemble":
+        return Ensemble(arms=(stage_arm("s"),), cardinality="k")
+    return Loop(
+        body=stage_arm("s"),
+        stop=StopDecl(StopKind.EXHAUSTED),
+        max_iters=1,
+    )
+
+
+def _make(kind: CompositeKind, present_fields, binds_value=False) -> Composite:
+    kw = {f: _body(f) for f in present_fields}
+    return Composite(name="c", kind=kind, binds_value=binds_value, **kw)
+
+
+# ===========================================================================
+# C1 — Constructor disjointness (kind partition) + closed result algebra.
+# §3.2 item 1, §3.1, §3.2.1.
+# ===========================================================================
+
+
+class TestC1KindPartition:
+    def test_exactly_one_kind_well_formed_iff_matching_single_body(self):
+        """Exhaustive: over every (kind × subset-of-body-fields), the node is
+        well-formed iff exactly the one body matching the kind is present and
+        no value is bound. This is the partition: one kind ⟺ one body."""
+        checked = 0
+        for kind in ALL_KINDS:
+            for r in range(len(BODY_FIELDS) + 1):
+                for subset in itertools.combinations(BODY_FIELDS, r):
+                    c = _make(kind, subset)
+                    expected = list(subset) == [
+                        {
+                            CompositeKind.CASCADE: "cascade",
+                            CompositeKind.ENSEMBLE: "ensemble",
+                            CompositeKind.LOOP: "loop",
+                        }[kind]
+                    ]
+                    assert well_formed_kind(c) == expected, (kind, subset)
+                    checked += 1
+        assert checked == len(ALL_KINDS) * (2 ** len(BODY_FIELDS))
+
+    def test_well_formed_node_has_exactly_one_body_field(self):
+        """No well-formed node carries a cross-kind or multi-body shape."""
+        kind_to_field = {
+            CompositeKind.CASCADE: "cascade",
+            CompositeKind.ENSEMBLE: "ensemble",
+            CompositeKind.LOOP: "loop",
+        }
+        for kind in ALL_KINDS:
+            c = _make(kind, [kind_to_field[kind]])
+            assert well_formed_kind(c)
+            assert len(body_fields(c)) == 1
+
+    def test_result_algebra_closed_disjoint_exhaustive(self):
+        """§3.2.1: every result lands in exactly one of output/no_accept/error;
+        ``out`` present iff OUTPUT. Exhaustive over the result-shape space."""
+        outs = [None, "o"]
+        margins = [None, 0.5]
+        checked = 0
+        for kind in ArmResultKind:
+            for o in outs:
+                for m in margins:
+                    r = ArmResult(kind, out=o, vote_stats=m)
+                    wf = result_well_formed(r)
+                    if kind == ArmResultKind.OUTPUT:
+                        assert wf == (o is not None)
+                    else:
+                        assert wf == (o is None and m is None)
+                    checked += 1
+        assert checked == len(ArmResultKind) * len(outs) * len(margins)
+
+    # --- TEETH ---------------------------------------------------------------
+
+    def test_c1_teeth_two_bodies_rejected(self):
+        """A cross-kind body (two bodies present) EXISTS and is flagged."""
+        bad = _make(CompositeKind.CASCADE, ["cascade", "ensemble"])
+        assert not well_formed_kind(bad)
+        assert len(body_fields(bad)) == 2
+
+    def test_c1_teeth_kind_without_matching_body_rejected(self):
+        """A kind whose matching body is absent (a different body present)."""
+        bad = _make(CompositeKind.LOOP, ["cascade"])
+        assert not well_formed_kind(bad)
+
+    def test_c1_teeth_composite_binds_value_rejected(self):
+        """§3.1: a value bound on a composite EXISTS and is rejected."""
+        bad = _make(CompositeKind.CASCADE, ["cascade"], binds_value=True)
+        assert not well_formed_kind(bad)
+
+    def test_c1_teeth_bad_result_no_accept_with_output_detected(self):
+        """A no_accept carrying an output is a broken result and is caught."""
+        bad = ArmResult(ArmResultKind.NO_ACCEPT, out="leaked")
+        assert not result_well_formed(bad)
+
+
+# ===========================================================================
+# C2 — Nesting well-formedness: acyclicity, finite expansion, tag resolution.
+# §3.2 item 4 + item 3.
+# ===========================================================================
+
+C2_NAMES = ("a", "b", "c")
+
+
+def _ref_composite(name: str, refs) -> Composite:
+    """A cascade composite whose arms reference the given composite names."""
+    arms = tuple(composite_arm(r) for r in refs) or (stage_arm("s"),)
+    return Composite(name=name, kind=CompositeKind.CASCADE, cascade=Cascade(arms=arms))
+
+
+def _enumerate_ref_graphs():
+    """All directed graphs over 3 composite nodes where each node references a
+    subset of the others (size ≤ 2) — the small-scope graph universe."""
+    nodes = C2_NAMES
+    others = {n: tuple(x for x in nodes if x != n) for n in nodes}
+    per_node_choices = {
+        n: [
+            subset
+            for k in range(3)
+            for subset in itertools.combinations(others[n], k)
+        ]
+        for n in nodes
+    }
+    for ca in per_node_choices["a"]:
+        for cb in per_node_choices["b"]:
+            for cc in per_node_choices["c"]:
+                yield {"a": ca, "b": cb, "c": cc}
+
+
+def _graph_has_cycle_groundtruth(adj):
+    """Independent reachability oracle for cycle presence."""
+    def reaches(start, target, seen):
+        for nxt in adj.get(start, ()):  # over edges
+            if nxt == target:
+                return True
+            if nxt not in seen:
+                seen.add(nxt)
+                if reaches(nxt, target, seen):
+                    return True
+        return False
+
+    return any(reaches(n, n, set()) for n in adj)
+
+
+class TestC2Nesting:
+    def test_acyclicity_matches_ground_truth_and_expansion_terminates(self):
+        """Exhaustive over the small ref-graph universe: ``has_cycle`` agrees
+        with an independent reachability oracle, AND when acyclic, transitive
+        expansion (reachable set) is finite & irreflexive (terminates)."""
+        checked = 0
+        for adj in _enumerate_ref_graphs():
+            comps = tuple(_ref_composite(n, adj[n]) for n in C2_NAMES)
+            env = Env(composites=comps)
+            gt_cycle = _graph_has_cycle_groundtruth(adj)
+            assert has_cycle(env) == gt_cycle, adj
+            if not gt_cycle:
+                # acyclic ⇒ no node reaches itself; expansion is finite.
+                from .composites_model import reachable
+
+                for n in C2_NAMES:
+                    assert n not in reachable(env, n), (adj, n)
+            checked += 1
+        # Each node references a subset (size 0/1/2) of the 2 OTHER nodes:
+        # C(2,0)+C(2,1)+C(2,2) = 4 choices per node, 3 nodes.
+        assert checked == 4 ** 3
+
+    def test_tag_resolution_is_unambiguous(self):
+        """§3.2 item 3: a stage arm never consults N_X; a composite arm always
+        does. The two tags are disjoint by construction."""
+        s = stage_arm("opaque", ["t1"])
+        x = composite_arm("inner")
+        assert s.is_stage and not s.is_composite
+        assert x.is_composite and not x.is_stage
+        env = Env(
+            composites=(
+                Composite("inner", CompositeKind.CASCADE, cascade=Cascade((stage_arm("y"),))),
+                Composite(
+                    "outer",
+                    CompositeKind.CASCADE,
+                    cascade=Cascade((s, x)),
+                ),
+            )
+        )
+        # child_refs reports ONLY the composite-tagged arm, never the stage.
+        assert child_refs(env.n_x["outer"]) == ["inner"]
+
+    # --- TEETH ---------------------------------------------------------------
+
+    def test_c2_teeth_two_cycle_detected(self):
+        """A 2-cycle instance EXISTS and is flagged (not silently accepted)."""
+        env = Env(
+            composites=(
+                _ref_composite("a", ["b"]),
+                _ref_composite("b", ["a"]),
+            )
+        )
+        assert has_cycle(env)
+
+    def test_c2_teeth_self_cycle_detected(self):
+        env = Env(composites=(_ref_composite("a", ["a"]),))
+        assert has_cycle(env)
+
+    def test_c2_teeth_three_cycle_detected(self):
+        env = Env(
+            composites=(
+                _ref_composite("a", ["b"]),
+                _ref_composite("b", ["c"]),
+                _ref_composite("c", ["a"]),
+            )
+        )
+        assert has_cycle(env)
+
+    def test_c2_teeth_dangling_composite_ref_detected(self):
+        """§3.2 item 3: a composite(x) resolving to no N_X member is caught by
+        ``missing_composite_refs`` (and does not crash cycle detection)."""
+        env = Env(composites=(_ref_composite("a", ["ghost"]),))
+        assert ("a", "ghost") in missing_composite_refs(env)
+        assert not has_cycle(env)  # dangling != cyclic
+
+
+# ===========================================================================
+# C3 — Coverage-fold soundness (PER-MEMBER). §3.6.
+# ===========================================================================
+
+# A small set of composites we nest to depth 2–3 for the fold cross-check.
+def _depth2_env():
+    """root(loop) -> ensemble(judge_max w/ composite judge + accept) ->
+    cascade(post, margin gate). Exercises judge arms + nested levels."""
+    inner_cascade = Composite(
+        "leaf_casc",
+        CompositeKind.CASCADE,
+        cascade=Cascade(
+            arms=(stage_arm("a", ["t1"]), stage_arm("b", ["t2"])),
+            gates=(GateDecl(GateKind.MARGIN_BELOW, "theta_casc"),),
+            placement=Placement.POST,
+        ),
+    )
+    judge = composite_arm("leaf_casc")
+    mid_ensemble = Composite(
+        "mid_ens",
+        CompositeKind.ENSEMBLE,
+        ensemble=Ensemble(
+            arms=(stage_arm("e", ["t3"]),),
+            cardinality="k_cal",  # calibrated cardinality -> in Cal
+            aggregate=AggregateDecl(
+                AggregateKind.JUDGE_MAX,
+                judge=judge,
+                accept=AcceptDecl(AcceptStat.VOTE_MARGIN, "theta_acc"),
+            ),
+        ),
+    )
+    root_loop = Composite(
+        "root_loop",
+        CompositeKind.LOOP,
+        loop=Loop(
+            body=composite_arm("mid_ens"),
+            stop=StopDecl(
+                StopKind.SIGNAL_ACCEPT,
+                threshold="theta_stop",
+                signal=SignalUse("sig"),
+            ),
+            max_iters=2,
+            state_keys=(),
+        ),
+    )
+    return Env(
+        n_t=frozenset({"t1", "t2", "t3"}),
+        n_c=frozenset({"theta_casc", "theta_acc", "theta_stop", "k_cal"}),
+        composites=(inner_cascade, mid_ensemble, root_loop),
+    )
+
+
+def _enumerate_small_composite_envs():
+    """Enumerate depth 2–3 composite shapes by toggling structural choices:
+    judge present/absent, accept present/absent, calibrated-vs-tuned k. Each
+    env is single-root so the fold has a clean target."""
+    for has_judge in (False, True):
+        for has_accept in (False, True):
+            for k_calibrated in (False, True):
+                leaf = Composite(
+                    "leaf",
+                    CompositeKind.CASCADE,
+                    cascade=Cascade(
+                        arms=(stage_arm("a", ["t1"]), stage_arm("b", ["t2"])),
+                        gates=(GateDecl(GateKind.MARGIN_BELOW, "theta_leaf"),),
+                    ),
+                )
+                agg = AggregateDecl(
+                    AggregateKind.JUDGE_MAX if has_judge else AggregateKind.MAJORITY_VOTE,
+                    judge=composite_arm("leaf") if has_judge else None,
+                    accept=AcceptDecl(AcceptStat.VOTE_MARGIN, "theta_acc")
+                    if has_accept
+                    else None,
+                )
+                k_name = "k_cal" if k_calibrated else "k_tuned"
+                root = Composite(
+                    "root",
+                    CompositeKind.ENSEMBLE,
+                    ensemble=Ensemble(
+                        arms=(stage_arm("e", ["t3"]),),
+                        cardinality=k_name,
+                        aggregate=agg,
+                    ),
+                )
+                env = Env(
+                    n_t=frozenset({"t1", "t2", "t3", "k_tuned"}),
+                    n_c=frozenset({"theta_leaf", "theta_acc", "k_cal"}),
+                    composites=(leaf, root),
+                )
+                yield env
+
+
+class TestC3CoverageFold:
+    def test_fold_equals_ground_truth_member_walk(self):
+        """C3: ``cal_composite`` over each root equals an INDEPENDENT member
+        walk that collects every gate/accept/stop threshold + calibrated
+        cardinality through nesting incl. judge arms. Exhaustive over the
+        small structural universe + the hand-built depth-2 env."""
+        envs = list(_enumerate_small_composite_envs()) + [_depth2_env()]
+        checked = 0
+        for env in envs:
+            for r in roots(env):
+                fold = cal_composite(env, r)
+                walk = member_walk_cal(env, r)
+                assert fold == walk, (r.name, fold, walk)
+                checked += 1
+        assert checked >= len(list(_enumerate_small_composite_envs()))
+
+    def test_cal_roots_collects_all_calibratable_members_depth2(self):
+        """The depth-2 env's root fold collects EXACTLY the expected members:
+        nested cascade gate, ensemble accept, calibrated k, loop stop."""
+        env = _depth2_env()
+        assert cal_roots(env) == frozenset(
+            {"theta_casc", "theta_acc", "k_cal", "theta_stop"}
+        )
+
+    def test_strict_selection_passes_iff_every_member_certified(self):
+        """§3.6 fail-closed: strict selection passes iff ALL Cal members are
+        certified-fresh. Exhaustive over every subset of the coverage set."""
+        env = _depth2_env()
+        coverage = cal_roots(env)
+        members = sorted(coverage)
+        checked = 0
+        for r in range(len(members) + 1):
+            for subset in itertools.combinations(members, r):
+                certified = frozenset(subset)
+                expected = coverage <= certified
+                assert calibration_pass(certified, coverage) == expected
+                checked += 1
+        assert checked == 2 ** len(members)
+
+    # --- TEETH ---------------------------------------------------------------
+
+    def test_c3_teeth_uncertified_gate_yields_coverage_gap(self):
+        """An instance with one uncertified gate: strict selection REFUSES
+        (the fold is fail-closed — never a partial pass)."""
+        env = _depth2_env()
+        coverage = cal_roots(env)
+        # certify everyone EXCEPT one gate -> must refuse.
+        certified = coverage - {"theta_casc"}
+        assert not calibration_pass(certified, coverage)
+        # and certifying all -> passes (sanity, so the teeth aren't vacuous).
+        assert calibration_pass(coverage, coverage)
+
+    def test_c3_teeth_broken_fold_dropping_judge_is_caught(self):
+        """A deliberately-broken fold variant that drops judge arms is CAUGHT
+        by the ground-truth member walk: it under-collects on a judge-bearing
+        nested composite."""
+        env = _depth2_env()
+        root = env.n_x["root_loop"]
+        good = cal_composite(env, root)
+        broken = cal_composite_drop_judge(env, root)
+        walk = member_walk_cal(env, root)
+        assert good == walk
+        assert broken != walk  # the bug is detectable
+        assert "theta_casc" in (walk - broken)  # the judge's gate is what was lost
+
+
+# ===========================================================================
+# C4 — Cost compositionality (FORM closure only). §3.4.
+# ===========================================================================
+
+
+def _all_five_form_env():
+    """One env exhibiting all five §3.4 cost forms as roots/arms."""
+    post = Composite(
+        "post",
+        CompositeKind.CASCADE,
+        cascade=Cascade((stage_arm("a"), stage_arm("b")), (GateDecl(GateKind.MARGIN_BELOW, "th"),)),
+    )
+    pre = Composite(
+        "pre",
+        CompositeKind.CASCADE,
+        cascade=Cascade(
+            (stage_arm("a"), stage_arm("b")),
+            (GateDecl(GateKind.SIGNAL_BELOW, "th", SignalUse("sig")),),
+            placement=Placement.PRE,
+        ),
+    )
+    sampling = Composite(
+        "sampling",
+        CompositeKind.ENSEMBLE,
+        ensemble=Ensemble((stage_arm("a"),), cardinality="k"),
+    )
+    committee = Composite(
+        "committee",
+        CompositeKind.ENSEMBLE,
+        ensemble=Ensemble((stage_arm("a"), stage_arm("b"))),
+    )
+    loopc = Composite(
+        "loopc",
+        CompositeKind.LOOP,
+        loop=Loop(stage_arm("a"), StopDecl(StopKind.EXHAUSTED), 2),
+    )
+    return Env(
+        n_t=frozenset({"k"}),
+        n_c=frozenset({"th"}),
+        composites=(post, pre, sampling, committee, loopc),
+    )
+
+
+class TestC4CostClosure:
+    def test_all_five_forms_reachable_and_closed(self):
+        """C4: each of the five §3.4 cost forms appears, and every composite's
+        cost term is CLOSED — substituting an arm's form yields the parent's,
+        with no unexpanded composite reference. (Structural FORM closure.)"""
+        env = _all_five_form_env()
+        forms_seen = set()
+        for c in env.composites:
+            term = cost_of_composite(env, c)
+            assert cost_is_closed(term), c.name
+            forms_seen.add(term.form)
+        assert forms_seen == {
+            CostForm.CASCADE_POST,
+            CostForm.CASCADE_PRE,
+            CostForm.ENSEMBLE_SAMPLING,
+            CostForm.ENSEMBLE_COMMITTEE,
+            CostForm.LOOP,
+        }
+
+    def test_nested_arm_cost_is_arms_own_form(self):
+        """§3.4 compositionality: a composite arm's cost term IS the referenced
+        composite's cost form (the equations close over the algebra)."""
+        env = Env(
+            n_t=frozenset(),
+            n_c=frozenset({"th"}),
+            composites=(
+                Composite(
+                    "inner",
+                    CompositeKind.CASCADE,
+                    cascade=Cascade((stage_arm("a"), stage_arm("b")), (GateDecl(GateKind.MARGIN_BELOW, "th"),)),
+                ),
+                Composite(
+                    "outer",
+                    CompositeKind.LOOP,
+                    loop=Loop(composite_arm("inner"), StopDecl(StopKind.EXHAUSTED), 1),
+                ),
+            ),
+        )
+        outer_term = cost_of_composite(env, env.n_x["outer"])
+        assert outer_term.form == CostForm.LOOP
+        # the loop body's cost form is the inner cascade's own form.
+        assert outer_term.kids[0].form == CostForm.CASCADE_POST
+        assert cost_is_closed(outer_term)
+
+    def test_nesting_to_depth_three_stays_closed(self):
+        """Exhaustive small trees: nest loop->ensemble->cascade and confirm the
+        whole cost term is closed (no leaked composite reference)."""
+        env = _depth2_env()
+        for c in env.composites:
+            assert cost_is_closed(cost_of_composite(env, c)), c.name
+
+    # --- TEETH ---------------------------------------------------------------
+
+    def test_c4_teeth_unexpanded_composite_ref_is_not_closed(self):
+        """A cost term carrying an UNEXPANDED composite reference (a dangling
+        arm whose form was never substituted) is NOT closed — the closure
+        property has teeth."""
+        env = Env(composites=())  # 'ghost' unresolved
+        term = cost_of_arm(env, composite_arm("ghost"))
+        assert term.composite_ref == "ghost"
+        assert not cost_is_closed(term)
+        # ... and a closed term passes (non-vacuous).
+        assert cost_is_closed(cost_of_arm(env, stage_arm("s")))
+
+
+# ===========================================================================
+# C5 — Loop → K-chain semantic compilation (signal_accept only). §3.8.
+# ===========================================================================
+
+# A small finite space of per-iteration outcomes for K ≤ 4.
+STEP_BODIES = [output("o"), NO_ACCEPT, ERROR]
+STEP_STOPS = [False, True]
+
+
+def _signal_accept_loop(k: int) -> Loop:
+    return Loop(
+        body=stage_arm("a"),
+        stop=StopDecl(StopKind.SIGNAL_ACCEPT, threshold="th", signal=SignalUse("s")),
+        max_iters=k,
+        state_keys=(),
+    )
+
+
+def _enumerate_step_traces(k: int):
+    """All length-k iteration traces over (body_result × stop_accepts),
+    with no ambient mutation (condition 1 holds)."""
+    cell = [
+        IterStep(body, stop)
+        for body in STEP_BODIES
+        for stop in STEP_STOPS
+    ]
+    for combo in itertools.product(cell, repeat=k):
+        yield list(combo)
+
+
+class TestC5LoopKChain:
+    def test_signal_accept_loop_and_kchain_outputs_coincide(self):
+        """C5: for signal_accept loops with K ≤ 4, pure/threaded bodies,
+        deterministic stop, the Loop execution and the unrolled K-chain
+        selection coincide on BOTH the final result kind/output AND the
+        selected iteration index. Exhaustive over all step traces for K=1..4."""
+        total = 0
+        for k in (1, 2, 3, 4):
+            loop = _signal_accept_loop(k)
+            assert signal_accept_unrollable(loop)
+            for steps in _enumerate_step_traces(k):
+                loop_res, loop_sel = loop_execute(loop, steps)
+                chain_res, chain_sel = kchain_execute(loop, steps)
+                assert loop_res.kind == chain_res.kind, steps
+                if loop_res.kind == ArmResultKind.OUTPUT:
+                    assert loop_res.out == chain_res.out, steps
+                assert loop_sel == chain_sel, steps
+                total += 1
+        # 6 cells per iteration; Σ_{k=1..4} 6^k traces.
+        assert total == sum(6 ** k for k in (1, 2, 3, 4))
+
+    def test_non_signal_accept_loops_offer_no_unroll(self):
+        """§3.8: external_accept and exhausted loops are NOT unrollable."""
+        for stop in (
+            StopDecl(StopKind.EXTERNAL_ACCEPT, predicate="p"),
+            StopDecl(StopKind.EXHAUSTED),
+        ):
+            loop = Loop(stage_arm("a"), stop, max_iters=2)
+            assert not signal_accept_unrollable(loop)
+
+    def test_k_above_four_not_unrollable_in_this_scope(self):
+        loop = _signal_accept_loop(5)
+        assert not signal_accept_unrollable(loop)
+
+    # --- TEETH ---------------------------------------------------------------
+
+    def test_c5_teeth_hidden_state_mutation_diverges_and_is_detectable(self):
+        """Violate §3.8 condition 1 (hidden ambient state mutation): construct
+        a trace where the loop's reference semantics and a mutation-corrupted
+        K-chain DISAGREE, and show the divergence IS detectable.
+
+        We model the corruption concretely: ambient mutation makes the chain's
+        escalation decision read a STALE stop bit (the chain still sees the old
+        ``stop_accepts`` while the loop, threading only declared state, sees the
+        true one). With state flowing only through declared keys the two agree;
+        once ambient flips a stop bit, they part."""
+        loop = _signal_accept_loop(2)
+
+        # Honest trace (condition 1 holds): both accept on iter 0.
+        honest = [IterStep(output("o"), stop_accepts=True),
+                  IterStep(output("p"), stop_accepts=True)]
+        lr, ls = loop_execute(loop, honest)
+        cr, cs = kchain_execute(loop, honest)
+        assert (lr.kind, lr.out, ls) == (cr.kind, cr.out, cs)  # agree -> non-vacuous
+
+        # Corrupted: the true loop semantics (declared state only) sees iter-0
+        # stop = False (no acceptance yet); but an ambient mutation made the
+        # chain's compiled escalation predicate read stop = True at iter 0.
+        loop_view = [IterStep(output("o"), stop_accepts=False, ambient=True),
+                     IterStep(output("p"), stop_accepts=True)]
+        chain_view = [IterStep(output("o"), stop_accepts=True, ambient=True),
+                      IterStep(output("p"), stop_accepts=True)]
+        # Condition 1 is violated -> the two views differ.
+        assert any(s.ambient for s in loop_view)
+        lr2, ls2 = loop_execute(loop, loop_view)
+        cr2, cs2 = kchain_execute(loop, chain_view)
+        # Loop selects iter 1 ("p"); corrupted chain selects iter 0 ("o").
+        assert (lr2.out, ls2) == ("p", 1)
+        assert (cr2.out, cs2) == ("o", 0)
+        assert (lr2.out, ls2) != (cr2.out, cs2)  # divergence IS detectable
+
+    def test_c5_teeth_error_absorbing_in_both(self):
+        """An error at any iteration fails BOTH the loop and the chain — the
+        absorbing rule (§3.2.1) holds in both implementations (so a divergence
+        here would be a real bug, not noise)."""
+        loop = _signal_accept_loop(3)
+        steps = [
+            IterStep(NO_ACCEPT, stop_accepts=False),  # iter 0: no_accept
+            IterStep(ERROR, stop_accepts=False),  # iter 1: error -> absorbing
+            IterStep(output("late"), stop_accepts=True),  # never reached
+        ]
+        lr, _ = loop_execute(loop, steps)
+        cr, _ = kchain_execute(loop, steps)
+        assert lr.kind == ArmResultKind.ERROR
+        assert cr.kind == ArmResultKind.ERROR
+
+
+# ===========================================================================
+# C6 — Dependency-compilation soundness (TVAR-ONLY obligations). §3.5.
+# ===========================================================================
+
+
+def _enumerate_c6_envs():
+    """Composite shapes whose required_parents we check land in N_T only:
+    post-cascade, pre-cascade, ensemble-accept (judge present/absent), loop
+    signal_accept — with tuned/calibrated cardinality toggled."""
+    n_t = frozenset({"t1", "t2", "t3", "k_tuned"})
+    n_c = frozenset({"theta", "theta_acc", "theta_stop", "k_cal"})
+    envs = []
+
+    post = Composite(
+        "post",
+        CompositeKind.CASCADE,
+        cascade=Cascade(
+            (stage_arm("a", ["t1"]), stage_arm("b", ["t2"]), stage_arm("c", ["t3"])),
+            (GateDecl(GateKind.MARGIN_BELOW, "theta"), GateDecl(GateKind.MARGIN_BELOW, "theta_acc")),
+        ),
+    )
+    envs.append(Env(n_t, n_c, (post,)))
+
+    pre = Composite(
+        "pre",
+        CompositeKind.CASCADE,
+        cascade=Cascade(
+            (stage_arm("a", ["t1"]), stage_arm("b", ["t2"])),
+            (GateDecl(GateKind.SIGNAL_BELOW, "theta", SignalUse("s")),),
+            placement=Placement.PRE,
+        ),
+    )
+    envs.append(Env(n_t, n_c, (pre,)))
+
+    for has_judge in (False, True):
+        for k_tuned in (False, True):
+            ens = Composite(
+                "ens",
+                CompositeKind.ENSEMBLE,
+                ensemble=Ensemble(
+                    (stage_arm("e", ["t1"]),),
+                    cardinality="k_tuned" if k_tuned else "k_cal",
+                    aggregate=AggregateDecl(
+                        AggregateKind.JUDGE_MAX if has_judge else AggregateKind.MAJORITY_VOTE,
+                        judge=stage_arm("j", ["t3"]) if has_judge else None,
+                        accept=AcceptDecl(AcceptStat.VOTE_MARGIN, "theta_acc"),
+                    ),
+                ),
+            )
+            envs.append(Env(n_t, n_c, (ens,)))
+
+    loop = Composite(
+        "loop",
+        CompositeKind.LOOP,
+        loop=Loop(
+            stage_arm("b", ["t1", "t2"]),
+            StopDecl(StopKind.SIGNAL_ACCEPT, threshold="theta_stop", signal=SignalUse("s")),
+            max_iters=2,
+        ),
+    )
+    envs.append(Env(n_t, n_c, (loop,)))
+    return envs
+
+
+class TestC6RequiredParents:
+    def test_required_parents_land_in_NT_only(self):
+        """C6: for every enumerated instance (incl. tuned cardinality + judge
+        arms), every threshold's required_parents ⊆ N_T. No CVAR ever appears
+        as a parent."""
+        checked = 0
+        for env in _enumerate_c6_envs():
+            for r in roots(env):
+                for theta, parents in required_parents(env, r).items():
+                    assert parents <= env.n_t, (r.name, theta, parents)
+                    assert not (parents & env.n_c), (theta, parents)
+                    checked += 1
+        assert checked > 0
+
+    def test_tuned_cardinality_in_leafT(self):
+        """§3.5: a sampling ensemble whose tuned cardinality is a TVAR includes
+        that TVAR in its leaf set (and in the accept threshold's parents)."""
+        env = Env(
+            n_t=frozenset({"t1", "k_tuned"}),
+            n_c=frozenset({"theta_acc"}),
+            composites=(
+                Composite(
+                    "ens",
+                    CompositeKind.ENSEMBLE,
+                    ensemble=Ensemble(
+                        (stage_arm("e", ["t1"]),),
+                        cardinality="k_tuned",
+                        aggregate=AggregateDecl(
+                            AggregateKind.MAJORITY_VOTE,
+                            accept=AcceptDecl(AcceptStat.VOTE_MARGIN, "theta_acc"),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        leaf = leaf_t_composite(env, env.n_x["ens"])
+        assert "k_tuned" in leaf and "t1" in leaf
+        parents = required_parents(env, env.n_x["ens"])["theta_acc"]
+        assert "k_tuned" in parents
+
+    def test_calibrated_cardinality_not_in_leafT(self):
+        """§3.5: a CALIBRATED cardinality contributes nothing to leafT (it is a
+        member of Cal instead). Keeps the codomain TVAR-only."""
+        env = Env(
+            n_t=frozenset({"t1"}),
+            n_c=frozenset({"k_cal", "theta_acc"}),
+            composites=(
+                Composite(
+                    "ens",
+                    CompositeKind.ENSEMBLE,
+                    ensemble=Ensemble(
+                        (stage_arm("e", ["t1"]),),
+                        cardinality="k_cal",
+                        aggregate=AggregateDecl(
+                            AggregateKind.MAJORITY_VOTE,
+                            accept=AcceptDecl(AcceptStat.VOTE_MARGIN, "theta_acc"),
+                        ),
+                    ),
+                ),
+            ),
+        )
+        leaf = leaf_t_composite(env, env.n_x["ens"])
+        assert "k_cal" not in leaf
+
+    def test_missing_composite_parent_lint_exact_gap(self):
+        """§3.5: ``missing_composite_parent`` fires exactly when
+        required_parents(θ) ⊄ depends_on(θ). Exhaustive over depends_on
+        subsets for a post-cascade with a known required set."""
+        env = Env(
+            n_t=frozenset({"t1", "t2"}),
+            n_c=frozenset({"theta"}),
+            composites=(
+                Composite(
+                    "post",
+                    CompositeKind.CASCADE,
+                    cascade=Cascade(
+                        (stage_arm("a", ["t1"]), stage_arm("b", ["t2"])),
+                        (GateDecl(GateKind.MARGIN_BELOW, "theta"),),
+                    ),
+                ),
+            ),
+        )
+        required = required_parents(env, env.n_x["post"])["theta"]
+        tvars = sorted(env.n_t)
+        checked = 0
+        for r in range(len(tvars) + 1):
+            for subset in itertools.combinations(tvars, r):
+                depends_on = {"theta": frozenset(subset)}
+                gaps = missing_composite_parent(env, depends_on)
+                expected_gap = bool(required - frozenset(subset))
+                assert bool(gaps) == expected_gap, subset
+                checked += 1
+        assert checked == 2 ** len(tvars)
+
+    # --- TEETH ---------------------------------------------------------------
+
+    def test_c6_teeth_broken_variant_emitting_cvar_parent_is_caught(self):
+        """A deliberately-broken required_parents variant that emits a CVAR
+        parent (e.g. a calibrated cardinality leaking in) is CAUGHT by the
+        TVAR-only codomain check."""
+        env = Env(
+            n_t=frozenset({"t1"}),
+            n_c=frozenset({"k_cal", "theta_acc"}),
+            composites=(
+                Composite(
+                    "ens",
+                    CompositeKind.ENSEMBLE,
+                    ensemble=Ensemble(
+                        (stage_arm("e", ["t1"]),),
+                        cardinality="k_cal",
+                        aggregate=AggregateDecl(
+                            AggregateKind.MAJORITY_VOTE,
+                            accept=AcceptDecl(AcceptStat.VOTE_MARGIN, "theta_acc"),
+                        ),
+                    ),
+                ),
+            ),
+        )
+
+        # Broken variant: include the cardinality WITHOUT the §3.5 N_T filter.
+        def broken_required(env, c):
+            parents = set()
+            for a in c.ensemble.arms:
+                parents |= set(a.tuned_params)
+            if c.ensemble.cardinality is not None:
+                parents.add(c.ensemble.cardinality)  # BUG: no ∩ N_T
+            return frozenset(parents)
+
+        good = required_parents(env, env.n_x["ens"])["theta_acc"]
+        bad = broken_required(env, env.n_x["ens"])
+        assert good <= env.n_t  # the real fn stays TVAR-only
+        assert not (bad <= env.n_t)  # the broken variant leaks a CVAR
+        assert "k_cal" in (bad & env.n_c)  # exactly the leaked CVAR
+
+    def test_c6_teeth_missing_parent_gap_detected(self):
+        """A post-cascade gate whose depends_on omits an arm's TVAR yields a
+        ``missing_composite_parent`` gap (the obligation has teeth)."""
+        env = Env(
+            n_t=frozenset({"t1", "t2"}),
+            n_c=frozenset({"theta"}),
+            composites=(
+                Composite(
+                    "post",
+                    CompositeKind.CASCADE,
+                    cascade=Cascade(
+                        (stage_arm("a", ["t1"]), stage_arm("b", ["t2"])),
+                        (GateDecl(GateKind.MARGIN_BELOW, "theta"),),
+                    ),
+                ),
+            ),
+        )
+        gaps = missing_composite_parent(env, {"theta": frozenset({"t1"})})
+        assert ("theta", frozenset({"t2"})) in gaps
+
+
+# ===========================================================================
+# Cross-claim: gate typing (§3.2 item 5) — supports C1/C3/C6 well-formedness.
+# Kept here as a paired UNSAT/teeth block since the C-tests rely on it.
+# ===========================================================================
+
+
+class TestGateTypingSupport:
+    def test_well_typed_gates_have_no_diagnostics(self):
+        env = Env(
+            n_c=frozenset({"th"}),
+            composites=(
+                Composite(
+                    "ok_post",
+                    CompositeKind.CASCADE,
+                    cascade=Cascade(
+                        (stage_arm("a"), stage_arm("b")),
+                        (GateDecl(GateKind.MARGIN_BELOW, "th"),),
+                    ),
+                ),
+            ),
+        )
+        assert gate_typing_diagnostics(env, env.n_x["ok_post"]) == []
+
+    def test_margin_bearing_classification(self):
+        env = Env(
+            composites=(
+                Composite("mv", CompositeKind.ENSEMBLE, ensemble=Ensemble((stage_arm("a"), stage_arm("b")), AggregateDecl(AggregateKind.MAJORITY_VOTE))),
+                Composite("jm", CompositeKind.ENSEMBLE, ensemble=Ensemble((stage_arm("a"),), AggregateDecl(AggregateKind.JUDGE_MAX, judge=stage_arm("j")), cardinality="k")),
+            )
+        )
+        assert arm_is_margin_bearing(env, stage_arm("s"))
+        assert arm_is_margin_bearing(env, composite_arm("mv"))
+        assert not arm_is_margin_bearing(env, composite_arm("jm"))
+
+    def test_gate_typing_teeth_margin_on_judge_max_rejected(self):
+        """§3.2 item 5: margin_below gating a judge_max ensemble arm rejects."""
+        env = Env(
+            n_c=frozenset({"th"}),
+            composites=(
+                Composite("jm", CompositeKind.ENSEMBLE, ensemble=Ensemble((stage_arm("a"),), AggregateDecl(AggregateKind.JUDGE_MAX, judge=stage_arm("j")), cardinality="k")),
+                Composite(
+                    "bad",
+                    CompositeKind.CASCADE,
+                    cascade=Cascade(
+                        (stage_arm("a"), composite_arm("jm")),
+                        (GateDecl(GateKind.MARGIN_BELOW, "th"),),
+                    ),
+                ),
+            ),
+        )
+        codes = {c for c, _ in gate_typing_diagnostics(env, env.n_x["bad"])}
+        assert "gate_arm_incompatible" in codes
+
+    def test_gate_typing_teeth_placement_mismatch_rejected(self):
+        """§3.2 item 5: signal_below in a POST cascade rejects (both-direction
+        ``gate_kind_placement_mismatch``)."""
+        env = Env(
+            n_c=frozenset({"th"}),
+            composites=(
+                Composite(
+                    "bad",
+                    CompositeKind.CASCADE,
+                    cascade=Cascade(
+                        (stage_arm("a"), stage_arm("b")),
+                        (GateDecl(GateKind.SIGNAL_BELOW, "th", SignalUse("s")),),
+                        placement=Placement.POST,
+                    ),
+                ),
+            ),
+        )
+        codes = {c for c, _ in gate_typing_diagnostics(env, env.n_x["bad"])}
+        assert "gate_kind_placement_mismatch" in codes
+
+    def test_gate_typing_teeth_signal_below_missing_signal_rejected(self):
+        env = Env(
+            n_c=frozenset({"th"}),
+            composites=(
+                Composite(
+                    "bad",
+                    CompositeKind.CASCADE,
+                    cascade=Cascade(
+                        (stage_arm("a"), stage_arm("b")),
+                        (GateDecl(GateKind.SIGNAL_BELOW, "th"),),
+                        placement=Placement.PRE,
+                    ),
+                ),
+            ),
+        )
+        codes = {c for c, _ in gate_typing_diagnostics(env, env.n_x["bad"])}
+        assert "missing_gate_signal" in codes

--- a/tests/model_checking/test_legacy_corpus.py
+++ b/tests/model_checking/test_legacy_corpus.py
@@ -21,12 +21,14 @@ from tvl.lints import lint_module
 
 EXAMPLES_ROOT = Path(__file__).resolve().parents[2] / "spec" / "examples"
 
-# The phase-6 fixtures themselves are 1.1-surface documents; exclude them from
-# the LEGACY corpus (they are the forward fixtures, not the 1.0 baseline).
+# The forward fixtures (phase-6 = RFC 0001 1.1 surface, phase-7 = RFC 0002 1.2
+# composites) are the validators-packet acceptance bar — many are deliberately
+# invalid — so they are NOT part of the LEGACY 1.0 baseline corpus.
+_FORWARD_FIXTURE_DIRS = ("validation-phase6-cvars", "validation-phase7-composites")
 CORPUS = sorted(
     p
     for p in EXAMPLES_ROOT.rglob("*.yml")
-    if "validation-phase6-cvars" not in str(p)
+    if not any(d in str(p) for d in _FORWARD_FIXTURE_DIRS)
 )
 
 INJECTED_CVARS = [

--- a/tests/model_checking/test_resolver.py
+++ b/tests/model_checking/test_resolver.py
@@ -31,6 +31,7 @@ from .model import (
     R6_STALE_CERTIFICATE,
     R7_EVIDENCE_LEAKAGE,
     R8_INSUFFICIENT_EVIDENCE,
+    R9_INVALID_CARDINALITY_VALUE,
     TVar,
     h_c,
     issue_certificate,
@@ -274,6 +275,36 @@ def test_accepted_config_contains_every_declared_cvar():
     res = resolve(module, sugg, fixed, cals, evs, certs, ctxs)
     assert res.accepted
     assert set(res.config) >= {c.name for c in module.cvars}
+
+
+def test_r9_invalid_cardinality_value_reachable_and_blocks():
+    """RFC 0002 §3.2 item 7: a resolved ensemble cardinality k < 1 is the R9
+    rejection (invalid_cardinality_value), surfaced exactly as R1-R8 are — it
+    blocks acceptance under the Accept₁.₂ algebra."""
+    module, sugg, fixed, cals, evs, certs, ctxs = _happy_inputs()
+    for bad_k in (0, -1):
+        res = resolve(
+            module, sugg, fixed, cals, evs, certs, ctxs,
+            cardinality_values={"k": bad_k},
+        )
+        assert not res.accepted
+        assert R9_INVALID_CARDINALITY_VALUE in res.rejections, (bad_k, res.rejections)
+
+
+def test_r9_unreachable_without_composites_conservativity():
+    """Accept₁.₂ coincides with RFC 0001's Accept on every composite-free
+    module: with no cardinality_values the happy path still accepts and R9 is
+    unreachable (P1 / conservative extension)."""
+    module, sugg, fixed, cals, evs, certs, ctxs = _happy_inputs()
+    res = resolve(module, sugg, fixed, cals, evs, certs, ctxs)
+    assert res.accepted
+    assert R9_INVALID_CARDINALITY_VALUE not in res.rejections
+    # A valid k ≥ 1 likewise does not trip R9.
+    res_ok = resolve(
+        module, sugg, fixed, cals, evs, certs, ctxs, cardinality_values={"k": 5}
+    )
+    assert res_ok.accepted
+    assert R9_INVALID_CARDINALITY_VALUE not in res_ok.rejections
 
 
 def test_r5_type_conformance(  # codex fresh-round finding 2

--- a/tests/test_composites.py
+++ b/tests/test_composites.py
@@ -105,6 +105,8 @@ EXPECTED: dict[str, set[str]] = {
     "unbound_signal_inputs-not-covered.tvl.yml": {"unbound_signal_inputs"},
     "missing_composite_parent-post-gate-omits-arm-tvar.tvl.yml": {"missing_composite_parent"},
     "invalid_arm_shape-unknown-arm-key.tvl.yml": {"invalid_arm_shape"},
+    "invalid_arm_shape-composite-with-tuned-params.tvl.yml": {"invalid_arm_shape"},
+    "invalid_signal_use-non-ident-inputs.tvl.yml": {"invalid_signal_use"},
     "invalid_signal_use-nonlist-inputs.tvl.yml": {"invalid_signal_use"},
     # --- reused RFC 0001 missing_ref family ---
     "missing_ref-threshold-unknown-cvar.tvl.yml": {"missing_ref"},

--- a/tests/test_composites.py
+++ b/tests/test_composites.py
@@ -1,0 +1,230 @@
+"""TVL 1.2 (RFC 0002) validators — the composite-knob algebra.
+
+Two layers, mirroring the RFC 0001 (phase-6) conformance suite:
+
+1. Fixture conformance: every module in spec/examples/validation-phase7-composites
+   produces EXACTLY its README-promised diagnostic through the real schema +
+   lint pipeline. These fixtures are the executable acceptance bar for the
+   validators packet (one happy + one rejecting fixture per §3.11 code, plus the
+   degenerate-acceptance and §4 subsumption fixtures from RFC §9 criterion 3).
+2. Targeted lint/schema checks for P1 conservative extension, the two intended
+   composite-only ratchets (§4), and the composite-use-site-only signal binding.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+BASE = pathlib.Path(__file__).resolve().parents[1]
+PKG_ROOT = BASE / "python"
+if str(PKG_ROOT) not in sys.path:
+    sys.path.insert(0, str(PKG_ROOT))
+
+import pytest  # noqa: E402
+import yaml  # noqa: E402
+
+from tvl.constraints import compile_constraints  # noqa: E402
+from tvl.lints import lint_module  # noqa: E402
+from tvl.schema import validator  # noqa: E402
+
+FIXTURES = BASE / "spec" / "examples" / "validation-phase7-composites"
+EXAMPLES = BASE / "spec" / "examples"
+
+
+def _load(name: str) -> dict:
+    return yaml.safe_load((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def _schema_errors(doc: dict) -> list:
+    return list(validator().iter_errors(doc))
+
+
+def _codes(doc: dict, severity: str | None = None) -> set:
+    return {
+        i["code"]
+        for i in lint_module(doc)
+        if isinstance(i, dict) and (severity is None or i.get("severity") == severity)
+    }
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — fixture conformance (the validators-packet acceptance bar).
+#
+# Each value is the EXACT set of ERROR codes the fixture must exhibit (and
+# nothing else). Positives map to the empty set. The single resolution-time
+# code, invalid_cardinality_value (R9), is verified by the resolver /
+# model-checking suite (tests/model_checking, R9_INVALID_CARDINALITY_VALUE) —
+# its static-well-formed companion fixture asserts NO static error here.
+# ---------------------------------------------------------------------------
+
+EXPECTED: dict[str, set[str]] = {
+    # --- happy / positive ---
+    "composite-knobs-happy.tvl.yml": set(),
+    "composite-knobs-happy-pre-cascade.tvl.yml": set(),
+    "composite-knobs-happy-m1-cascade.tvl.yml": set(),
+    "composite-knobs-happy-sampling-k1-ensemble.tvl.yml": set(),
+    "composite-knobs-happy-committee-majority.tvl.yml": set(),
+    "composite-knobs-happy-loop-max-iters-one.tvl.yml": set(),
+    "composite-knobs-happy-tagged-nesting-under-judge.tvl.yml": set(),
+    "composite-cascade-subsumes-policy.tvl.yml": set(),
+    "legacy-policy-cascade-unchanged.tvl.yml": set(),
+    "legacy-cvar-missing-signal-remains-valid.tvl.yml": set(),
+    "invalid_cardinality_value-zero-resolved-k.tvl.yml": set(),  # R9 is resolution-time
+    # --- rejecting: one per §3.11 code ---
+    "unknown_composite_kind-fourth-kind.tvl.yml": {"unknown_composite_kind"},
+    "unknown_composite_field-cross-kind-field.tvl.yml": {"unknown_composite_field"},
+    "cascade_arity-no-gate-for-two-arms.tvl.yml": {"cascade_arity"},
+    "unknown_gate_kind-unregistered-gate.tvl.yml": {"unknown_gate_kind"},
+    "composite_binds_value-value-field.tvl.yml": {"composite_binds_value"},
+    "composite_shadows_name-tvar-collision.tvl.yml": {"composite_shadows_name"},
+    "duplicate_composite-same-name.tvl.yml": {"duplicate_composite"},
+    "empty_arms-cascade-no-arms.tvl.yml": {"empty_arms"},
+    "ambiguous_arm-bare-collides-composite.tvl.yml": {"ambiguous_arm"},
+    "missing_composite_ref-tagged-nesting-ghost.tvl.yml": {"missing_composite_ref"},
+    "composite_cycle-two-node-cycle.tvl.yml": {"composite_cycle"},
+    "gate_arm_incompatible-margin-on-judge-max.tvl.yml": {"gate_arm_incompatible"},
+    "gate_kind_placement_mismatch-signal-below-post.tvl.yml": {"gate_kind_placement_mismatch"},
+    "missing_gate_signal-signal-below-no-signal.tvl.yml": {"missing_gate_signal"},
+    "duplicate_stage-stage-repeat.tvl.yml": {"duplicate_stage"},
+    "cardinality_arity_mismatch-committee-has-cardinality.tvl.yml": {"cardinality_arity_mismatch"},
+    "invalid_cardinality_type-float-cardinality.tvl.yml": {"invalid_cardinality_type"},
+    "missing_judge-judge-max-without-judge.tvl.yml": {"missing_judge"},
+    "unknown_aggregate_kind-weighted-vote.tvl.yml": {"unknown_aggregate_kind"},
+    "unknown_stop_kind-unregistered.tvl.yml": {"unknown_stop_kind"},
+    "missing_stop_threshold-signal-accept-no-threshold.tvl.yml": {"missing_stop_threshold"},
+    "missing_stop_signal-signal-accept-no-signal.tvl.yml": {"missing_stop_signal"},
+    "missing_stop_predicate-external-accept-no-predicate.tvl.yml": {"missing_stop_predicate"},
+    "stop_signal_outside_state-undeclared-key.tvl.yml": {"stop_signal_outside_state"},
+    "invalid_max_iters-zero.tvl.yml": {"invalid_max_iters"},
+    "invalid_tuned_param-cvar-parent.tvl.yml": {"invalid_tuned_param"},
+    "invalid_threshold_type-enum-cvar.tvl.yml": {"invalid_threshold_type"},
+    "missing_calibration_signal-no-signal.tvl.yml": {"missing_calibration_signal"},
+    "signal_mismatch-wrong-signal.tvl.yml": {"signal_mismatch"},
+    "unbound_signal_inputs-not-covered.tvl.yml": {"unbound_signal_inputs"},
+    "missing_composite_parent-post-gate-omits-arm-tvar.tvl.yml": {"missing_composite_parent"},
+    "invalid_arm_shape-unknown-arm-key.tvl.yml": {"invalid_arm_shape"},
+    "invalid_signal_use-nonlist-inputs.tvl.yml": {"invalid_signal_use"},
+    # --- reused RFC 0001 missing_ref family ---
+    "missing_ref-threshold-unknown-cvar.tvl.yml": {"missing_ref"},
+    "missing_ref-threshold-tvar-kind-mismatch.tvl.yml": {"missing_ref"},
+}
+
+
+def test_every_fixture_has_an_expectation():
+    """No phase-7 fixture may be added without an exact expectation (and vice
+    versa) — the suite must enumerate the whole directory."""
+    on_disk = {p.name for p in FIXTURES.glob("*.tvl.yml")}
+    assert on_disk == set(EXPECTED), {
+        "missing_expectation": sorted(on_disk - set(EXPECTED)),
+        "missing_fixture": sorted(set(EXPECTED) - on_disk),
+    }
+
+
+@pytest.mark.parametrize("name,expected_codes", sorted(EXPECTED.items()))
+def test_fixture_conformance(name, expected_codes):
+    doc = _load(name)
+
+    # All phase-7 fixtures are schema-valid 1.2 documents: the §3.11 codes are
+    # NORMATIVE LINTS, not schema_errors (the shape-vs-registry layering).
+    errors = _schema_errors(doc)
+    assert not errors, f"{name}: schema errors {[e.message for e in errors[:3]]}"
+
+    error_codes = _codes(doc, "error")
+    # EXACT equality: the fixture exhibits its diagnostic and NOTHING else —
+    # extra errors would be new-lint false positives.
+    assert error_codes == expected_codes, (name, error_codes)
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — targeted checks (P1, the two ratchets, use-site-only binding).
+# ---------------------------------------------------------------------------
+
+
+def test_p1_no_composites_block_is_byte_identical_lint():
+    """Conservative extension: removing the composites block from a 1.2 module
+    leaves a 1.1 module whose lint output gains no composite error code."""
+    doc = _load("composite-knobs-happy.tvl.yml")
+    before = _codes(doc, "error")
+    assert not before
+    doc.pop("composites")
+    after = _codes(doc, "error")
+    assert not after
+
+
+def test_legacy_policy_cascade_does_not_get_composite_ratchets():
+    """§4 / P1: the two composite-only ratchets — empty-tuned_params parent
+    coverage and the signal/threshold binding — NEVER fire on a legacy
+    policies: cascade, even when its threshold CVAR omits calibration.signal."""
+    doc = _load("legacy-policy-cascade-unchanged.tvl.yml")
+    codes = _codes(doc, "error")
+    ratchet_codes = {
+        "missing_calibration_signal",
+        "signal_mismatch",
+        "unbound_signal_inputs",
+        "missing_composite_parent",
+    }
+    assert not (codes & ratchet_codes), codes
+
+
+def test_signal_binding_is_composite_use_site_only():
+    """§3.2 item 11: a CVAR whose calibration.signal is absent is well-formed in
+    isolation — the binding lints fire ONLY at a composite use site."""
+    doc = _load("legacy-cvar-missing-signal-remains-valid.tvl.yml")
+    codes = _codes(doc, "error")
+    assert "missing_calibration_signal" not in codes
+    assert "signal_mismatch" not in codes
+    assert "unbound_signal_inputs" not in codes
+
+
+def test_subsumption_pair_lints_identically_modulo_ratchets():
+    """RFC §9 criterion 3: the policies cascade and its composite form have
+    identical execution semantics and both validate clean — the composite form
+    only ADDS the two ratchet obligations (which it satisfies here)."""
+    policy_doc = _load("legacy-policy-cascade-unchanged.tvl.yml")
+    composite_doc = _load("composite-cascade-subsumes-policy.tvl.yml")
+    assert not _codes(policy_doc, "error")
+    assert not _codes(composite_doc, "error")
+
+
+def test_composites_are_excluded_from_sat_encoding():
+    """P2/P5: composites are invisible to search — they never enter Γ or the SAT
+    encoding (only the member TVARs do)."""
+    doc = _load("composite-knobs-happy.tvl.yml")
+    compiled = compile_constraints(doc)
+    assert set(compiled.domains) == {
+        "cheap_model",
+        "temperature",
+        "strong_model",
+        "k_samples",
+    }
+    # no composite/cvar name leaks into the solver variables
+    for leaked in ("answerer", "voter", "refiner", "router.margin_threshold"):
+        assert leaked not in compiled.domains
+
+
+def test_loop_over_composite_accrues_nested_leaf_tvars():
+    """§3.5 note: a signal_accept loop whose body is a COMPOSITE arm accrues the
+    whole nested subtree's tuned TVARs into its stop-threshold obligation."""
+    doc = _load("composite-knobs-happy.tvl.yml")
+    # Re-point the loop body at the answerer composite (whose arms tune
+    # cheap_model/temperature/strong_model) without covering them in depends_on.
+    loop = next(c for c in doc["composites"] if c["name"] == "refiner")
+    loop["body"] = {"composite": "answerer"}
+    codes = _codes(doc, "error")
+    assert "missing_composite_parent" in codes
+
+
+def test_schema_keeps_signal_inputs_extension_key():
+    """The §3.2 item-11 freshness extension key is admissible AND the new
+    declaration sub-shapes that ARE closed stay closed (P8 discipline)."""
+    schema = json.loads((BASE / "spec" / "grammar" / "tvl.schema.json").read_text())
+    rc = schema["properties"]["promotion_policy"]["properties"]["require_calibration"]
+    enum = rc["properties"]["hash_covered_context"]["items"]["enum"]
+    assert "signal_inputs" in enum
+    assert "signal_inputs" in rc["properties"]
+    # The composite gate/aggregate/accept/stop sub-shapes stay CLOSED; only the
+    # Composite envelope and the arm/signal surfaces are open (lints own those).
+    for shape in ("CompositeGateDecl", "AggregateDecl", "AcceptDecl", "StopDecl"):
+        assert schema["$defs"][shape].get("additionalProperties") is False, shape

--- a/tests/test_cvars_policies.py
+++ b/tests/test_cvars_policies.py
@@ -154,7 +154,9 @@ def test_p1_all_existing_examples_unchanged():
     }
     checked = 0
     for path in sorted(EXAMPLES.rglob("*.yml")):
-        if "validation-phase6-cvars" in str(path):
+        # Skip the forward validators-packet fixtures (phase 6 = RFC 0001,
+        # phase 7 = RFC 0002) — many are deliberately invalid by design.
+        if "validation-phase6-cvars" in str(path) or "validation-phase7-composites" in str(path):
             continue
         doc = yaml.safe_load(path.read_text(encoding="utf-8"))
         if not isinstance(doc, dict) or "tvars" not in doc:


### PR DESCRIPTION
## What

The complete TVL-side delivery of **RFC 0002 — Composite Knobs** (TVL 1.2, conservative extension of 1.1):

1. **`formalization/rfc-0002-composite-knobs.md` — ACCEPTED** (owner, 2026-06-06). Sealed `CompositeKind ∈ {cascade, ensemble, loop}` closed under nesting; open pattern catalog contract; cascade-policy subsumption; claims C1–C6.
2. **Model checking** (`tests/model_checking/composites_model.py` + `test_composites_c1_c6.py`): 38 small-scope checks with paired vacuity TEETH and independent oracles (reachability, member walk, dual execution).
3. **Validators packet**: `composites:` grammar (schema + EBNF), `_lint_composites()` implementing the full §3.11 1:1 code table (34 codes incl. the item-11 signal/threshold binding family) with exact diagnostics, **48 conformance fixtures** (12 positive incl. degenerates + subsumption pair; 36 rejecting, one per code), R9 `Accept₁.₂` resolver extension (conservative — unreachable on 1.1 modules).

## Review chain (recorded in RFC §10)
- RFC: 7 anchored codex gpt-5.5 xhigh rounds (10→5→3→1→ACCEPT→1→ACCEPT) + a **fresh unanchored pass** (8 blocking + 4 non-blocking — all dispositioned) + owner acceptance.
- Validators: codex round 1 REJECT (2 closure bypasses proven by mutation probes) → both fixed **red-first using the reviewer's exact probes as fixtures** → delta **ACCEPT**.
- Model checking: green, re-run personally by the integrating captain.

## Verification
- Full suite: **400 passed** (342 baseline + 56 packet + 2 closure fixes).
- P1 conservativity: `rag-support-bot.tvl.yml` + all legacy examples validate unchanged; legacy-corpus exclusions mirror the phase-6 precedent.
- Governance: ChangeSession `cs_aef1b9d2edfa5200`, FR-TVL-COMPOSITE-KNOBS-V1.

Sibling PRs: Traigent#1164 (SDK IR + pattern catalog, codex-ACCEPTed); js loader parse-parity in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)