### PR TITLE
fix(tvl): promotion n<2 guard, value-based enum inequality SAT, lint fail-closed on non-mapping

### DIFF
--- a/python/tvl/constraints.py
+++ b/python/tvl/constraints.py
@@ -250,6 +250,39 @@ def _create_variable(model: cp_model.CpModel, domain: Domain) -> cp_model.IntVar
     raise ValueError(f"Unsupported domain type {domain.kind}")
 
 
+def _reify_index_membership(
+    model: cp_model.CpModel,
+    var: cp_model.IntVar,
+    allowed: Sequence[int],
+    num_values: int,
+    lit: cp_model.BoolVar,
+) -> None:
+    """Constrain ``lit`` to be true iff ``var`` takes one of the ``allowed`` indices.
+
+    Unlike the previous ``var <= max(allowed)`` encoding, this makes no
+    assumption that the enum's index order matches its value order — it reifies
+    membership over the exact set of satisfying indices, so it is correct for
+    unsorted numeric enums (e.g. legacy dict-form tvars, which are not sorted).
+    """
+    allowed_set = sorted({idx for idx in allowed if 0 <= idx < num_values})
+    if not allowed_set:
+        model.Add(lit == 0)
+        return
+    if len(allowed_set) == num_values:
+        model.Add(lit == 1)
+        return
+    member_lits = []
+    for idx in allowed_set:
+        member = model.NewBoolVar(f"{var.Name()}_eq_{idx}")
+        model.Add(var == idx).OnlyEnforceIf(member)
+        model.Add(var != idx).OnlyEnforceIf(member.Not())
+        member_lits.append(member)
+    # lit <=> OR(member_lits)
+    model.AddBoolOr(member_lits).OnlyEnforceIf(lit)
+    for member in member_lits:
+        model.AddImplication(member, lit)
+
+
 def _atom_literal(
     model: cp_model.CpModel,
     var_map: Dict[str, cp_model.IntVar],
@@ -299,40 +332,23 @@ def _atom_literal(
                 model.Add(var == encoded).OnlyEnforceIf(lit.Not())
             return lit
 
-        if is_numeric_enum:
+        if is_numeric_enum and atom.op in ("<", "<=", ">", ">="):
             threshold = float(atom.value)
+            # Compare enum VALUES against the threshold, not enum indices: the
+            # index order is not guaranteed to match value order (legacy
+            # dict-form tvars are stored verbatim; only list-form sorts), so we
+            # collect the exact set of value-satisfying indices and reify
+            # membership over it rather than assuming a contiguous index range.
             if atom.op == "<":
                 allowed = [idx for idx, val in enumerate(values) if val < threshold]
-                if not allowed:
-                    model.Add(lit == 0)
-                else:
-                    model.Add(var <= max(allowed)).OnlyEnforceIf(lit)
-                    model.Add(var >= max(allowed) + 1).OnlyEnforceIf(lit.Not())
-                return lit
-            if atom.op == "<=":
+            elif atom.op == "<=":
                 allowed = [idx for idx, val in enumerate(values) if val <= threshold]
-                if not allowed:
-                    model.Add(lit == 0)
-                else:
-                    model.Add(var <= max(allowed)).OnlyEnforceIf(lit)
-                    model.Add(var >= max(allowed) + 1).OnlyEnforceIf(lit.Not())
-                return lit
-            if atom.op == ">":
+            elif atom.op == ">":
                 allowed = [idx for idx, val in enumerate(values) if val > threshold]
-                if not allowed:
-                    model.Add(lit == 0)
-                else:
-                    model.Add(var >= min(allowed)).OnlyEnforceIf(lit)
-                    model.Add(var <= min(allowed) - 1).OnlyEnforceIf(lit.Not())
-                return lit
-            if atom.op == ">=":
+            else:  # ">="
                 allowed = [idx for idx, val in enumerate(values) if val >= threshold]
-                if not allowed:
-                    model.Add(lit == 0)
-                else:
-                    model.Add(var >= min(allowed)).OnlyEnforceIf(lit)
-                    model.Add(var <= min(allowed) - 1).OnlyEnforceIf(lit.Not())
-                return lit
+            _reify_index_membership(model, var, allowed, len(values), lit)
+            return lit
 
         # Unsupported comparison on symbolic enum; fall back to conservative true.
         model.Add(lit == 1)

--- a/python/tvl/promotion.py
+++ b/python/tvl/promotion.py
@@ -389,6 +389,28 @@ def _test_from_samples(
     sigma = 1 if spec.direction == "maximize" else -1
     epsilon = spec.epsilon
 
+    # A single sample provides no variance estimate, so no t-test is defined.
+    # Mirror the aggregated-stats sibling (`_test_from_stats`) and degrade to an
+    # 'inconclusive' verdict instead of dividing by (n - 1) == 0 further down
+    # (Welch-Satterthwaite df), which raised ZeroDivisionError.
+    if n_inc < 2 or n_cand < 2:
+        return ObjectiveResult(
+            name=spec.name,
+            test_type="welch",
+            n_incumbent=n_inc,
+            n_candidate=n_cand,
+            mean_incumbent=mean_inc,
+            mean_candidate=mean_cand,
+            delta=delta,
+            std_pooled=None,
+            t_statistic=None,
+            df=None,
+            p_value_noninf=1.0,
+            p_value_super=1.0,
+            epsilon=epsilon,
+            verdict="inconclusive",
+        )
+
     if paired and n_inc == n_cand and n_inc > 1:
         # Paired t-test
         diffs = [c - i for c, i in zip(cand_samples, inc_samples)]

--- a/tests/test_constraints_numeric_enum_order.py
+++ b/tests/test_constraints_numeric_enum_order.py
@@ -1,0 +1,85 @@
+"""Regression: numeric-enum inequality constraints assumed index order == value order.
+
+The `<`/`<=`/`>`/`>=` encoder in `_atom_literal` built the set of indices whose
+VALUE satisfies the comparison, then constrained `var <= max(allowed)` (or
+`var >= min(allowed)`). That is only correct when the enum values are sorted so
+the satisfying indices are contiguous. List-form tvar declarations sort numeric
+enums, but the legacy dict-form path stores them verbatim, so an out-of-order
+numeric enum encoded a wrong SAT/UNSAT verdict (fail-open): the solver could
+satisfy `temperature < 0.6` by picking the value 1.0.
+
+The encoder now reifies membership over the exact satisfying index set, so the
+verdict is correct regardless of declaration form / value order.
+
+See Traigent/tvl#33.
+"""
+
+from __future__ import annotations
+
+from tvl.constraints import check_structural_satisfiable, compile_constraints
+
+
+def test_unsorted_dict_form_numeric_enum_is_unsat():
+    """`temp < 0.6 AND temp = 1.0` is UNSAT; the buggy encoder reported SAT."""
+    module = {
+        "tvars": {"sampling": {"temperature": {"type": "enum", "values": [1.0, 0.0, 0.5]}}},
+        "constraints": {
+            "structural": [
+                {"expr": "sampling.temperature < 0.6"},
+                {"expr": "sampling.temperature = 1.0"},
+            ]
+        },
+    }
+    result = check_structural_satisfiable(compile_constraints(module))
+    assert result["ok"] is False
+
+
+def test_unsorted_dict_form_numeric_enum_sat_witness_respects_threshold():
+    """A genuinely satisfiable spec still solves, with a value below threshold."""
+    module = {
+        "tvars": {"sampling": {"temperature": {"type": "enum", "values": [1.0, 0.0, 0.5]}}},
+        "constraints": {"structural": [{"expr": "sampling.temperature < 0.6"}]},
+    }
+    result = check_structural_satisfiable(compile_constraints(module))
+    assert result["ok"] is True
+    assert result["assignment"]["sampling.temperature"] < 0.6
+
+
+def test_dict_form_and_list_form_agree():
+    """The verdict must depend on semantics, not declaration form."""
+    dict_form = {
+        "tvars": {"sampling": {"temperature": {"type": "enum", "values": [1.0, 0.0, 0.5]}}},
+        "constraints": {
+            "structural": [
+                {"expr": "sampling.temperature < 0.6"},
+                {"expr": "sampling.temperature = 1.0"},
+            ]
+        },
+    }
+    list_form = {
+        "tvars": [{"name": "temperature", "type": "enum", "domain": {"set": [1.0, 0.0, 0.5]}}],
+        "constraints": {
+            "structural": [
+                {"expr": "temperature < 0.6"},
+                {"expr": "temperature = 1.0"},
+            ]
+        },
+    }
+    d = check_structural_satisfiable(compile_constraints(dict_form))
+    l = check_structural_satisfiable(compile_constraints(list_form))
+    assert d["ok"] == l["ok"] is False
+
+
+def test_greater_than_on_unsorted_enum():
+    """The same fix must hold for the `>` direction."""
+    module = {
+        "tvars": {"sampling": {"temperature": {"type": "enum", "values": [1.0, 0.0, 0.5]}}},
+        "constraints": {
+            "structural": [
+                {"expr": "sampling.temperature > 0.6"},
+                {"expr": "sampling.temperature = 0.0"},
+            ]
+        },
+    }
+    result = check_structural_satisfiable(compile_constraints(module))
+    assert result["ok"] is False

--- a/tests/test_lint_non_mapping.py
+++ b/tests/test_lint_non_mapping.py
@@ -1,0 +1,51 @@
+"""Regression: tvl-lint fail-open on a non-mapping top-level document.
+
+`cli.py` coerced the parsed document with `doc if isinstance(doc, dict) else {}`,
+so a top-level YAML sequence, a bare scalar, or an empty file linted against an
+empty mapping — the CLI printed "Lint checks passed." with ok=true and exited 0.
+The sibling `tvl-validate` rejects the identical input (`raise TypeError` -> exit
+2), so a CI step gating on tvl-lint alone failed open on a non-TVL file.
+
+tvl-lint now emits an `invalid_document` issue and fails closed, consistent with
+tvl-validate.
+
+See Traigent/tvl#34.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tvl_tools.tvl_lint import cli as lint_cli
+
+
+def _run_lint(tmp_path, monkeypatch, capsys, content: str):
+    target = tmp_path / "broken.tvl.yml"
+    target.write_text(content)
+    monkeypatch.setattr("sys.argv", ["tvl-lint", str(target), "--format", "json"])
+    with pytest.raises(SystemExit) as exc:
+        lint_cli.main()
+    out = json.loads(capsys.readouterr().out)
+    return exc.value.code, out
+
+
+@pytest.mark.parametrize(
+    "content",
+    ["- foo\n- bar\n", "just a string\n", ""],
+    ids=["sequence", "scalar", "empty"],
+)
+def test_non_mapping_document_fails_closed(tmp_path, monkeypatch, capsys, content):
+    code, out = _run_lint(tmp_path, monkeypatch, capsys, content)
+    assert code == 2
+    assert out["ok"] is False
+    assert any(issue["code"] == "invalid_document" for issue in out["issues"])
+
+
+def test_mapping_document_still_lints_normally(tmp_path, monkeypatch, capsys):
+    """A real mapping is still linted (no spurious invalid_document issue)."""
+    content = "tvars:\n  x:\n    type: bool\n"
+    code, out = _run_lint(tmp_path, monkeypatch, capsys, content)
+    # The stub module has other lint issues, but never the top-level one.
+    assert not any(issue["code"] == "invalid_document" for issue in out["issues"])

--- a/tests/test_promotion_single_sample.py
+++ b/tests/test_promotion_single_sample.py
@@ -1,0 +1,50 @@
+"""Regression: sample-based objective test crashed on a single-sample arm.
+
+`_test_from_samples` reached the Welch-Satterthwaite df computation
+`(var/n)**2 / (n - 1)` with n == 1 whenever exactly one arm had a single
+sample and the other had non-zero variance, raising ZeroDivisionError
+(promotion.py). Its aggregated-stats sibling `_test_from_stats` already
+guarded the identical degenerate input with `if n_inc < 2 or n_cand < 2:
+return ... verdict='inconclusive'`. A single sample is schema-valid
+(tvl-measurement.schema.json: samples minItems 1, n minimum 1) and passes
+the readiness pre-gate, so the crash was reachable from valid input.
+
+See Traigent/tvl#32.
+"""
+
+from __future__ import annotations
+
+from tvl.promotion import ObjectiveSpec, _test_from_samples, _test_from_stats
+
+
+def _spec() -> ObjectiveSpec:
+    return ObjectiveSpec(
+        name="quality", direction="maximize", epsilon=0.02, band=None, metric_ref=None
+    )
+
+
+def test_single_sample_incumbent_degrades_to_inconclusive():
+    """n=1 vs n>=2 (non-zero variance) must not raise; it degrades gracefully."""
+    result = _test_from_samples(_spec(), [0.90], [0.80, 0.85, 0.88], paired=False)
+    assert result.verdict == "inconclusive"
+    assert result.df is None
+    assert result.p_value_noninf == 1.0
+    assert result.p_value_super == 1.0
+
+
+def test_single_sample_matches_aggregated_stats_sibling():
+    """Identical n=1 evidence yields the same verdict from both code paths."""
+    from_samples = _test_from_samples(_spec(), [0.90], [0.80, 0.85, 0.88], paired=False)
+    from_stats = _test_from_stats(
+        _spec(), {"mean": 0.90, "std": 0.0, "n": 1}, {"mean": 0.84, "std": 0.04, "n": 3}
+    )
+    assert from_samples.verdict == from_stats.verdict == "inconclusive"
+
+
+def test_multi_sample_still_runs_welch():
+    """The guard must not disturb the normal (n>=2 on both arms) path."""
+    result = _test_from_samples(
+        _spec(), [0.90, 0.91, 0.92], [0.80, 0.85, 0.88], paired=False
+    )
+    assert result.df is not None
+    assert result.df > 0

--- a/tvl_tools/tvl_lint/cli.py
+++ b/tvl_tools/tvl_lint/cli.py
@@ -37,8 +37,22 @@ def main() -> None:
     args = parser.parse_args()
 
     try:
-        doc: Dict[str, Any] = load_yaml_safely(args.file)
-        issues = lint(doc if isinstance(doc, dict) else {}, precision=args.precision)
+        doc = load_yaml_safely(args.file)
+        if isinstance(doc, dict):
+            issues = lint(doc, precision=args.precision)
+        else:
+            # A top-level YAML sequence, bare scalar, or empty file is not a TVL
+            # module. Fail closed with an explicit issue instead of substituting
+            # an empty mapping (which silently linted clean), staying consistent
+            # with the sibling tvl-validate that rejects the same input.
+            issues = [
+                {
+                    "code": "invalid_document",
+                    "message": "TVL module must be a mapping at the top level",
+                    "path": [],
+                    "severity": "error",
+                }
+            ]
 
         out = {
             "ok": len(issues) == 0,


### PR DESCRIPTION
Three small, validated correctness fixes from the captains-leader campaign (wave 1).

## #32 — promotion single-sample crash (`python/tvl/promotion.py`)
`_test_from_samples` reached the Welch-Satterthwaite df term `(var/n)**2 / (n - 1)` with `n == 1` whenever one arm had a single sample and the other had non-zero variance, raising `ZeroDivisionError`. A single sample is schema-valid (`tvl-measurement.schema.json`: samples `minItems 1`, n `minimum 1`) and passes the readiness pre-gate, so the crash was reachable from valid input, while the identical evidence supplied as aggregated `mean/std/n` returned a clean `inconclusive`.
Fix: add the same `if n_inc < 2 or n_cand < 2: return ... verdict="inconclusive"` guard the sibling `_test_from_stats` already has, so both code paths degrade identically.
Verified: reproduced the `ZeroDivisionError`; after the fix the same input returns `inconclusive` and matches the stats sibling; the normal n>=2 Welch path is unchanged (df still computed).

## #33 — numeric-enum inequality compared indices, not values (`python/tvl/constraints.py`)
The `<`/`<=`/`>`/`>=` encoder in `_atom_literal` collected the value-satisfying indices then constrained `var <= max(allowed)` / `var >= min(allowed)`, which is only correct when the enum values are sorted so those indices are contiguous. List-form tvars sort numeric enums; the legacy dict-form path stores them verbatim, so an out-of-order numeric enum (e.g. `values: [1.0, 0.0, 0.5]`) encoded a fail-open verdict — the solver could satisfy `temperature < 0.6` by choosing the value `1.0`.
Fix: reify literal membership over the exact set of value-satisfying indices (`_reify_index_membership`) instead of assuming a contiguous index range, so the verdict follows enum VALUES regardless of declaration form / order.
Verified: reproduced the fail-open (`temp < 0.6 AND temp = 1.0` reported SAT with witness `1.0`); after the fix it is UNSAT, a genuinely satisfiable spec still solves with a value below threshold, and dict-form now agrees with the already-correct list-form. All existing structural-SAT and model-checking suites still pass (no encoding regressions).

## #34 — tvl-lint fail-open on a non-mapping document (`tvl_tools/tvl_lint/cli.py`)
`lint(doc if isinstance(doc, dict) else {}, ...)` linted a top-level YAML sequence / bare scalar / empty file against an empty mapping, printing "Lint checks passed." with `ok: true`, exit 0 — while sibling `tvl-validate` rejects the same input (exit 2), so a CI step gating on tvl-lint alone failed open.
Fix: on a non-mapping document emit an `invalid_document` issue and fail closed (exit 2), consistent with tvl-validate.
Verified: sequence, scalar, and empty inputs now all return `ok: false` with the `invalid_document` issue and exit 2; a real mapping still lints normally (no spurious top-level issue).

## Tests
Added three focused regression tests (`tests/test_promotion_single_sample.py`, `tests/test_constraints_numeric_enum_order.py`, `tests/test_lint_non_mapping.py`). Ran the new tests plus the touched-area existing suites — all green.

Closes #32
Closes #33
Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #32
Closes #33
Closes #34

Spine: cs_db182d6d0d9b1f82

🤖 Generated with [Claude Code](https://claude.com/claude-code)
