### PR TITLE
fix(deps): upgrade react-hook-form to 7.81.0

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -58,7 +58,7 @@
     "react": "^18.3.1",
     "react-day-picker": "^9.11.1",
     "react-dom": "^18.3.1",
-    "react-hook-form": "^7.64.0",
+    "react-hook-form": "^7.81.0",
     "react-resizable-panels": "^3.0.6",
     "recharts": "^2.15.2",
     "sonner": "^2.0.7",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -150,8 +150,8 @@ importers:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
       react-hook-form:
-        specifier: ^7.64.0
-        version: 7.72.1(react@18.3.1)
+        specifier: ^7.81.0
+        version: 7.81.0(react@18.3.1)
       react-resizable-panels:
         specifier: ^3.0.6
         version: 3.0.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3329,8 +3329,8 @@ packages:
     peerDependencies:
       react: ^19.2.5
 
-  react-hook-form@7.72.1:
-    resolution: {integrity: sha512-RhwBoy2ygeVZje+C+bwJ8g0NjTdBmDlJvAUHTxRjTmSUKPYsKfMphkS2sgEMotsY03bP358yEYlnUeZy//D9Ig==}
+  react-hook-form@7.81.0:
+    resolution: {integrity: sha512-ocbmr2p5KBMoAfj4WCUvped33lVi1Kd5DuDUvQDnB6VEAacOjPI/jMbtDdbhco4y9ct4xUuCmMY0b/C9L0QHjw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
@@ -7252,7 +7252,7 @@ snapshots:
       react: 19.2.5
       scheduler: 0.27.0
 
-  react-hook-form@7.72.1(react@18.3.1):
+  react-hook-form@7.81.0(react@18.3.1):
     dependencies:
       react: 18.3.1
 


### PR DESCRIPTION
## Summary

- upgrade website react-hook-form from 7.72.1 / ^7.64.0 to 7.81.0 / ^7.81.0
- preserve Python 3.10 support; no Python or NumPy files are changed

Aikido: AIKIDO-2026-925158

## Testing

- pnpm frozen install passes
- TypeScript check passes
- production Vite build passes
- independent review: pass, no findings

## Residual

TVL's Python 3.10 lock branch cannot adopt NumPy 2.4.5 because NumPy 2.4 requires Python 3.11+. That residual remains visible and unsuppressed.

Spine: cs_cf11a85e943a0581