### PR TITLE
fix(constraints): close three fail-open gaps in the assignment-constraint validator

### DIFF
--- a/python/tvl/constraints.py
+++ b/python/tvl/constraints.py
@@ -14,7 +14,7 @@ from .model import Domain, extract_domains, flatten_assignments
 
 _OR_SPLIT = re.compile(r"\s+or\s+", re.IGNORECASE)
 _AND_SPLIT = re.compile(r"\s+and\s+", re.IGNORECASE)
-_LITERAL_RE = re.compile(r"^\s*([A-Za-z0-9_.-]+)\s*(<=|>=|!=|=|<|>)\s*(.+?)\s*$")
+_LITERAL_RE = re.compile(r"^\s*([A-Za-z0-9_.-]+)\s*(<=|>=|!=|==|=|<|>)\s*(.+?)\s*$")
 
 _TRUE_COUNTER = 0
 
@@ -210,18 +210,24 @@ def evaluate_assignment(compiled: CompiledConstraints, assignments: Dict[str, An
         antecedent = constraint.antecedent or [[]]
         consequent = constraint.consequent or [[]]
 
-        satisfied = False
-        for cond in antecedent:
-            cond_true = all(atom_true(atom) for atom in cond)
-            if not cond_true:
-                satisfied = True
-                break
-
+        # The antecedent is a DNF (OR of conjunctions); it holds iff ANY
+        # disjunct holds. It is vacuously true only when EVERY disjunct is
+        # false. Short-circuiting on the first false disjunct (the previous
+        # behaviour) declared the whole constraint satisfied as soon as one
+        # disjunct was false — a fail-open that mirrored neither the intended
+        # semantics nor the SAT encoder, which encodes (d1 ∨ d2) → C as
+        # (d1 → C) ∧ (d2 → C).
+        antecedent_true = any(
+            all(atom_true(atom) for atom in cond) for cond in antecedent
+        )
+        if not antecedent_true:
+            # antecedent false → constraint vacuously satisfied
+            satisfied = True
+        else:
             # antecedent holds → consequent must hold
-            conseq_ok = any(all(atom_true(atom) for atom in conj) for conj in consequent)
-            if conseq_ok:
-                satisfied = True
-                break
+            satisfied = any(
+                all(atom_true(atom) for atom in conj) for conj in consequent
+            )
 
         if not satisfied:
             constraint_issues.append({"code": "constraint_failed", "constraint_index": idx, "raw": constraint.raw})
@@ -334,9 +340,16 @@ def _atom_literal(
                     model.Add(var <= min(allowed) - 1).OnlyEnforceIf(lit.Not())
                 return lit
 
-        # Unsupported comparison on symbolic enum; fall back to conservative true.
-        model.Add(lit == 1)
-        return lit
+        # Ordering comparison (<, <=, >, >=) on a symbolic (non-numeric) enum
+        # has no defined order, so it cannot be encoded soundly. Forcing the
+        # literal true (the previous behaviour) made the atom a tautology and
+        # the whole clause fail open, letting violating configs pass. Reject it
+        # instead — matching the fail-closed `raise` for unsupported operators
+        # on ordered domains below.
+        raise ValueError(
+            f"Unsupported ordering operator {atom.op!r} on symbolic enum "
+            f"'{atom.path}' (enum values are not ordered)"
+        )
 
     encoded = domain.encode(atom.value)
     lit = model.NewBoolVar(f"lit_{atom.path.replace('.', '_')}_{atom.op}_{atom.value}")

--- a/tests/test_constraints_fail_open_regression.py
+++ b/tests/test_constraints_fail_open_regression.py
@@ -1,0 +1,117 @@
+"""Regression tests for fail-open defects in the assignment-constraint path.
+
+Covers three divergences between the shipped ``tvl-config-validate`` path
+(``compile_constraints`` / ``evaluate_assignment`` / ``_atom_literal``) and the
+intended constraint semantics:
+
+- #37 — the ``==`` equality operator was truncated to ``=`` by the regex literal
+  parser, swallowing the sign into the value string so ``==`` constraints were
+  never enforced (fail-open).
+- #38 — a disjunctive antecedent (``when: "a = 1 or b = 1"``) short-circuited to
+  satisfied on the first false disjunct, so OR-antecedent constraints were never
+  enforced (fail-open).
+- #40 — an ordering comparison on a symbolic (non-numeric) enum was encoded as
+  unconditionally satisfied in the CP-SAT encoder (fail-open); it must be
+  rejected instead.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tvl.constraints import (
+    compile_constraints,
+    evaluate_assignment,
+    parse_expression,
+)
+
+
+# --- #37: `==` equality operator ------------------------------------------
+
+
+def test_double_equals_parses_as_equality_with_typed_value():
+    disjuncts = parse_expression("a == 1")
+    assert len(disjuncts) == 1
+    (atom,) = disjuncts[0]
+    assert atom.path == "a"
+    assert atom.op == "=="
+    # The value must be the typed int 1 — not the swallowed string "= 1".
+    assert atom.value == 1
+    assert isinstance(atom.value, int)
+
+
+def test_double_equals_constraint_reports_violation():
+    module = {
+        "tvars": [
+            {"name": "a", "type": "enum", "domain": {"set": [0, 1]}},
+            {"name": "c", "type": "enum", "domain": {"set": [0, 1]}},
+        ],
+        "constraints": {"structural": [{"when": "a == 1", "then": "c == 1"}]},
+    }
+    compiled = compile_constraints(module)
+    result = evaluate_assignment(compiled, {"a": 1, "c": 0})
+    # a==1 holds, c==1 fails → the constraint must be reported violated.
+    assert any(i["code"] == "constraint_failed" for i in result["constraints"])
+
+    ok = evaluate_assignment(compiled, {"a": 1, "c": 1})
+    assert ok["constraints"] == []
+
+
+# --- #38: disjunctive antecedent ------------------------------------------
+
+
+@pytest.mark.parametrize("a,b", [(0, 1), (1, 0)])
+def test_or_antecedent_violation_is_reported(a, b):
+    module = {
+        "tvars": [
+            {"name": "a", "type": "enum", "domain": {"set": [0, 1]}},
+            {"name": "b", "type": "enum", "domain": {"set": [0, 1]}},
+            {"name": "c", "type": "enum", "domain": {"set": [0, 1]}},
+        ],
+        "constraints": {
+            "structural": [{"when": "a = 1 or b = 1", "then": "c = 1"}]
+        },
+    }
+    compiled = compile_constraints(module)
+    # (a or b) holds but c != 1 → antecedent true, consequent false → violation.
+    result = evaluate_assignment(compiled, {"a": a, "b": b, "c": 0})
+    assert any(i["code"] == "constraint_failed" for i in result["constraints"])
+
+
+def test_or_antecedent_vacuously_true_when_all_disjuncts_false():
+    module = {
+        "tvars": [
+            {"name": "a", "type": "enum", "domain": {"set": [0, 1]}},
+            {"name": "b", "type": "enum", "domain": {"set": [0, 1]}},
+            {"name": "c", "type": "enum", "domain": {"set": [0, 1]}},
+        ],
+        "constraints": {
+            "structural": [{"when": "a = 1 or b = 1", "then": "c = 1"}]
+        },
+    }
+    compiled = compile_constraints(module)
+    # Neither disjunct holds → antecedent false → vacuously satisfied.
+    result = evaluate_assignment(compiled, {"a": 0, "b": 0, "c": 0})
+    assert result["constraints"] == []
+
+
+# --- #40: ordering comparison on a symbolic enum --------------------------
+
+
+def test_symbolic_enum_ordering_is_rejected_not_fail_open():
+    pytest.importorskip("ortools")
+    from tvl.constraints import check_structural_satisfiable
+
+    module = {
+        "tvars": [
+            {
+                "name": "model",
+                "type": "enum",
+                "domain": {"set": ["gpt-3.5", "gpt-4", "claude"]},
+            }
+        ],
+        "constraints": {"structural": [{"expr": 'model < "gpt-4"'}]},
+    }
+    compiled = compile_constraints(module)
+    with pytest.raises(ValueError, match="symbolic enum"):
+        check_structural_satisfiable(compiled)


### PR DESCRIPTION
## What

Three surgical fixes to `python/tvl/constraints.py`, the module behind `tvl-config-validate`, each closing a silent fail-open where a violating configuration was reported valid:

- **#37 — `==` equality swallowed by the regex literal parser.** `_LITERAL_RE`'s operator alternation lacked `==`, so on `a == 1` it matched the first `=`, truncated the operator to `=`, and folded the leftover `= 1` into the value **string** `'= 1'` — an atom that can never match a real assignment, so the constraint failed open. Added `==` to the alternation (before the single `=` branch): `(<=|>=|!=|==|=|<|>)`. `_parse_literal` already canonicalizes to `==`, so the value is now the typed `1`.

- **#38 — OR-antecedent short-circuit in `evaluate_assignment`.** The DNF antecedent loop declared the whole constraint satisfied on the **first false disjunct**, so any `when: "a = 1 or b = 1"` constraint was effectively never checked. Replaced with the correct semantics: the antecedent (an OR of conjunctions) holds iff **any** disjunct holds and is vacuously true only when **every** disjunct is false — mirroring the SAT encoder, which encodes `(d1 ∨ d2) → C` as `(d1 → C) ∧ (d2 → C)`.

- **#40 — symbolic-enum ordering encoded as unconditionally satisfied.** In the CP-SAT encoder `_atom_literal`, an ordering comparison (`<`/`<=`/`>`/`>=`) on a non-numeric (string) enum fell through to `model.Add(lit == 1)`, making the atom a tautology and the whole clause fail open. Replaced with a fail-closed `raise ValueError`, matching the existing `raise` for unsupported operators on ordered domains — a comparison with no defined order is now rejected, not silently satisfied.

Added `tests/test_constraints_fail_open_regression.py` with focused regressions for each (equality parse + violation reporting, OR-antecedent violation + vacuous-truth cases, symbolic-enum ordering rejection; the last skips gracefully when OR-Tools is absent).

## Not done here

**#41 (consolidate the two divergent parsers onto `structural_parser`)** is intentionally left open. `structural_parser`'s output model (`Literal` with `membership` / `interval` kinds and NNF negation) has no representation in `constraints.py`'s `Atom` shape or the CP-SAT encoder / `evaluate_assignment`, which only understand flat comparison atoms. A faithful consolidation needs new bridging (membership→disjunction expansion, interval→two-atom splitting, negation→operator flips) plus a shared round-trip corpus — a design-heavy refactor beyond a small validated fix PR, and riskier than the three surgical symptom fixes. Left for a dedicated change.

## Verification

`PYTHONPATH=python TRAIGENT_MOCK_LLM=true pytest tests/test_constraints_fail_open_regression.py` → 6 passed (with OR-Tools installed; 5 passed + 1 skipped without). No LLM calls, zero spend. Existing constraint/SAT/corpus suites (`test_constraints_float_domain.py`, `test_structural_sat.py`, `test_cvars_policies.py`, `tests/model_checking/`) → 251 passed, confirming the #40 fail-closed change does not disturb the canonical example corpus.

Closes #37
Closes #38
Closes #40

Closes #37
Closes #38
Closes #40

Spine: cs_155eb5f47d463504

🤖 Generated with [Claude Code](https://claude.com/claude-code)
