### PR TITLE
chore(deps): bump axios to 1.18.0 (GHSA-gcfj-64vw-6mp9)

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -40,7 +40,7 @@
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tanstack/react-query": "^4.41.0",
-    "axios": "^1.16.1",
+    "axios": "^1.18.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -96,8 +96,8 @@ importers:
         specifier: ^4.41.0
         version: 4.44.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       axios:
-        specifier: ^1.16.1
-        version: 1.16.1
+        specifier: ^1.18.0
+        version: 1.18.1
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2070,8 +2070,8 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
-  axios@1.16.1:
-    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
+  axios@1.18.1:
+    resolution: {integrity: sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==}
 
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
@@ -2588,8 +2588,8 @@ packages:
       debug:
         optional: true
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   forwarded@0.2.0:
@@ -2672,6 +2672,10 @@ packages:
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
 
   hast-util-from-dom@5.0.1:
@@ -5565,10 +5569,10 @@ snapshots:
       postcss: 8.5.9
       postcss-value-parser: 4.2.0
 
-  axios@1.16.1:
+  axios@1.18.1:
     dependencies:
       follow-redirects: 1.16.0
-      form-data: 4.0.5
+      form-data: 4.0.6
       https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -6189,12 +6193,12 @@ snapshots:
 
   follow-redirects@1.16.0: {}
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       mime-types: 2.1.35
 
   forwarded@0.2.0: {}
@@ -6260,6 +6264,10 @@ snapshots:
       has-symbols: 1.1.0
 
   hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
+  hasown@2.0.4:
     dependencies:
       function-bind: 1.1.2
 


### PR DESCRIPTION
## Summary

- Aikido High finding **GHSA-gcfj-64vw-6mp9**: `website/pnpm-lock.yaml` pinned `axios@1.16.1`, vulnerable; patched in `1.18.0`.
- Bumps the direct dependency in `website/package.json` (`^1.16.1` → `^1.18.0`) and re-resolves the lockfile to `axios@1.18.1`.
- Transitive churn is limited to axios's own dependency graph: `form-data@4.0.5 → 4.0.6` and a new `hasown@2.0.4` (both pulled in by the new axios). No unrelated lock churn.

Diffstat: `website/package.json` (1 line) + `website/pnpm-lock.yaml` (2 files changed, 19 insertions(+), 11 deletions(-)).

## Verification

- `pnpm --dir website install --frozen-lockfile` — passes (lockfile consistent).
- `pnpm --dir website why axios` — resolves `axios 1.18.1`.
- `pnpm --dir website build` — passes (Vite build + static prep + server bundle).
- Re-verified independently (not just by the fixer) — same frozen-install and `why axios` results reproduced.

## Type of change

- [ ] Spec
- [ ] Schema
- [ ] Tools
- [ ] SDK
- [ ] Docs
- [x] Examples *(N/A — this is a dependency-only bump in `website/`, no spec/schema/example content changed)*

## Checklist

- [ ] Ran `tvl-parse`, `tvl-lint`, `tvl-validate` on examples and new files — **N/A**, no `.tvl` spec/example files touched.
- [ ] Updated docs and changelog if needed — **N/A**, dependency patch only, no user-facing behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)