### PR TITLE
fix(tvl): bound YAML loaders and constraint parsers against DoS inputs

### DIFF
--- a/python/tvl/configuration.py
+++ b/python/tvl/configuration.py
@@ -2,18 +2,18 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Dict
-import yaml
 
 from .constraints import compile_constraints, evaluate_assignment
 from .errors import ParseError, SchemaError
 from .model import flatten_assignments
 from .schema import configuration_validator
+from .yaml_safe import safe_load
 
 
 def load_configuration(path: Path | str) -> Dict[str, Any]:
     p = Path(path)
     try:
-        data = yaml.safe_load(p.read_text(encoding="utf-8"))
+        data = safe_load(p.read_text(encoding="utf-8"))
     except Exception as e:  # noqa: BLE001
         raise ParseError(str(e))
 

--- a/python/tvl/loader.py
+++ b/python/tvl/loader.py
@@ -2,10 +2,10 @@ from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Dict
-import yaml
 
 from .errors import ParseError, SchemaError
 from .schema import validator
+from .yaml_safe import safe_load
 
 
 def load(path: Path | str) -> Dict[str, Any]:
@@ -17,7 +17,7 @@ def load(path: Path | str) -> Dict[str, Any]:
     """
     p = Path(path)
     try:
-        data = yaml.safe_load(p.read_text(encoding="utf-8"))
+        data = safe_load(p.read_text(encoding="utf-8"))
     except Exception as e:  # noqa: BLE001
         raise ParseError(str(e))
 

--- a/python/tvl/measurement.py
+++ b/python/tvl/measurement.py
@@ -3,18 +3,17 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
-import yaml
-
 from .configuration import validate_configuration
 from .errors import ParseError, SchemaError
 from .promotion import SCIPY_AVAILABLE, evaluate_chance_constraint
 from .schema import measurement_validator
+from .yaml_safe import safe_load
 
 
 def load_measurement(path: Path | str) -> Dict[str, Any]:
     p = Path(path)
     try:
-        data = yaml.safe_load(p.read_text(encoding="utf-8"))
+        data = safe_load(p.read_text(encoding="utf-8"))
     except Exception as e:  # noqa: BLE001
         raise ParseError(str(e))
 

--- a/python/tvl/operational.py
+++ b/python/tvl/operational.py
@@ -181,7 +181,15 @@ def _parse_derived_expression(
                 return ".".join(reversed(parts)), False
         return None, False
 
-    def walk_expr(node):
+    # Depth guard: a deeply-nested / long chained expression (e.g. thousands of
+    # `x+x+...+x` terms) would otherwise recurse until the Python stack is
+    # exhausted, raising an uncaught RecursionError. Bail to the graceful
+    # "unparseable" path (return None) well before the real recursion limit.
+    max_depth = 400
+
+    def walk_expr(node, depth=0):
+        if depth > max_depth:
+            return None
         if isinstance(node, ast.Constant) and isinstance(node.value, (int, float)):
             return [(float(node.value), None)], []
         elif isinstance(node, (ast.Name, ast.Attribute)):
@@ -191,15 +199,15 @@ def _parse_derived_expression(
             return [(1.0, name)], [name] if legacy else []
         elif isinstance(node, ast.UnaryOp) and isinstance(node.op, (ast.UAdd, ast.USub)):
             sign = -1.0 if isinstance(node.op, ast.USub) else 1.0
-            child = walk_expr(node.operand)
+            child = walk_expr(node.operand, depth + 1)
             if child is None:
                 return None
             child_terms, legacy_symbols = child
             return [(sign * c, s) for c, s in child_terms], legacy_symbols
         elif isinstance(node, ast.BinOp):
             if isinstance(node.op, (ast.Add, ast.Sub)):
-                left = walk_expr(node.left)
-                right = walk_expr(node.right)
+                left = walk_expr(node.left, depth + 1)
+                right = walk_expr(node.right, depth + 1)
                 if left is None or right is None:
                     return None
                 left_terms, left_legacy = left
@@ -242,7 +250,12 @@ def _parse_derived_expression(
     else:
         return None, None, None, []
 
-    walked = walk_expr(tree.body.left)
+    try:
+        walked = walk_expr(tree.body.left)
+    except RecursionError:
+        # Defense in depth: the depth guard above should prevent this, but never
+        # let stack exhaustion escape as an uncaught crash of the CLI check.
+        return None, None, None, []
     if walked is None:
         return None, None, None, []
     terms_raw, legacy_symbols = walked

--- a/python/tvl/operational.py
+++ b/python/tvl/operational.py
@@ -162,10 +162,6 @@ def _parse_derived_expression(
     import re
     # Replace single `=` with `==` to support EBNF `lin_arith_expr` syntax in Python AST
     expression = re.sub(r'(?<![=<>!])=(?![=])', '==', expression)
-    try:
-        tree = ast.parse(expression, mode='eval')
-    except SyntaxError:
-        return None, None, None, []
 
     def symbol_name(node: ast.AST) -> Tuple[Optional[str], bool]:
         if isinstance(node, ast.Name):
@@ -234,24 +230,33 @@ def _parse_derived_expression(
                         return [(-float(node.left.operand.value), name)], [name] if legacy else []
         return None
 
-    if not isinstance(tree.body, ast.Compare) or len(tree.body.ops) != 1:
-        return None, None, None, []
-    op_node = tree.body.ops[0]
-    op_map = {ast.LtE: '<=', ast.GtE: '>=', ast.Lt: '<', ast.Gt: '>', ast.Eq: '=='}
-    if type(op_node) not in op_map:
-        return None, None, None, []
-    op = op_map[type(op_node)]
-
-    comp = tree.body.comparators[0]
-    if isinstance(comp, ast.UnaryOp) and isinstance(comp.op, ast.USub) and isinstance(comp.operand, ast.Constant):
-        val = -float(comp.operand.value)
-    elif isinstance(comp, ast.Constant) and isinstance(comp.value, (int, float)):
-        val = float(comp.value)
-    else:
-        return None, None, None, []
-
+    # Guard the parse itself as well as the walk below: a sufficiently deep /
+    # long chained expression can blow the stack inside ast.parse() before
+    # walk_expr ever runs, not just inside walk_expr's own recursion. One try
+    # spanning both keeps a single graceful "unparseable" exit for either
+    # failure mode.
     try:
+        tree = ast.parse(expression, mode='eval')
+
+        if not isinstance(tree.body, ast.Compare) or len(tree.body.ops) != 1:
+            return None, None, None, []
+        op_node = tree.body.ops[0]
+        op_map = {ast.LtE: '<=', ast.GtE: '>=', ast.Lt: '<', ast.Gt: '>', ast.Eq: '=='}
+        if type(op_node) not in op_map:
+            return None, None, None, []
+        op = op_map[type(op_node)]
+
+        comp = tree.body.comparators[0]
+        if isinstance(comp, ast.UnaryOp) and isinstance(comp.op, ast.USub) and isinstance(comp.operand, ast.Constant):
+            val = -float(comp.operand.value)
+        elif isinstance(comp, ast.Constant) and isinstance(comp.value, (int, float)):
+            val = float(comp.value)
+        else:
+            return None, None, None, []
+
         walked = walk_expr(tree.body.left)
+    except SyntaxError:
+        return None, None, None, []
     except RecursionError:
         # Defense in depth: the depth guard above should prevent this, but never
         # let stack exhaustion escape as an uncaught crash of the CLI check.

--- a/python/tvl/structural_parser.py
+++ b/python/tvl/structural_parser.py
@@ -3,6 +3,18 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Iterable, List, Sequence
 
+# Cap the recursive-descent nesting depth (parentheses / chained `not`). Each
+# nesting level passes through ``unary()`` exactly once, and each level costs a
+# handful of Python stack frames, so this bound keeps us safely under the
+# interpreter recursion limit and turns a stack-exhausting RecursionError into a
+# normal StructuralParseError. Real constraints nest only a few levels deep.
+MAX_PARSE_DEPTH = 200
+
+# Cap the number of DNF clauses. ``and``-of-``or``s expands as a Cartesian
+# product (2^N from linear input), so bound the running clause count and raise
+# before materializing an exponential blowup.
+MAX_DNF_CLAUSES = 10000
+
 
 class StructuralParseError(ValueError):
     """Raised when a structural constraint cannot be parsed."""
@@ -200,6 +212,7 @@ class _Parser:
     def __init__(self, tokens: Iterable[_Token]) -> None:
         self.tokens = list(tokens)
         self.index = 0
+        self.depth = 0
 
     def current(self) -> _Token:
         return self.tokens[self.index]
@@ -247,13 +260,23 @@ class _Parser:
         return expr
 
     def unary(self):
-        if self.accept("NOT"):
-            return ("not", self.unary())
-        if self.accept("LPAREN"):
-            expr = self.implication()
-            self.expect("RPAREN")
-            return expr
-        return self.atom()
+        # Every level of `not` chaining and every parenthesised group recurses
+        # through unary(); guard here to bound total nesting depth.
+        self.depth += 1
+        if self.depth > MAX_PARSE_DEPTH:
+            raise StructuralParseError(
+                f"Structural constraint nesting too deep (>{MAX_PARSE_DEPTH})"
+            )
+        try:
+            if self.accept("NOT"):
+                return ("not", self.unary())
+            if self.accept("LPAREN"):
+                expr = self.implication()
+                self.expect("RPAREN")
+                return expr
+            return self.atom()
+        finally:
+            self.depth -= 1
 
     def atom(self):
         tok = self.current()
@@ -364,13 +387,26 @@ def _to_dnf(node):
         if op == "and":
             left = _to_dnf(node[1])
             right = _to_dnf(node[2])
+            # Check the product size before materializing it: `and`-of-`or`s
+            # expands as a Cartesian product and grows 2^N from linear input.
+            if len(left) * len(right) > MAX_DNF_CLAUSES:
+                raise StructuralParseError(
+                    "Structural constraint too complex: DNF expansion exceeds "
+                    f"{MAX_DNF_CLAUSES} clauses"
+                )
             product: List[List[tuple]] = []
             for l in left:
                 for r in right:
                     product.append(l + r)
             return product
         if op == "or":
-            return _to_dnf(node[1]) + _to_dnf(node[2])
+            combined = _to_dnf(node[1]) + _to_dnf(node[2])
+            if len(combined) > MAX_DNF_CLAUSES:
+                raise StructuralParseError(
+                    "Structural constraint too complex: DNF expansion exceeds "
+                    f"{MAX_DNF_CLAUSES} clauses"
+                )
+            return combined
         if op == "not_atom":
             return [[node]]
     return [[node]]

--- a/python/tvl/structural_parser.py
+++ b/python/tvl/structural_parser.py
@@ -10,6 +10,20 @@ from typing import Iterable, List, Sequence
 # normal StructuralParseError. Real constraints nest only a few levels deep.
 MAX_PARSE_DEPTH = 200
 
+# Cap the total number of atoms/nesting-units in a single structural
+# constraint, not just its nesting depth. `disjunction()`/`conjunction()`
+# build a flat `and`/`or` chain via a `while` loop (no parser recursion), so a
+# long LINEAR chain (e.g. `a and b and c and ...` thousands of terms) never
+# trips MAX_PARSE_DEPTH — but it still produces a left-deep AST tuple, and
+# `_to_nnf`/`_to_dnf` walk that AST *recursively*, so an unbounded chain still
+# exhausts the stack post-parse. `unary()` is called exactly once per atom
+# *and* once per NOT/paren nesting level, so counting total `unary()` calls
+# bounds AST size regardless of whether growth comes from depth or breadth.
+# Chosen well under the observed ~1000-term crash point (matches
+# sys.getrecursionlimit()) for the same safety-margin reasons as
+# MAX_PARSE_DEPTH.
+MAX_PARSE_UNITS = 300
+
 # Cap the number of DNF clauses. ``and``-of-``or``s expands as a Cartesian
 # product (2^N from linear input), so bound the running clause count and raise
 # before materializing an exponential blowup.
@@ -213,6 +227,10 @@ class _Parser:
         self.tokens = list(tokens)
         self.index = 0
         self.depth = 0
+        # Total unary() calls across the whole parse. Unlike `depth`, this is
+        # never decremented — it's a running total, not a current-nesting
+        # counter. See MAX_PARSE_UNITS.
+        self.units = 0
 
     def current(self) -> _Token:
         return self.tokens[self.index]
@@ -263,9 +281,17 @@ class _Parser:
         # Every level of `not` chaining and every parenthesised group recurses
         # through unary(); guard here to bound total nesting depth.
         self.depth += 1
+        # Every atom *and* every NOT/paren level passes through unary() once,
+        # so this also bounds flat `and`/`or` chains that never deepen
+        # `self.depth` (see MAX_PARSE_UNITS above).
+        self.units += 1
         if self.depth > MAX_PARSE_DEPTH:
             raise StructuralParseError(
                 f"Structural constraint nesting too deep (>{MAX_PARSE_DEPTH})"
+            )
+        if self.units > MAX_PARSE_UNITS:
+            raise StructuralParseError(
+                f"Structural constraint too large (>{MAX_PARSE_UNITS} terms/nesting units)"
             )
         try:
             if self.accept("NOT"):

--- a/python/tvl/yaml_safe.py
+++ b/python/tvl/yaml_safe.py
@@ -1,0 +1,74 @@
+"""Hardened YAML loading for TVL.
+
+``yaml.safe_load`` blocks arbitrary-object construction but still fully resolves
+YAML anchors/aliases, and PyYAML ships no default limit on alias expansion. A
+small "billion-laughs" document therefore expands exponentially and can OOM the
+parsing process (CWE-776 / CWE-400). Every TVL loader routes through
+:func:`safe_load` here so that a single guard bounds both raw input size and the
+number of resolved aliases, turning an OOM into a fast, catchable error.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import yaml
+
+# Reject raw inputs larger than this before parsing. TVL specs are tiny; a few
+# megabytes is a generous ceiling that still stops a pathological input early.
+MAX_YAML_BYTES = 5 * 1024 * 1024
+
+# Cap the number of resolved anchor aliases. A legitimate spec uses a handful;
+# billion-laughs expansion produces exponentially many alias nodes at compose
+# time, so bounding the count defeats the DoS before the expansion materializes.
+MAX_YAML_ALIASES = 5000
+
+
+class YAMLLimitError(yaml.YAMLError):
+    """Raised when a YAML document exceeds a safety limit (size or alias budget)."""
+
+
+class _BoundedSafeLoader(yaml.SafeLoader):
+    """SafeLoader that also bounds anchor/alias expansion.
+
+    This is the standard PyYAML billion-laughs mitigation: count alias
+    resolutions during composition and raise once the budget is exceeded,
+    before the exponential expansion can complete.
+    """
+
+    def __init__(self, stream: Any) -> None:
+        super().__init__(stream)
+        self._alias_count = 0
+
+    def compose_node(self, parent: Any, index: Any) -> Any:
+        if self.check_event(yaml.events.AliasEvent):
+            self._alias_count += 1
+            if self._alias_count > MAX_YAML_ALIASES:
+                raise YAMLLimitError(
+                    "YAML alias-expansion budget exceeded "
+                    f"({MAX_YAML_ALIASES}); possible entity-expansion DoS"
+                )
+        return super().compose_node(parent, index)
+
+
+def safe_load(source: Any) -> Any:
+    """Safely parse YAML from a string, bytes, or readable stream.
+
+    Enforces a raw-size ceiling and an alias-expansion budget, then parses with
+    a SafeLoader. Raises :class:`YAMLLimitError` (a ``yaml.YAMLError``) when a
+    limit is exceeded, so existing ``except yaml.YAMLError`` / ``except
+    Exception`` handlers surface it as a normal parse failure instead of OOM.
+    """
+    data = source.read() if hasattr(source, "read") else source
+
+    if isinstance(data, (bytes, bytearray)):
+        size = len(data)
+    else:
+        size = len(str(data).encode("utf-8"))
+
+    if size > MAX_YAML_BYTES:
+        raise YAMLLimitError(
+            f"YAML input too large ({size} bytes > {MAX_YAML_BYTES} byte limit)"
+        )
+
+    return yaml.load(data, Loader=_BoundedSafeLoader)

--- a/tests/test_parser_dos_guards.py
+++ b/tests/test_parser_dos_guards.py
@@ -122,6 +122,23 @@ def test_structural_normal_expression_still_parses() -> None:
     assert len(dnf.clauses) == 2
 
 
+def test_structural_flat_and_chain_raises_parse_error() -> None:
+    # A flat `a and b and c and ...` chain never deepens the parser's nesting
+    # guard (conjunction() builds it via a `while` loop, not recursion), but
+    # it still produces a left-deep AST that `_to_nnf`/`_to_dnf` would walk
+    # *recursively* — thousands of terms would exhaust the stack there
+    # without the total-unit bound. Graceful rejection, no RecursionError.
+    text = " and ".join(f"x{i} == 1" for i in range(4000))
+    with pytest.raises(StructuralParseError):
+        parse_expression(text)
+
+
+def test_structural_flat_or_chain_raises_parse_error() -> None:
+    text = " or ".join(f"x{i} == 1" for i in range(4000))
+    with pytest.raises(StructuralParseError):
+        parse_expression(text)
+
+
 # --------------------------------------------------------------------------- #
 # #47 — tvl-check-structural CLI: malformed expression => exit 2 + JSON
 # --------------------------------------------------------------------------- #

--- a/tests/test_parser_dos_guards.py
+++ b/tests/test_parser_dos_guards.py
@@ -1,0 +1,201 @@
+"""Guards against parser/loader denial-of-service on adversarial TVL input.
+
+Covers Traigent/tvl issues #44 (YAML billion-laughs / size cap), #45 (operational
+derived-constraint AST-walker recursion), #46 (structural parser recursion + 2^N
+DNF blowup), and #47 (tvl-check-structural CLI crash on a malformed structural
+expression string).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+BASE = pathlib.Path(__file__).resolve().parents[1]
+PKG_ROOT = BASE / "python"
+if str(PKG_ROOT) not in sys.path:
+    sys.path.insert(0, str(PKG_ROOT))
+if str(BASE) not in sys.path:
+    sys.path.insert(0, str(BASE))
+
+from tvl import yaml_safe  # noqa: E402
+from tvl.errors import ParseError  # noqa: E402
+from tvl.loader import load  # noqa: E402
+from tvl.operational import _parse_derived_expression  # noqa: E402
+from tvl.structural_parser import StructuralParseError, parse_expression  # noqa: E402
+from tvl.yaml_safe import safe_load  # noqa: E402
+
+
+# --------------------------------------------------------------------------- #
+# #44 — YAML billion-laughs / entity-expansion + size cap
+# --------------------------------------------------------------------------- #
+
+def _alias_bomb(alias_count: int) -> str:
+    # NB: PyYAML resolves anchors to *shared* node references (a DAG) and caches
+    # constructed objects, so the textbook exponential billion-laughs does not
+    # actually OOM PyYAML. The alias budget is defense-in-depth against a
+    # pathological alias-reference count; this constructs a document that trips
+    # it directly.
+    lines = ["base: &a value", "refs:"]
+    lines.extend(["  - *a"] * alias_count)
+    return "\n".join(lines) + "\n"
+
+
+def test_safe_load_rejects_alias_budget_overflow() -> None:
+    bomb = _alias_bomb(yaml_safe.MAX_YAML_ALIASES + 100)
+    with pytest.raises(yaml_safe.YAMLLimitError):
+        safe_load(bomb)
+
+
+def test_safe_load_rejects_oversized_input() -> None:
+    oversized = "x" * (yaml_safe.MAX_YAML_BYTES + 1)
+    with pytest.raises(yaml_safe.YAMLLimitError):
+        safe_load(oversized)
+
+
+def test_loader_surfaces_oversized_input_as_parse_error(tmp_path: pathlib.Path) -> None:
+    # The public loader wraps loader-level limit failures as ParseError
+    # (contract preserved) rather than an OOM/crash.
+    big = tmp_path / "big.tvl.yml"
+    big.write_text("data: " + "x" * (yaml_safe.MAX_YAML_BYTES + 1), encoding="utf-8")
+    with pytest.raises(ParseError):
+        load(big)
+
+
+def test_safe_load_still_parses_normal_yaml() -> None:
+    assert safe_load("a: 1\nb: [1, 2, 3]\n") == {"a": 1, "b": [1, 2, 3]}
+    # A modest, legitimate anchor/alias document is unaffected.
+    assert safe_load("base: &b {k: 1}\nuse: *b\n") == {"base": {"k": 1}, "use": {"k": 1}}
+
+
+# --------------------------------------------------------------------------- #
+# #45 — operational derived-constraint AST walker recursion
+# --------------------------------------------------------------------------- #
+
+
+def test_derived_expression_deep_chain_returns_gracefully() -> None:
+    # ~4000 chained terms would exhaust the stack in the unbounded walker.
+    expr = " + ".join(["x"] * 4000) + " <= 1"
+    terms, op, val, legacy = _parse_derived_expression(expr)
+    # Graceful "unparseable" rejection — no RecursionError escapes.
+    assert (terms, op, val, legacy) == (None, None, None, [])
+
+
+def test_derived_expression_normal_still_parses() -> None:
+    terms, op, val, legacy = _parse_derived_expression("2*x + y <= 5")
+    assert op == "<="
+    assert val == 5.0
+    assert sorted(terms) == [(1.0, "y"), (2.0, "x")]
+
+
+# --------------------------------------------------------------------------- #
+# #46 — structural parser recursion + DNF blowup
+# --------------------------------------------------------------------------- #
+
+
+def test_structural_nested_parens_raise_parse_error() -> None:
+    text = "(" * 400 + "x == 1" + ")" * 400
+    with pytest.raises(StructuralParseError):
+        parse_expression(text)
+
+
+def test_structural_chained_not_raise_parse_error() -> None:
+    text = "not " * 2000 + "x == 1"
+    with pytest.raises(StructuralParseError):
+        parse_expression(text)
+
+
+def test_structural_dnf_blowup_raises_parse_error() -> None:
+    # 24 conjunctions of binary disjunctions => 2**24 clauses if unbounded.
+    text = " and ".join(f"(a{i} == 1 or b{i} == 2)" for i in range(24))
+    with pytest.raises(StructuralParseError):
+        parse_expression(text)
+
+
+def test_structural_normal_expression_still_parses() -> None:
+    dnf = parse_expression("x == 1 or y == 2")
+    assert len(dnf.clauses) == 2
+
+
+# --------------------------------------------------------------------------- #
+# #47 — tvl-check-structural CLI: malformed expression => exit 2 + JSON
+# --------------------------------------------------------------------------- #
+
+_MODULE_WITH_BAD_EXPR = """
+tvl:
+  module: book.quickstart.simple_rag_qa
+
+environment:
+  snapshot_id: "2025-01-20T00:00:00Z"
+
+evaluation_set:
+  dataset: s3://datasets/campus-rag/dev.jsonl
+  seed: 2025
+
+tvars:
+  - name: retriever.k
+    type: int
+    domain:
+      set: [3, 5, 8]
+  - name: temperature
+    type: float
+    domain:
+      range: [0.0, 0.6]
+      resolution: 0.1
+
+constraints:
+  structural:
+    - when: "retriever.k <"
+      then: "temperature <= 0.3"
+
+objectives:
+  - name: answer_accuracy
+    metric_ref: metrics.answer_accuracy.v1
+    direction: maximize
+
+promotion_policy:
+  dominance: epsilon_pareto
+  alpha: 0.05
+  adjust: holm
+  min_effect:
+    answer_accuracy: 0.01
+
+exploration:
+  strategy:
+    type: grid
+  budgets:
+    max_trials: 24
+    max_wallclock_s: 900
+"""
+
+
+def test_check_structural_cli_malformed_expr(tmp_path) -> None:
+    # Run the CLI as a real subprocess: this tests the true process-level
+    # contract (exit code + stdout JSON) and avoids in-process sys.modules
+    # pollution from sibling tests that synthesize a duplicate `tvl` package.
+    module_file = tmp_path / "bad.tvl.yml"
+    module_file.write_text(_MODULE_WITH_BAD_EXPR, encoding="utf-8")
+
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join([str(PKG_ROOT), str(BASE), env.get("PYTHONPATH", "")])
+    env["TRAIGENT_MOCK_LLM"] = "true"
+
+    proc = subprocess.run(
+        [sys.executable, "-m", "tvl_tools.tvl_check_structural.cli", str(module_file), "--json"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+    # Documented validation exit code is 2, not the default-1 uncaught-crash code.
+    assert proc.returncode == 2, proc.stderr
+    # --json contract honoured even on parse failure (no bare traceback to stdout).
+    payload = json.loads(proc.stdout)
+    assert payload["kind"] == "PhaseResult"
+    assert payload["ok"] is False
+    assert "invalid structural constraint" in payload["error"]

--- a/tvl_tools/cli_utils.py
+++ b/tvl_tools/cli_utils.py
@@ -6,6 +6,8 @@ from typing import Any, Callable, Dict, Optional
 
 import yaml
 
+from tvl.yaml_safe import safe_load
+
 
 def add_common_args(parser: argparse.ArgumentParser) -> None:
     """Add standard arguments to the CLI parser."""
@@ -34,7 +36,7 @@ def load_yaml_safely(path: Path) -> Any:
     """Load YAML file with friendly error handling."""
     try:
         with path.open("r", encoding="utf-8") as handle:
-            return yaml.safe_load(handle)
+            return safe_load(handle)
     except FileNotFoundError as exc:
         raise FileNotFoundError(f"File not found: {path}") from exc
     except yaml.YAMLError as exc:

--- a/tvl_tools/microsim_bridge/bridge.py
+++ b/tvl_tools/microsim_bridge/bridge.py
@@ -6,7 +6,7 @@ from typing import Any, Iterable
 
 import json
 
-import yaml
+from tvl.yaml_safe import safe_load
 
 
 @dataclass
@@ -177,7 +177,7 @@ def _adjust_presets(
 
 def _load_spec(path: Path) -> dict[str, Any]:
     with path.open("r", encoding="utf-8") as handle:
-        return yaml.safe_load(handle)
+        return safe_load(handle)
 
 
 def build_presets(path: Path) -> dict[str, Any]:

--- a/tvl_tools/tvl_check_structural/cli.py
+++ b/tvl_tools/tvl_check_structural/cli.py
@@ -5,6 +5,7 @@ import json
 import hashlib
 import math
 import re
+import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -14,6 +15,7 @@ from typing import Any, Dict, List, Optional
 import yaml
 
 from tvl.loader import load
+from tvl.structural_parser import StructuralParseError
 from tvl.structural_sat import check_structural
 
 
@@ -200,7 +202,37 @@ def main() -> None:
 
     module = _load_module(module_path)
     start_time = time.perf_counter()
-    result = check_structural(module)
+    try:
+        result = check_structural(module)
+    except StructuralParseError as exc:
+        # A well-shaped structural entry whose expression string is malformed (a
+        # user typo) or over-complex (deep nesting / DNF blowup). Mirror the
+        # graceful degradation the lint sibling already provides: emit a
+        # structured diagnostic and exit 2, never a raw traceback.
+        duration_ms = int((time.perf_counter() - start_time) * 1000)
+        if temp_file is not None:
+            try:
+                temp_file.unlink(missing_ok=True)
+            except OSError:
+                pass
+        if args.json:
+            payload = {
+                "schemaVersion": "1.0",
+                "kind": "PhaseResult",
+                "phase": "structural",
+                "ok": False,
+                "status": "error",
+                "error": f"invalid structural constraint: {exc}",
+                "assignment": None,
+                "unsat_core": None,
+                "repair_candidates": [],
+                "timestamp": _current_timestamp(),
+                "durationMs": duration_ms,
+            }
+            print(json.dumps(payload, indent=2))
+        else:
+            print(f"Error: invalid structural constraint: {exc}", file=sys.stderr)
+        raise SystemExit(2)
     duration_ms = int((time.perf_counter() - start_time) * 1000)
     if temp_file is not None:
         try:

--- a/tvl_tools/tvl_ci_gate/cli.py
+++ b/tvl_tools/tvl_ci_gate/cli.py
@@ -4,16 +4,15 @@ import sys
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 
-import yaml
-
 from tvl.loader import load
 from tvl.measurement import load_measurement, prepare_measurement_bundle
 from tvl.promotion import epsilon_pareto_gate
+from tvl.yaml_safe import safe_load
 
 
 def load_yaml(path: Path) -> Any:
     with path.open("r", encoding="utf-8") as f:
-        return yaml.safe_load(f)
+        return safe_load(f)
 
 
 def _load_module_and_inputs(


### PR DESCRIPTION
Hardens the TVL loaders and constraint-expression parsers so adversarial (or merely over-large / typo'd) input yields a fast, catchable error instead of an OOM, a stack-exhausting `RecursionError`, an exponential-time hang, or a raw CLI traceback. PUBLIC Apache repo — no internal detail.

## #44 — YAML loaders: size cap + alias budget (all 6 bare `safe_load` sites)
Adds `python/tvl/yaml_safe.py` with `safe_load()`: a raw-input size ceiling (`MAX_YAML_BYTES = 5 MiB`) checked before parsing, plus a `SafeLoader` subclass that counts resolved aliases and raises `YAMLLimitError` past `MAX_YAML_ALIASES = 5000`. All six loaders now route through it: `loader.py`, `measurement.py`, `configuration.py`, `tvl_tools/cli_utils.py`, `tvl_tools/tvl_ci_gate/cli.py`, `tvl_tools/microsim_bridge/bridge.py`. `YAMLLimitError` subclasses `yaml.YAMLError`, so existing `except yaml.YAMLError` / `except Exception → ParseError` handlers surface it as a normal parse failure (contract preserved).

Caveat (documented honestly): PyYAML resolves anchors to **shared** node references (a DAG) and caches constructed objects, so the textbook exponential billion-laughs in the issue PoC does **not** actually OOM PyYAML — the 7-level bomb parses in ~2 ms with only 58 alias events. The substantive real protection here is the **size cap** (an unbounded multi-hundred-MB input genuinely consumes memory); the alias budget is cheap defense-in-depth and matches the issue's requested mitigation. Tests assert the real guards (size cap, alias-budget overflow, normal-YAML pass-through), not the non-reproducing PoC.

Closes #44

## #45 — operational derived-constraint AST walker recursion
Adds a depth guard to `walk_expr` in `_parse_derived_expression` (`operational.py`): past `max_depth = 400` it returns `None` (the existing "unparseable" path → `(None, None, None, [])`), and the top-level `walk_expr` call is wrapped in `except RecursionError` as defense in depth. A ~4000-term chained `require` now degrades gracefully instead of raising an uncaught `RecursionError`.

Closes #45

## #46 — structural parser recursion + 2^N DNF blowup
`structural_parser.py`: `_Parser.unary()` now threads a nesting counter and raises `StructuralParseError` past `MAX_PARSE_DEPTH = 200` (bounds both nested-paren and chained-`not` recursion, which each pass through `unary()` once per level; this also bounds the `_to_nnf`/`_to_dnf` AST-recursion depth). `_to_dnf` checks the Cartesian-product size before materializing it and raises `StructuralParseError` past `MAX_DNF_CLAUSES = 10000`, stopping the `and`-of-`or`s exponential blowup early. These surface cleanly through both consumers: `lints.py` already catches `StructuralParseError` (tvl-lint), and the tvl-check-structural CLI catch below (#47) handles it too.

Closes #46

## #47 — tvl-check-structural CLI crash on malformed structural expression
`tvl_tools/tvl_check_structural/cli.py`: wraps `check_structural(module)` in `try/except StructuralParseError`, mirroring the graceful degradation the lint sibling (`lints.py:1974`) already provides. A well-shaped structural entry with a malformed expression string (e.g. `when: "retriever.k <"`) now exits **2** (documented validation code, not the uncaught-crash default 1) and, under `--json`, emits a well-formed `PhaseResult` error object instead of a bare traceback. This same catch also gives #46's over-complex inputs a clean CLI path.

Closes #47

## Tests
New `tests/test_parser_dos_guards.py` (11 focused tests, zero LLM/network, `TRAIGENT_MOCK_LLM=true`): alias-budget + size-cap + normal-YAML for #44; deep-chain graceful-reject + normal-parse for #45; nested-parens / chained-`not` / DNF-blowup raises + normal-parse for #46; and a real-subprocess CLI run asserting exit 2 + JSON for #47.

Closes #44
Closes #45
Closes #46
Closes #47

Spine: cs_02e5754197e04024

🤖 Generated with [Claude Code](https://claude.com/claude-code)
