### PR TITLE
fix(security): harden tvl website (path traversal, headers, XSS) + pin CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
           node-version: "22"
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: "10"
 

--- a/.github/workflows/tvl-website-deploy.yml
+++ b/.github/workflows/tvl-website-deploy.yml
@@ -49,7 +49,7 @@ jobs:
           test -n "$TVL_WEBSITE_CLOUDFRONT_DISTRIBUTION_ID"
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10.30.3
 
@@ -77,7 +77,7 @@ jobs:
         run: pnpm run build
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-region: ${{ env.AWS_REGION }}

--- a/website/client/src/components/CodeIDE.tsx
+++ b/website/client/src/components/CodeIDE.tsx
@@ -1,6 +1,8 @@
-import { useMemo } from "react";
+import { Fragment, useMemo } from "react";
+import type { ReactNode } from "react";
+import Prism from "prismjs";
 
-import { highlightCode, resolvePrismLanguage } from "@/lib/prism";
+import { resolvePrismLanguage } from "@/lib/prism";
 
 interface CodeIDEProps {
   code: string;
@@ -8,9 +10,51 @@ interface CodeIDEProps {
   filename?: string;
 }
 
+const FALLBACK_LANGUAGE = "markdown";
+
+type PrismTokenPart = string | Prism.Token;
+
+function sanitizeTokenClassPart(classPart: string) {
+  return classPart.replace(/[^A-Za-z0-9_-]/g, "");
+}
+
+function renderToken(token: PrismTokenPart, key: string): ReactNode {
+  if (typeof token === "string") {
+    return <Fragment key={key}>{token}</Fragment>;
+  }
+
+  const aliases = Array.isArray(token.alias)
+    ? token.alias
+    : token.alias
+      ? [token.alias]
+      : [];
+  const className = ["token", token.type, ...aliases]
+    .map(sanitizeTokenClassPart)
+    .filter(Boolean)
+    .join(" ");
+  const content = Array.isArray(token.content)
+    ? token.content.map((child, index) => renderToken(child, `${key}-${index}`))
+    : renderToken(token.content as PrismTokenPart, `${key}-0`);
+
+  return (
+    <span key={key} className={className}>
+      {content}
+    </span>
+  );
+}
+
+function tokenizeSafely(code: string, language: string): PrismTokenPart[] {
+  const grammar = Prism.languages[language] ?? Prism.languages[FALLBACK_LANGUAGE];
+  if (!grammar) {
+    return [code];
+  }
+
+  return Prism.tokenize(code, grammar) as PrismTokenPart[];
+}
+
 export default function CodeIDE({ code, language, filename }: CodeIDEProps) {
   const resolvedLanguage = resolvePrismLanguage(language);
-  const highlighted = useMemo(() => highlightCode(code, resolvedLanguage), [code, resolvedLanguage]);
+  const tokens = useMemo(() => tokenizeSafely(code, resolvedLanguage), [code, resolvedLanguage]);
 
   return (
     <div className="code-ide overflow-hidden rounded-lg border border-border/70 bg-card/40">
@@ -26,12 +70,10 @@ export default function CodeIDE({ code, language, filename }: CodeIDEProps) {
         </span>
       </div>
       <pre className="m-0 overflow-x-auto px-4 py-4 text-sm">
-        <code
-          className={`language-${resolvedLanguage}`}
-          dangerouslySetInnerHTML={{ __html: highlighted }}
-        />
+        <code className={`language-${resolvedLanguage}`}>
+          {tokens.map((token, index) => renderToken(token, `${resolvedLanguage}-${index}`))}
+        </code>
       </pre>
     </div>
   );
 }
-

--- a/website/server/index.ts
+++ b/website/server/index.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import { rateLimit } from "express-rate-limit";
+import fs from "fs";
 import { createServer } from "http";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -9,6 +10,138 @@ const __dirname = path.dirname(__filename);
 
 const DEFAULT_RATE_LIMIT_WINDOW_MS = 60_000;
 const DEFAULT_RATE_LIMIT_MAX_REQUESTS = 120;
+const SECURITY_HEADERS: Record<string, string> = {
+  "Content-Security-Policy":
+    "default-src 'self'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; object-src 'none'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data: https:; connect-src 'self' https:; worker-src 'self' blob:; manifest-src 'self'; upgrade-insecure-requests",
+  "Referrer-Policy": "strict-origin-when-cross-origin",
+  "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+  "X-Content-Type-Options": "nosniff",
+  "X-Frame-Options": "DENY",
+};
+
+type SafeStaticFileResult =
+  | { status: "file"; filePath: string }
+  | { status: "forbidden" }
+  | { status: "missing" };
+
+function applySecurityHeaders(res: express.Response) {
+  for (const [header, value] of Object.entries(SECURITY_HEADERS)) {
+    res.setHeader(header, value);
+  }
+}
+
+function isPathInsideRoot(root: string, targetPath: string) {
+  const relative = path.relative(root, targetPath);
+  return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+function resolveContainedPath(root: string, ...segments: string[]) {
+  const resolvedRoot = path.resolve(root);
+  const resolvedPath = path.resolve(resolvedRoot, ...segments);
+
+  if (!isPathInsideRoot(resolvedRoot, resolvedPath)) {
+    throw new Error(`resolved path escaped static root: ${resolvedPath}`);
+  }
+
+  return resolvedPath;
+}
+
+function safeRealpath(filePath: string) {
+  try {
+    return fs.realpathSync(filePath);
+  } catch {
+    return null;
+  }
+}
+
+function safeStat(filePath: string) {
+  try {
+    return fs.statSync(filePath);
+  } catch {
+    return null;
+  }
+}
+
+function rawPathnameFromUrl(rawUrl: string) {
+  const schemeSeparatorIndex = rawUrl.indexOf("://");
+  const originPathStart =
+    schemeSeparatorIndex === -1 ? 0 : rawUrl.indexOf("/", schemeSeparatorIndex + 3);
+  const pathAndQuery =
+    originPathStart === -1 ? "/" : rawUrl.slice(originPathStart || 0);
+  const queryStart = pathAndQuery.search(/[?#]/);
+
+  return queryStart === -1 ? pathAndQuery : pathAndQuery.slice(0, queryStart);
+}
+
+function resolveRequestPath(staticRoot: string, rawUrl: string) {
+  let decodedPathname: string;
+
+  try {
+    decodedPathname = decodeURIComponent(rawPathnameFromUrl(rawUrl));
+  } catch {
+    return null;
+  }
+
+  if (decodedPathname.includes("\0")) {
+    return null;
+  }
+
+  const segments = decodedPathname.split(/[\\/]+/).filter(Boolean);
+  if (segments.some(segment => segment === "..")) {
+    return null;
+  }
+
+  return resolveContainedPath(staticRoot, path.join(...segments));
+}
+
+function resolveSafeStaticFile(
+  staticRoot: string,
+  realStaticRoot: string,
+  requestedPath: string
+): SafeStaticFileResult {
+  if (!isPathInsideRoot(staticRoot, requestedPath)) {
+    return { status: "forbidden" };
+  }
+
+  const realRequestedPath = safeRealpath(requestedPath);
+  if (!realRequestedPath) {
+    return { status: "missing" };
+  }
+
+  if (!isPathInsideRoot(realStaticRoot, realRequestedPath)) {
+    return { status: "forbidden" };
+  }
+
+  const stat = safeStat(realRequestedPath);
+  if (!stat) {
+    return { status: "missing" };
+  }
+
+  if (stat.isDirectory()) {
+    const indexPath = path.resolve(requestedPath, "index.html");
+    if (!isPathInsideRoot(staticRoot, indexPath)) {
+      return { status: "forbidden" };
+    }
+
+    const realIndexPath = safeRealpath(indexPath);
+    if (!realIndexPath) {
+      return { status: "missing" };
+    }
+
+    if (!isPathInsideRoot(realStaticRoot, realIndexPath)) {
+      return { status: "forbidden" };
+    }
+
+    const indexStat = safeStat(realIndexPath);
+    return indexStat?.isFile()
+      ? { status: "file", filePath: realIndexPath }
+      : { status: "missing" };
+  }
+
+  return stat.isFile()
+    ? { status: "file", filePath: realRequestedPath }
+    : { status: "missing" };
+}
 
 export function createRateLimitMiddleware(options?: {
   windowMs?: number;
@@ -41,7 +174,9 @@ export function createApp(options?: {
   trustProxy?: boolean;
 }) {
   const app = express();
-  const staticPath = options?.staticPath ?? resolveStaticPath();
+  const staticPath = path.resolve(options?.staticPath ?? resolveStaticPath());
+  const realStaticPath = safeRealpath(staticPath) ?? staticPath;
+  const indexPath = resolveContainedPath(staticPath, "index.html");
   const trustProxy = options?.trustProxy ?? process.env.TRUST_PROXY === "true";
   const rateLimit = createRateLimitMiddleware({
     windowMs: options?.rateLimitWindowMs,
@@ -49,23 +184,55 @@ export function createApp(options?: {
     trustProxy,
   });
 
+  app.disable("x-powered-by");
+
   if (trustProxy) {
     app.set("trust proxy", true);
   }
 
-  app.use(
-    express.static(staticPath, {
-      setHeaders: (res, filePath) => {
-        if (filePath.endsWith(".ebnf")) {
-          res.type("text/plain; charset=utf-8");
-        }
-      },
-    })
-  );
+  app.use((_req, res, next) => {
+    applySecurityHeaders(res);
+    next();
+  });
+
+  app.use((req, res, next) => {
+    if (req.method !== "GET" && req.method !== "HEAD") {
+      return next();
+    }
+
+    const requestedPath = resolveRequestPath(staticPath, req.originalUrl || req.url);
+    if (!requestedPath) {
+      return res.status(400).send("Invalid path");
+    }
+
+    const staticFile = resolveSafeStaticFile(staticPath, realStaticPath, requestedPath);
+    if (staticFile.status === "forbidden") {
+      return res.status(403).send("Forbidden");
+    }
+
+    if (staticFile.status === "missing") {
+      return next();
+    }
+
+    if (requestedPath.endsWith(".ebnf") || staticFile.filePath.endsWith(".ebnf")) {
+      res.type("text/plain; charset=utf-8");
+    }
+
+    return res.sendFile(staticFile.filePath);
+  });
 
   // Handle client-side routing - serve index.html for all routes
   app.get("*", rateLimit, (_req, res) => {
-    res.sendFile(path.join(staticPath, "index.html"));
+    const indexFile = resolveSafeStaticFile(staticPath, realStaticPath, indexPath);
+    if (indexFile.status === "forbidden") {
+      return res.status(403).send("Forbidden");
+    }
+
+    if (indexFile.status === "missing") {
+      return res.status(404).send("Not found");
+    }
+
+    return res.sendFile(indexFile.filePath);
   });
 
   return app;


### PR DESCRIPTION
Resolves Aikido P0 SAST findings (independent Codex 5.5 review: GO).

**Server (`website/server/index.ts`)** — Express **path-traversal/file-inclusion** containment: reject `../`/absolute paths, resolve + verify under static root, **realpath** check blocks symlink escapes; add **security headers** (CSP, X-Content-Type-Options, X-Frame-Options + frame-ancestors, Referrer-Policy, HSTS); disable `x-powered-by`.
**Client (`CodeIDE.tsx`)** — remove `dangerouslySetInnerHTML`; render Prism tokens as escaped React nodes.
**CI** — pin 3rd-party actions to **commit SHAs** (pnpm/action-setup `b906affc`, aws configure-creds `7474bc46`; verified real).

No deps added. tsc not run locally (no node_modules offline) — CI validates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)