### PR TITLE
fix(cli): make tvl-compose --validate run without -o; text-mode error for tvl-config-validate

### DIFF
--- a/tests/test_cli_error_paths.py
+++ b/tests/test_cli_error_paths.py
@@ -1,0 +1,124 @@
+"""Regression tests for CLI validation/error behavior.
+
+Covers:
+- #54: `tvl-compose --validate` must actually validate (and fail non-zero on
+  an invalid composed module) even when no `-o/--output` is given.
+- #56: `tvl-config-validate` must emit text (not raw JSON) on a TVLError in
+  text mode, consistent with its success path and cli_utils.handle_error.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tvl_tools.tvl_compose import cli as compose_cli
+from tvl_tools.tvl_config_validate import cli as config_validate_cli
+
+
+def _write_yaml(path: Path, data: dict) -> None:
+    path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+
+
+def test_compose_validate_without_output_fails_on_invalid_spec(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """#54: `--validate` (no -o) validates and exits non-zero on an invalid spec."""
+    base_path = tmp_path / "base.tvl.yml"
+    overlay_path = tmp_path / "staging.overlay.yml"
+
+    # Base is missing required TVL structure (no `tvl`/`tvars`/etc.) so the
+    # composed module fails schema/lint validation.
+    _write_yaml(base_path, {"not_a_real_field": True})
+    _write_yaml(
+        overlay_path,
+        {
+            "_tvl_overlay": {"extends": "base.tvl.yml"},
+            "overrides": {},
+        },
+    )
+
+    monkeypatch.setattr(
+        "sys.argv",
+        ["tvl-compose", str(overlay_path), "--no-validate", "--validate"],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        compose_cli.main()
+
+    # Validation ran and surfaced a failure with a non-zero exit code even
+    # though no -o/--output was provided.
+    assert excinfo.value.code != 0
+    err = capsys.readouterr().err
+    assert "Validation failed" in err
+
+
+def test_compose_validate_without_output_passes_on_valid_spec(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """#54: a valid composed module still exits 0 under `--validate` without -o."""
+    base_path = tmp_path / "base.tvl.yml"
+    overlay_path = tmp_path / "prod.overlay.yml"
+
+    _write_yaml(
+        base_path,
+        {
+            "tvl": {"module": "demo.compose"},
+            "environment": {"snapshot_id": "2025-01-20T00:00:00Z"},
+            "evaluation_set": {"dataset": "s3://datasets/demo.jsonl"},
+            "tvars": [
+                {
+                    "name": "temperature",
+                    "type": "float",
+                    "domain": {"range": [0.0, 1.0], "resolution": 0.05},
+                }
+            ],
+            "constraints": {"structural": [], "derived": []},
+            "objectives": [{"name": "quality", "direction": "maximize"}],
+            "promotion_policy": {
+                "dominance": "epsilon_pareto",
+                "alpha": 0.05,
+                "min_effect": {"quality": 0.01},
+            },
+        },
+    )
+    _write_yaml(
+        overlay_path,
+        {"_tvl_overlay": {"extends": "base.tvl.yml"}, "overrides": {}},
+    )
+
+    monkeypatch.setattr(
+        "sys.argv", ["tvl-compose", str(overlay_path), "--validate"]
+    )
+
+    # Valid module: main() completes without raising SystemExit(non-zero).
+    compose_cli.main()
+
+
+def test_config_validate_tvlerror_text_mode_is_not_raw_json(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+) -> None:
+    """#56: a TVLError in text mode prints `Error: ...` to stderr, not JSON."""
+    # A nonexistent/invalid module path triggers a TVLError from the loader.
+    missing_module = tmp_path / "does_not_exist.tvl.yml"
+    config_file = tmp_path / "config.yml"
+    _write_yaml(config_file, {"assignments": {}})
+
+    monkeypatch.setattr(
+        "sys.argv",
+        ["tvl-config-validate", str(missing_module), str(config_file)],
+    )
+
+    with pytest.raises(SystemExit) as excinfo:
+        config_validate_cli.main()
+
+    assert excinfo.value.code == 5
+    captured = capsys.readouterr()
+    # Text mode: error goes to stderr as plain text, not raw JSON on stdout.
+    assert captured.out.strip() == ""
+    assert captured.err.startswith("Error:")
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(captured.err.strip())

--- a/tvl_tools/tvl_compose/cli.py
+++ b/tvl_tools/tvl_compose/cli.py
@@ -168,6 +168,11 @@ def text_renderer(data: Dict[str, Any]) -> None:
         else:
             # Print the composed YAML to stdout
             print(yaml.dump(data["composed"], default_flow_style=False, sort_keys=False))
+    elif data.get("validation") and not data["validation"]["ok"]:
+        # Validation failure: surface the issues on stderr
+        print("Validation failed:", file=sys.stderr)
+        for issue in data["validation"]["issues"]:
+            print(f"  {issue}", file=sys.stderr)
     else:
         print(f"Error: {data.get('error')}", file=sys.stderr)
 
@@ -204,29 +209,29 @@ def main() -> None:
             "composed": composed,
         }
 
+        # Optionally validate the composed module (independent of output target)
+        if args.validate:
+            from tvl_tools.tvl_validate.cli import _load_schema, _schema_issues
+            from tvl.lints import lint_module
+
+            schema = _load_schema(Path(__file__))
+            issues = _schema_issues(composed, schema)
+            if not issues:
+                issues = lint_module(composed)
+
+            result["validation"] = {
+                "ok": len(issues) == 0,
+                "issues": issues,
+            }
+
+            if issues:
+                result["ok"] = False
+
         # Write to output file if specified
         if args.output:
             with args.output.open("w", encoding="utf-8") as handle:
                 yaml.dump(composed, handle, default_flow_style=False, sort_keys=False)
             result["output_file"] = str(args.output)
-
-            # Optionally validate the output
-            if args.validate:
-                from tvl_tools.tvl_validate.cli import _load_schema, _schema_issues
-                from tvl.lints import lint_module
-
-                schema = _load_schema(Path(__file__))
-                issues = _schema_issues(composed, schema)
-                if not issues:
-                    issues = lint_module(composed)
-
-                result["validation"] = {
-                    "ok": len(issues) == 0,
-                    "issues": issues,
-                }
-
-                if issues:
-                    result["ok"] = False
 
         print_output(result, get_format(args), text_renderer)
 

--- a/tvl_tools/tvl_config_validate/cli.py
+++ b/tvl_tools/tvl_config_validate/cli.py
@@ -141,7 +141,7 @@ def main() -> None:
             diag.update(event)
             print(json.dumps(diag, indent=2))
         else:
-            print(json.dumps(diag, indent=2))
+            print(f"Error: {exc}", file=sys.stderr)
         raise SystemExit(5)
 
 


### PR DESCRIPTION
Two tvl CLI honesty fixes:

- **#54** — `tvl-compose --validate` was nested under `if args.output:`, so it was a silent no-op unless `-o/--output` was also passed — the documented "compose and validate" never validated. Moved the validation block out so it runs on the composed module regardless of output target (before the optional file write); a validation failure now surfaces its issues on stderr and sets a non-zero exit.
- **#56** — `tvl-config-validate` printed raw JSON to stdout on `TVLError` even in text mode, inconsistent with its success path. The text branch now prints `Error: <exc>` to stderr (JSON reserved for `--json`), matching the success path / `cli_utils.handle_error` convention.

Tests: added `tests/test_cli_error_paths.py`; `pytest tests/test_cli_error_paths.py tests/test_tvl_compose.py` → 5 passed.

Closes #54
Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Spine: none (reason: captains-leader automated research/fix PR — not run through a governed ChangeSession; owner to govern/merge)

## Captain-PR gauntlet (orchestrate-captain-pr, 2026-07-19)
- Tier: LIGHT (economy batch) · Draft→review→ready per owner instruction
- Review cycle: opus@xhigh (review-code bar) + sol@xhigh, independent — **both clean (0 BLOCKING / 0 ADVISORY)**
- Fixes: none needed · Head unchanged
_Run economy per owner directive (2026-07-19): batched LIGHT-tier packets; sol=gpt-5.6-sol; aikido/greptile: n/a — no bot integration on this repo (no bot comments on any recent PR)._
