### PR TITLE
fix(promotion): no false-Promote from zero-variance SE floor; NoDecision for low-power banded

### DIFF
--- a/python/tvl/promotion.py
+++ b/python/tvl/promotion.py
@@ -379,36 +379,32 @@ def _from_precomputed(spec: ObjectiveSpec, cand_data: Dict[str, Any]) -> Objecti
     )
 
 
-# Relative tolerance below which an observed variance is treated as unestimable
-# (a degenerate/zero-variance sample rather than genuine measurement spread).
-#
-# The tolerance is squared and scaled by the arm mean (see `tol` below) because
-# cancellation roundoff in a sum/difference of samples scales with the samples'
-# own magnitude, ~ (scale * 2**-52)**2 for float64. Scaling by arm magnitude is
-# therefore correct; only the coefficient must be tight enough to not swallow
-# genuine small-variance signal at high offsets. At 1e-12: an O(1)-scale
-# rounded-identical sample (variance ~1e-33) and a 1e9-scale roundoff sample
-# (variance ~4e-14, i.e. (1e9 * 2**-52)**2) are both still caught with orders
-# of margin, while genuine small variance riding on a large offset (e.g. 0.01
-# at scale 1e9 -> tol = (1e-12 * 1e9)**2 = 1e-6) is preserved rather than
-# misclassified as degenerate.
-_VARIANCE_REL_TOL = 1e-12
+# Bound numerical zero by the input representation, rather than by an arbitrary
+# relative tolerance.  A paired difference can inherit cancellation/input
+# rounding on the order of one ULP of either arm.  We allow 32 ULPs: this small
+# conservative factor covers both input rounding and the subsequent mean and
+# sample-variance arithmetic, while avoiding a scale-proportional floor that
+# can erase genuine variation after a common translation.
+_VARIANCE_ERROR_BOUND_ULPS = 32
 
 
-def _variance_is_degenerate(variance: float, scale: float) -> bool:
+def _variance_is_degenerate(variance: float, input_scale: float) -> bool:
     """True when an observed variance is effectively zero (SE unestimable).
 
     Both exact-zero variance and floating-point "roundoff zero" must be caught.
     Identical-but-rounded values (e.g. the sample variance of paired differences
     like 0.9 - 0.5 repeated) produce a variance on the order of 1e-33 rather than
     exactly 0.0; a plain ``variance > 0`` guard would miss it and still fabricate
-    a near-infinite test statistic. We compare against a scale-relative tolerance
-    so genuine (even small) measurement spread is preserved.
+    a near-infinite test statistic.  For paired samples, ``input_scale`` is the
+    largest arm value, so the bound is on the rounding/cancellation error in the
+    paired differences, not on their mean.  ``math.ulp`` keeps this threshold at
+    float64 representation resolution instead of imposing a coarse relative
+    variance floor.
     """
     if variance <= 0:
         return True
-    tol = (_VARIANCE_REL_TOL * max(1.0, abs(scale))) ** 2
-    return variance <= tol
+    error_bound = _VARIANCE_ERROR_BOUND_ULPS * math.ulp(abs(input_scale))
+    return variance <= error_bound ** 2
 
 
 def _unestimable_result(
@@ -469,7 +465,8 @@ def _test_from_samples(
         diffs = [c - i for c, i in zip(cand_samples, inc_samples)]
         mean_diff = sum(diffs) / len(diffs)
         var_diff = sum((d - mean_diff) ** 2 for d in diffs) / (len(diffs) - 1)
-        if _variance_is_degenerate(var_diff, max(abs(mean_diff), abs(mean_cand), abs(mean_inc))):
+        input_scale = max(abs(x) for x in [*inc_samples, *cand_samples])
+        if _variance_is_degenerate(var_diff, input_scale):
             # Zero variance in the paired differences -> SE unestimable.
             # Do not floor to 1e-10 (which would fabricate significance).
             return _unestimable_result(

--- a/python/tvl/promotion.py
+++ b/python/tvl/promotion.py
@@ -381,7 +381,18 @@ def _from_precomputed(spec: ObjectiveSpec, cand_data: Dict[str, Any]) -> Objecti
 
 # Relative tolerance below which an observed variance is treated as unestimable
 # (a degenerate/zero-variance sample rather than genuine measurement spread).
-_VARIANCE_REL_TOL = 1e-9
+#
+# The tolerance is squared and scaled by the arm mean (see `tol` below) because
+# cancellation roundoff in a sum/difference of samples scales with the samples'
+# own magnitude, ~ (scale * 2**-52)**2 for float64. Scaling by arm magnitude is
+# therefore correct; only the coefficient must be tight enough to not swallow
+# genuine small-variance signal at high offsets. At 1e-12: an O(1)-scale
+# rounded-identical sample (variance ~1e-33) and a 1e9-scale roundoff sample
+# (variance ~4e-14, i.e. (1e9 * 2**-52)**2) are both still caught with orders
+# of margin, while genuine small variance riding on a large offset (e.g. 0.01
+# at scale 1e9 -> tol = (1e-12 * 1e9)**2 = 1e-6) is preserved rather than
+# misclassified as degenerate.
+_VARIANCE_REL_TOL = 1e-12
 
 
 def _variance_is_degenerate(variance: float, scale: float) -> bool:

--- a/python/tvl/promotion.py
+++ b/python/tvl/promotion.py
@@ -97,6 +97,7 @@ class PromotionEvidence:
     all_noninferior: bool = False
     any_superior: bool = False
     all_bands_pass: bool = True
+    any_band_out_of_band: bool = False
     all_chance_pass: bool = True
     adjustment_method: str = "none"
     fdr_controlled_at: Optional[float] = None
@@ -115,6 +116,7 @@ class PromotionEvidence:
                 "all_noninferior": self.all_noninferior,
                 "any_superior": self.any_superior,
                 "all_bands_pass": self.all_bands_pass,
+                "any_band_out_of_band": self.any_band_out_of_band,
                 "all_chance_pass": self.all_chance_pass,
                 "adjustment_method": self.adjustment_method,
                 "fdr_controlled_at": self.fdr_controlled_at,
@@ -218,8 +220,14 @@ def epsilon_pareto_gate(
             # Banded objective - use TOST
             result = _test_banded_objective(spec, cand_objectives.get(spec.name, {}), alpha)
             evidence.per_objective[spec.name] = result
+            # A band contributes to Promote only when it is proven in-band.
+            # A genuine out-of-band point estimate is a hard Reject; an
+            # under-powered/inconclusive band is neither Promote nor Reject
+            # (spec 5.3 / test matrix "TOST fail (power)" -> NoDecision).
             if result.verdict != "in_band":
                 evidence.all_bands_pass = False
+            if result.verdict == "out_of_band":
+                evidence.any_band_out_of_band = True
         else:
             # Standard objective - use t-tests
             result = _test_objective(
@@ -371,6 +379,62 @@ def _from_precomputed(spec: ObjectiveSpec, cand_data: Dict[str, Any]) -> Objecti
     )
 
 
+# Relative tolerance below which an observed variance is treated as unestimable
+# (a degenerate/zero-variance sample rather than genuine measurement spread).
+_VARIANCE_REL_TOL = 1e-9
+
+
+def _variance_is_degenerate(variance: float, scale: float) -> bool:
+    """True when an observed variance is effectively zero (SE unestimable).
+
+    Both exact-zero variance and floating-point "roundoff zero" must be caught.
+    Identical-but-rounded values (e.g. the sample variance of paired differences
+    like 0.9 - 0.5 repeated) produce a variance on the order of 1e-33 rather than
+    exactly 0.0; a plain ``variance > 0`` guard would miss it and still fabricate
+    a near-infinite test statistic. We compare against a scale-relative tolerance
+    so genuine (even small) measurement spread is preserved.
+    """
+    if variance <= 0:
+        return True
+    tol = (_VARIANCE_REL_TOL * max(1.0, abs(scale))) ** 2
+    return variance <= tol
+
+
+def _unestimable_result(
+    spec: ObjectiveSpec,
+    test_type: str,
+    n_inc: int,
+    n_cand: int,
+    mean_inc: float,
+    mean_cand: float,
+) -> ObjectiveResult:
+    """Objective result when the standard error is unestimable (total variance == 0).
+
+    When both arms have zero observed variance, the SE is genuinely
+    unestimable. Substituting a tiny floor (e.g. 1e-10) would manufacture a
+    near-infinite test statistic and a spuriously significant superiority
+    verdict from an underpowered/degenerate sample. Per spec §7.3, we instead
+    report both p-values as 1.0 so the objective cannot pass non-inferiority or
+    superiority and the gate fails closed (never a false Promote).
+    """
+    return ObjectiveResult(
+        name=spec.name,
+        test_type=test_type,
+        n_incumbent=n_inc,
+        n_candidate=n_cand,
+        mean_incumbent=mean_inc,
+        mean_candidate=mean_cand,
+        delta=mean_cand - mean_inc,
+        std_pooled=0.0,
+        t_statistic=None,
+        df=None,
+        p_value_noninf=1.0,
+        p_value_super=1.0,
+        epsilon=spec.epsilon,
+        verdict="inconclusive",
+    )
+
+
 def _test_from_samples(
     spec: ObjectiveSpec,
     inc_samples: List[float],
@@ -394,7 +458,13 @@ def _test_from_samples(
         diffs = [c - i for c, i in zip(cand_samples, inc_samples)]
         mean_diff = sum(diffs) / len(diffs)
         var_diff = sum((d - mean_diff) ** 2 for d in diffs) / (len(diffs) - 1)
-        std_diff = math.sqrt(var_diff) if var_diff > 0 else 1e-10
+        if _variance_is_degenerate(var_diff, max(abs(mean_diff), abs(mean_cand), abs(mean_inc))):
+            # Zero variance in the paired differences -> SE unestimable.
+            # Do not floor to 1e-10 (which would fabricate significance).
+            return _unestimable_result(
+                spec, "paired", n_inc, n_cand, mean_inc, mean_cand
+            )
+        std_diff = math.sqrt(var_diff)
         se = std_diff / math.sqrt(len(diffs))
         df = len(diffs) - 1
 
@@ -427,7 +497,12 @@ def _test_from_samples(
     var_inc = sum((x - mean_inc) ** 2 for x in inc_samples) / (n_inc - 1) if n_inc > 1 else 0
     var_cand = sum((x - mean_cand) ** 2 for x in cand_samples) / (n_cand - 1) if n_cand > 1 else 0
 
-    se = math.sqrt(var_inc / n_inc + var_cand / n_cand) if var_inc + var_cand > 0 else 1e-10
+    if _variance_is_degenerate(var_inc + var_cand, max(abs(mean_inc), abs(mean_cand))):
+        # Total variance zero -> SE unestimable. Do not floor to 1e-10, which
+        # would manufacture a near-infinite t-statistic and a false Promote.
+        return _unestimable_result(spec, "welch", n_inc, n_cand, mean_inc, mean_cand)
+
+    se = math.sqrt(var_inc / n_inc + var_cand / n_cand)
 
     # Welch-Satterthwaite degrees of freedom
     if var_inc > 0 or var_cand > 0:
@@ -502,7 +577,11 @@ def _test_from_stats(
 
     var_inc = std_inc ** 2
     var_cand = std_cand ** 2
-    se = math.sqrt(var_inc / n_inc + var_cand / n_cand) if var_inc + var_cand > 0 else 1e-10
+    if _variance_is_degenerate(var_inc + var_cand, max(abs(mean_inc), abs(mean_cand))):
+        # Both reported stds are zero -> SE unestimable. Do not floor to 1e-10,
+        # which would manufacture a false Promote from a degenerate sample.
+        return _unestimable_result(spec, "welch", n_inc, n_cand, mean_inc, mean_cand)
+    se = math.sqrt(var_inc / n_inc + var_cand / n_cand)
 
     # Welch-Satterthwaite df
     if var_inc > 0 or var_cand > 0:
@@ -592,10 +671,19 @@ def _test_banded_objective(
     ci_lower = mean - t_crit * se
     ci_upper = mean + t_crit * se
 
-    # Pass if max(p1, p2) < alpha, equivalently if CI ⊂ [L, U]
+    # Pass if max(p1, p2) < alpha, equivalently if the (1 - 2α) CI ⊂ [L, U].
+    #
+    # NOTE: the in_band p-value test is *exactly* equivalent to "CI ⊂ [L, U]"
+    # (t_crit uses 1 - band_alpha, i.e. the 1 - 2α interval), so a CI-based
+    # classification of the failing case would make the "inconclusive" branch
+    # unreachable and would hard-Reject an under-powered but on-target band.
+    # Reserve "out_of_band" for a genuinely out-of-band *point estimate*
+    # (mean outside [L, U]); an on-target mean whose CI merely spills past the
+    # band edge is low-power evidence -> "inconclusive" -> NoDecision
+    # (spec promotion-gate-io.md §5.3 and the §6 "TOST fail (power)" row).
     if max(p1, p2) < band_alpha:
         verdict = "in_band"
-    elif ci_lower < band_lower or ci_upper > band_upper:
+    elif mean < band_lower or mean > band_upper:
         verdict = "out_of_band"
     else:
         verdict = "inconclusive"
@@ -779,20 +867,32 @@ def _make_decision(evidence: PromotionEvidence) -> Tuple[str, str]:
         ]
         return ("Reject", f"Chance constraints failed: {', '.join(failing)}")
 
-    if not evidence.all_bands_pass:
+    # Only a genuinely out-of-band point estimate is a hard Reject. An
+    # under-powered / inconclusive band does not Reject; it merely fails to
+    # satisfy the Promote requirement (spec §5.3, "TOST fail (power)").
+    if evidence.any_band_out_of_band:
         failing = [
             name for name, r in evidence.per_objective.items()
-            if isinstance(r, BandedResult) and r.verdict != "in_band"
+            if isinstance(r, BandedResult) and r.verdict == "out_of_band"
         ]
         return ("Reject", f"Banded objectives failed TOST: {', '.join(failing)}")
 
-    # Check for promotion (need at least one superior)
-    if evidence.any_superior:
+    # Check for promotion (need at least one superior AND all bands proven in-band)
+    if evidence.all_bands_pass and evidence.any_superior:
         superior = [
             name for name, r in evidence.per_objective.items()
             if isinstance(r, ObjectiveResult) and r.verdict == "superior"
         ]
         return ("Promote", f"All non-inferiority tests pass; superior on: {', '.join(superior)}")
 
-    # All pass but no superiority demonstrated
+    # All pass but no superiority demonstrated, or a band is inconclusive (low power).
+    if not evidence.all_bands_pass:
+        inconclusive = [
+            name for name, r in evidence.per_objective.items()
+            if isinstance(r, BandedResult) and r.verdict != "in_band"
+        ]
+        return (
+            "NoDecision",
+            f"Banded objectives inconclusive (insufficient power): {', '.join(inconclusive)}",
+        )
     return ("NoDecision", "All objectives non-inferior but no superiority demonstrated")

--- a/tests/test_promotion_policy.py
+++ b/tests/test_promotion_policy.py
@@ -751,20 +751,18 @@ class PromotionGateTests(unittest.TestCase):
         self.assertNotEqual("Promote", decision)
         self.assertEqual(1.0, evidence["per_objective"]["quality"]["p_value_super"])
 
-    def test_high_offset_paired_variance_not_over_classified_degenerate(self) -> None:
-        """Genuine small variance at a high arm offset must not be treated as unestimable.
+    def test_high_offset_paired_variance_is_estimable(self) -> None:
+        """The reported 1e12-offset regression remains an estimable paired test.
 
-        Paired arms sit at mean ~1e9 with differences [9.9, 10.0, 10.1] -> a
-        real (non-degenerate) diff variance of ~0.01. The degeneracy tolerance
-        is scaled by arm magnitude (correct, since cancellation roundoff scales
-        with it too), but too loose a coefficient over-classifies this as
-        unestimable and forces NoDecision on a clearly estimable effect (:384).
+        The paired differences [9.9, 10.0, 10.1] have real variance near 0.01.
+        A common +1e12 offset must not turn that signal into a numerical-zero
+        variance classification.
         """
-        incumbent = {"objective_values": {"quality": {"samples": [1e9, 1e9, 1e9]}}}
+        incumbent = {"objective_values": {"quality": {"samples": [1e12, 1e12, 1e12]}}}
         candidate = {
             "objective_values": {
                 "quality": {
-                    "samples": [1e9 + 9.9, 1e9 + 10.0, 1e9 + 10.1],
+                    "samples": [1e12 + 9.9, 1e12 + 10.0, 1e12 + 10.1],
                     "paired": True,
                 }
             }
@@ -778,6 +776,52 @@ class PromotionGateTests(unittest.TestCase):
         # real signal here must survive to produce a genuine test statistic.
         self.assertNotEqual(1.0, evidence["per_objective"]["quality"]["p_value_super"])
         self.assertIsNotNone(evidence["per_objective"]["quality"]["t_statistic"])
+
+    def test_paired_samples_are_translation_invariant(self) -> None:
+        """A common offset must not change the paired promotion verdict class."""
+        policy = {"alpha": 0.05, "min_effect": {"quality": 0.0}, "adjust": "none"}
+        objectives = [{"name": "quality", "direction": "maximize"}]
+
+        base_incumbent = {"objective_values": {"quality": {"samples": [0.0, 0.0, 0.0]}}}
+        base_candidate = {
+            "objective_values": {
+                "quality": {"samples": [9.9, 10.0, 10.1], "paired": True}
+            }
+        }
+        shifted_incumbent = {"objective_values": {"quality": {"samples": [1e12, 1e12, 1e12]}}}
+        shifted_candidate = {
+            "objective_values": {
+                "quality": {
+                    "samples": [1e12 + 9.9, 1e12 + 10.0, 1e12 + 10.1],
+                    "paired": True,
+                }
+            }
+        }
+
+        base_decision, _ = epsilon_pareto_gate(base_incumbent, base_candidate, policy, objectives)
+        shifted_decision, _ = epsilon_pareto_gate(
+            shifted_incumbent, shifted_candidate, policy, objectives
+        )
+
+        self.assertEqual(base_decision, shifted_decision)
+        self.assertEqual("Promote", shifted_decision)
+
+    def test_high_offset_identical_paired_samples_stay_degenerate(self) -> None:
+        """Identical high-offset arms safely fail closed instead of promoting."""
+        incumbent = {"objective_values": {"quality": {"samples": [1e12, 1e12, 1e12]}}}
+        candidate = {
+            "objective_values": {
+                "quality": {"samples": [1e12, 1e12, 1e12], "paired": True}
+            }
+        }
+        policy = {"alpha": 0.05, "min_effect": {"quality": 0.0}, "adjust": "none"}
+        objectives = [{"name": "quality", "direction": "maximize"}]
+
+        decision, evidence = epsilon_pareto_gate(incumbent, candidate, policy, objectives)
+
+        self.assertNotEqual("Promote", decision)
+        self.assertIsNone(evidence["per_objective"]["quality"]["t_statistic"])
+        self.assertEqual(1.0, evidence["per_objective"]["quality"]["p_value_super"])
 
     def test_real_variance_still_promotes(self) -> None:
         """Genuine (non-degenerate) variance path is unchanged: clear win Promotes."""

--- a/tests/test_promotion_policy.py
+++ b/tests/test_promotion_policy.py
@@ -702,6 +702,123 @@ class PromotionGateTests(unittest.TestCase):
         self.assertEqual("Promote", decision)
         self.assertEqual("welch", evidence["per_objective"]["quality"]["test_type"])
 
+    # --- Regression: zero-variance standard error must not manufacture a Promote (#59) ---
+
+    def test_zero_variance_samples_not_promoted(self) -> None:
+        """Degenerate (zero-variance) samples must not yield a superiority Promote.
+
+        Both arms have zero observed variance; the standard error is unestimable.
+        The gate must fail closed (never Promote) rather than substitute a tiny SE
+        that fabricates a near-infinite t-statistic.
+        """
+        incumbent = {"objective_values": {"quality": {"samples": [0.5, 0.5]}}}
+        candidate = {"objective_values": {"quality": {"samples": [0.9, 0.9]}}}
+        policy = {"alpha": 0.05, "min_effect": {"quality": 0.0}, "adjust": "none"}
+        objectives = [{"name": "quality", "direction": "maximize"}]
+
+        decision, evidence = epsilon_pareto_gate(incumbent, candidate, policy, objectives)
+        # Fails closed (Reject here, matching the n<2 degenerate path) - never Promote.
+        self.assertNotEqual("Promote", decision)
+        self.assertEqual(1.0, evidence["per_objective"]["quality"]["p_value_super"])
+        self.assertEqual(1.0, evidence["per_objective"]["quality"]["p_value_noninf"])
+
+    def test_zero_variance_aggregated_stats_not_promoted(self) -> None:
+        """Aggregated stats with std=0 (even at large n) must not Promote (#59)."""
+        incumbent = {"objective_values": {"quality": {"mean": 0.5, "std": 0.0, "n": 50}}}
+        candidate = {"objective_values": {"quality": {"mean": 0.9, "std": 0.0, "n": 50}}}
+        policy = {"alpha": 0.05, "min_effect": {"quality": 0.0}, "adjust": "none"}
+        objectives = [{"name": "quality", "direction": "maximize"}]
+
+        decision, evidence = epsilon_pareto_gate(incumbent, candidate, policy, objectives)
+        self.assertNotEqual("Promote", decision)
+        self.assertEqual(1.0, evidence["per_objective"]["quality"]["p_value_super"])
+
+    def test_zero_variance_paired_samples_not_promoted(self) -> None:
+        """Paired differences with zero variance must not Promote (#59, :397).
+
+        The paired difference variance is only "roundoff zero" (~1e-33), so a
+        plain ``variance > 0`` guard would miss it; the degeneracy check must
+        still treat it as unestimable.
+        """
+        incumbent = {"objective_values": {"quality": {"samples": [0.5, 0.5, 0.5]}}}
+        candidate = {
+            "objective_values": {"quality": {"samples": [0.9, 0.9, 0.9], "paired": True}}
+        }
+        policy = {"alpha": 0.05, "min_effect": {"quality": 0.0}, "adjust": "none"}
+        objectives = [{"name": "quality", "direction": "maximize"}]
+
+        decision, evidence = epsilon_pareto_gate(incumbent, candidate, policy, objectives)
+        self.assertNotEqual("Promote", decision)
+        self.assertEqual(1.0, evidence["per_objective"]["quality"]["p_value_super"])
+
+    def test_real_variance_still_promotes(self) -> None:
+        """Genuine (non-degenerate) variance path is unchanged: clear win Promotes."""
+        incumbent = {"objective_values": {"quality": {"samples": [0.80, 0.82, 0.81, 0.79, 0.80]}}}
+        candidate = {"objective_values": {"quality": {"samples": [0.92, 0.91, 0.93, 0.90, 0.92]}}}
+        policy = {"alpha": 0.05, "min_effect": {"quality": 0.02}, "adjust": "none"}
+        objectives = [{"name": "quality", "direction": "maximize"}]
+
+        decision, _ = epsilon_pareto_gate(incumbent, candidate, policy, objectives)
+        self.assertEqual("Promote", decision)
+
+    # --- Regression: low-power banded objective must be NoDecision, not Reject (#58) ---
+
+    def test_low_power_banded_is_no_decision(self) -> None:
+        """On-target banded metric measured with few samples -> NoDecision, not Reject.
+
+        Spec promotion-gate-io.md section 6 "TOST fail (power)" row:
+        Mean=100, band=[95,105], n=5, sigma=5 -> NoDecision.
+        """
+        incumbent = {"objective_values": {}}
+        candidate = {"objective_values": {"length": {"mean": 100.0, "std": 8.0, "n": 5}}}
+        policy = {"alpha": 0.05, "min_effect": {}, "adjust": "none"}
+        objectives = [{"name": "length", "band": {"target": [95, 105], "alpha": 0.05}}]
+
+        decision, evidence = epsilon_pareto_gate(incumbent, candidate, policy, objectives)
+        self.assertEqual("NoDecision", decision)
+        self.assertEqual("inconclusive", evidence["per_objective"]["length"]["verdict"])
+
+    def test_out_of_band_still_rejects(self) -> None:
+        """A genuinely out-of-band point estimate still hard-Rejects (#58).
+
+        Spec section 6 "TOST fail (OOB)" row: Mean=110, band=[95,105] -> Reject.
+        """
+        incumbent = {"objective_values": {}}
+        candidate = {"objective_values": {"length": {"mean": 110.0, "std": 2.0, "n": 50}}}
+        policy = {"alpha": 0.05, "min_effect": {}, "adjust": "none"}
+        objectives = [{"name": "length", "band": {"target": [95, 105], "alpha": 0.05}}]
+
+        decision, evidence = epsilon_pareto_gate(incumbent, candidate, policy, objectives)
+        self.assertEqual("Reject", decision)
+        self.assertEqual("out_of_band", evidence["per_objective"]["length"]["verdict"])
+
+    def test_low_power_band_does_not_block_via_false_reject_with_superior_std_obj(self) -> None:
+        """A superior standard objective alongside a low-power band -> NoDecision.
+
+        The inconclusive band must neither Reject nor be ignored to allow Promote;
+        it downgrades the overall decision to NoDecision.
+        """
+        incumbent = {
+            "objective_values": {
+                "quality": {"samples": [0.80, 0.82, 0.81, 0.79, 0.80, 0.81, 0.80, 0.79]},
+            },
+        }
+        candidate = {
+            "objective_values": {
+                "quality": {"samples": [0.92, 0.91, 0.93, 0.90, 0.92, 0.91, 0.90, 0.92]},
+                "length": {"mean": 100.0, "std": 8.0, "n": 5},
+            },
+        }
+        policy = {"alpha": 0.05, "min_effect": {"quality": 0.02}, "adjust": "none"}
+        objectives = [
+            {"name": "quality", "direction": "maximize"},
+            {"name": "length", "band": {"target": [95, 105], "alpha": 0.05}},
+        ]
+
+        decision, evidence = epsilon_pareto_gate(incumbent, candidate, policy, objectives)
+        self.assertEqual("NoDecision", decision)
+        self.assertEqual("inconclusive", evidence["per_objective"]["length"]["verdict"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_promotion_policy.py
+++ b/tests/test_promotion_policy.py
@@ -751,6 +751,34 @@ class PromotionGateTests(unittest.TestCase):
         self.assertNotEqual("Promote", decision)
         self.assertEqual(1.0, evidence["per_objective"]["quality"]["p_value_super"])
 
+    def test_high_offset_paired_variance_not_over_classified_degenerate(self) -> None:
+        """Genuine small variance at a high arm offset must not be treated as unestimable.
+
+        Paired arms sit at mean ~1e9 with differences [9.9, 10.0, 10.1] -> a
+        real (non-degenerate) diff variance of ~0.01. The degeneracy tolerance
+        is scaled by arm magnitude (correct, since cancellation roundoff scales
+        with it too), but too loose a coefficient over-classifies this as
+        unestimable and forces NoDecision on a clearly estimable effect (:384).
+        """
+        incumbent = {"objective_values": {"quality": {"samples": [1e9, 1e9, 1e9]}}}
+        candidate = {
+            "objective_values": {
+                "quality": {
+                    "samples": [1e9 + 9.9, 1e9 + 10.0, 1e9 + 10.1],
+                    "paired": True,
+                }
+            }
+        }
+        policy = {"alpha": 0.05, "min_effect": {"quality": 0.0}, "adjust": "none"}
+        objectives = [{"name": "quality", "direction": "maximize"}]
+
+        decision, evidence = epsilon_pareto_gate(incumbent, candidate, policy, objectives)
+        # A degenerate/unestimable classification pins both p-values to 1.0
+        # and the test_type stays "paired" but with p_value_super == 1.0; the
+        # real signal here must survive to produce a genuine test statistic.
+        self.assertNotEqual(1.0, evidence["per_objective"]["quality"]["p_value_super"])
+        self.assertIsNotNone(evidence["per_objective"]["quality"]["t_statistic"])
+
     def test_real_variance_still_promotes(self) -> None:
         """Genuine (non-degenerate) variance path is unchanged: clear win Promotes."""
         incumbent = {"objective_values": {"quality": {"samples": [0.80, 0.82, 0.81, 0.79, 0.80]}}}


### PR DESCRIPTION
Two promotion-gate governance-honesty fixes (public repo).

- **#59 (HIGH)** — a zero total variance floored the standard error to `1e-10`, manufacturing a near-infinite test statistic → a false **Promote** from a degenerate/underpowered sample (present in the paired and both Welch paths). Added a **scale-relative** degeneracy check (a plain `variance > 0` guard misses genuine-zero paired-difference variance, which surfaces as ~1e-33 roundoff) and return an unestimable result (p=1.0) instead of the SE floor. Zero-variance now **fails closed to Reject** (consistent with the existing n<2 handling); real-variance paths still Promote (no regression).
- **#58 (MED)** — the banded (TOST) classifier marked any non-in-band verdict as `out_of_band` (equivalent to the in-band test), so a low-power on-target band was hard-**Rejected**, contradicting spec §6 (`TOST fail (power)` → NoDecision). Now `out_of_band` only when the point estimate is outside the band; a wide-CI in-band (low-power) result returns **NoDecision**. Reject is reserved for genuine out-of-band.

Tests: `test_promotion_policy.py` 46 passed (7 new). Pre-existing unrelated failures (OR-Tools missing dep; model_checking import) confirmed on pristine main.

Closes #59
Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Spine: none (reason: captains-leader automated research/fix PR — not run through a governed ChangeSession; owner to govern/merge)

## Captain-PR gauntlet (orchestrate-captain-pr, 2026-07-19)
- Tier: LIGHT (economy batch) · Draft→review→fix→ready per owner instruction
- Review cycle: opus@xhigh (review-code bar) + sol@xhigh, independent — sol 1 BLOCKING (confirmed by captain arithmetic) / opus clean
- Fixes pushed: degeneracy tolerance 1e-9 -> 1e-12 (high-offset paired metrics no longer misclassified unestimable) + regression test (validated by the captain before dispatch; new head `9c6f03d`)
_Run economy per owner directive (2026-07-19): batched LIGHT-tier packets; sol=gpt-5.6-sol; aikido/greptile: n/a — no bot integration on this repo (no bot comments on any recent PR)._
