### PR TITLE
fix: update DOMPurify override

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -99,7 +99,7 @@
   "pnpm": {
     "overrides": {
       "@ungap/structured-clone": "1.3.1",
-      "dompurify": "3.4.11",
+      "dompurify": "3.4.12",
       "qs": "6.15.2",
       "uuid": "11.1.1"
     }

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 overrides:
   '@ungap/structured-clone': 1.3.1
-  dompurify: 3.4.11
+  dompurify: 3.4.12
   qs: 6.15.2
   uuid: 11.1.1
 
@@ -2422,8 +2422,8 @@ packages:
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
-  dompurify@3.4.11:
-    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -5931,7 +5931,7 @@ snapshots:
       '@babel/runtime': 7.29.2
       csstype: 3.2.3
 
-  dompurify@3.4.11:
+  dompurify@3.4.12:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -6773,7 +6773,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
       dayjs: 1.11.20
-      dompurify: 3.4.11
+      dompurify: 3.4.12
       es-toolkit: 1.47.1
       katex: 0.16.45
       khroma: 2.1.0


### PR DESCRIPTION
## Summary
- update the website DOMPurify override from 3.4.11 to the first patched release, 3.4.12
- regenerate only the required pnpm lock entries

## Verification
- frozen install
- type check
- production build
- independent static review of lock integrity and dependency compatibility

## Note
Vitest reports no matching test files; this PR changes no application source or test configuration.

## Scope
- non-core repository; main has no develop branch