### PR TITLE
fix(security): contain overlay extends paths

### DIFF
--- a/tests/test_tvl_compose.py
+++ b/tests/test_tvl_compose.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
 import yaml
 
 from tvl_tools.tvl_compose.cli import compose
@@ -101,3 +102,154 @@ def test_compose_replaces_enum_domain_lists_in_nested_domains(tmp_path: Path) ->
     composed = compose(overlay_path)
 
     assert composed["tvars"][0]["domain"] == ["gpt-4o-mini", "claude-3-haiku"]
+
+
+def test_compose_rejects_absolute_extends_path(tmp_path: Path) -> None:
+    base_path = tmp_path / "base.tvl.yml"
+    overlay_path = tmp_path / "overlay.tvl.yml"
+    _write_yaml(base_path, {"tvl": {"module": "demo.compose"}})
+    _write_yaml(
+        overlay_path,
+        {"_tvl_overlay": {"extends": str(base_path)}, "overrides": {}},
+    )
+
+    with pytest.raises(ValueError, match="must be a relative path"):
+        compose(overlay_path)
+
+
+def test_compose_rejects_extends_path_outside_overlay_root(tmp_path: Path) -> None:
+    overlay_root = tmp_path / "overlays"
+    overlay_root.mkdir()
+    base_path = tmp_path / "base.tvl.yml"
+    overlay_path = overlay_root / "overlay.tvl.yml"
+    _write_yaml(base_path, {"tvl": {"module": "demo.compose"}})
+    _write_yaml(
+        overlay_path,
+        {"_tvl_overlay": {"extends": "../base.tvl.yml"}, "overrides": {}},
+    )
+
+    with pytest.raises(ValueError, match="must stay within the overlay root"):
+        compose(overlay_path)
+
+
+def test_compose_rejects_symlinked_extends_path_outside_overlay_root(
+    tmp_path: Path,
+) -> None:
+    overlay_root = tmp_path / "overlays"
+    external_root = tmp_path / "external"
+    overlay_root.mkdir()
+    external_root.mkdir()
+    (overlay_root / "external").symlink_to(external_root, target_is_directory=True)
+    _write_yaml(external_root / "base.tvl.yml", {"tvl": {"module": "demo.compose"}})
+    overlay_path = overlay_root / "overlay.tvl.yml"
+    _write_yaml(
+        overlay_path,
+        {"_tvl_overlay": {"extends": "external/base.tvl.yml"}, "overrides": {}},
+    )
+
+    with pytest.raises(ValueError, match="must stay within the overlay root"):
+        compose(overlay_path)
+
+
+def test_compose_allows_nested_relative_extends_within_overlay_root(
+    tmp_path: Path,
+) -> None:
+    overlay_root = tmp_path / "overlays"
+    nested_root = overlay_root / "nested"
+    nested_root.mkdir(parents=True)
+    module_path = overlay_root / "base.tvl.yml"
+    nested_overlay_path = nested_root / "shared.overlay.yml"
+    overlay_path = overlay_root / "production.overlay.yml"
+    _write_yaml(module_path, {"tvl": {"module": "demo.compose"}, "value": "base"})
+    _write_yaml(
+        nested_overlay_path,
+        {
+            "_tvl_overlay": {"extends": "../base.tvl.yml"},
+            "overrides": {"value": "shared"},
+        },
+    )
+    _write_yaml(
+        overlay_path,
+        {
+            "_tvl_overlay": {"extends": "nested/shared.overlay.yml"},
+            "overrides": {"value": "production"},
+        },
+    )
+
+    assert compose(overlay_path)["value"] == "production"
+
+
+def _write_overlay_chain(
+    tmp_path: Path, overlay_count: int, cycle_to_initial: bool = False
+) -> Path:
+    base_path = tmp_path / "base.tvl.yml"
+    _write_yaml(base_path, {"tvl": {"module": "demo.compose"}})
+
+    for index in reversed(range(overlay_count)):
+        if cycle_to_initial and index == overlay_count - 1:
+            extends = "overlay-0.tvl.yml"
+        else:
+            extends = (
+                "base.tvl.yml"
+                if index == overlay_count - 1
+                else f"overlay-{index + 1}.tvl.yml"
+            )
+        _write_yaml(
+            tmp_path / f"overlay-{index}.tvl.yml",
+            {"_tvl_overlay": {"extends": extends}, "overrides": {}},
+        )
+
+    return tmp_path / "overlay-0.tvl.yml"
+
+
+def test_compose_allows_64_overlay_chain(tmp_path: Path) -> None:
+    assert (
+        compose(_write_overlay_chain(tmp_path, overlay_count=64))["tvl"]["module"]
+        == "demo.compose"
+    )
+
+
+def test_compose_rejects_65_overlay_chain_before_recursion_error(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(
+        ValueError, match="Overlay extends chain exceeds maximum depth of 64"
+    ):
+        compose(_write_overlay_chain(tmp_path, overlay_count=65))
+
+
+def test_compose_prioritizes_cycle_errors_over_chain_depth(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="Overlay extends cycle detected"):
+        compose(_write_overlay_chain(tmp_path, overlay_count=64, cycle_to_initial=True))
+
+
+@pytest.mark.parametrize(
+    ("overlays", "expected_cycle"),
+    [
+        (
+            {"self.overlay.yml": "self.overlay.yml"},
+            "self.overlay.yml -> self.overlay.yml",
+        ),
+        (
+            {
+                "first.overlay.yml": "second.overlay.yml",
+                "second.overlay.yml": "first.overlay.yml",
+            },
+            "first.overlay.yml -> second.overlay.yml -> first.overlay.yml",
+        ),
+    ],
+)
+def test_compose_rejects_overlay_cycles_deterministically(
+    tmp_path: Path, overlays: dict[str, str], expected_cycle: str
+) -> None:
+    for name, extends in overlays.items():
+        _write_yaml(
+            tmp_path / name,
+            {"_tvl_overlay": {"extends": extends}, "overrides": {}},
+        )
+
+    first_overlay = tmp_path / next(iter(overlays))
+    with pytest.raises(
+        ValueError, match=f"Overlay extends cycle detected: {expected_cycle}"
+    ):
+        compose(first_overlay)

--- a/tvl_tools/tvl_compose/cli.py
+++ b/tvl_tools/tvl_compose/cli.py
@@ -14,14 +14,34 @@ from typing import Any, Dict, List, Optional
 
 import yaml
 
-from tvl_tools.cli_utils import add_common_args, get_format, handle_error, load_yaml_safely, print_output
+from tvl_tools.cli_utils import (
+    add_common_args,
+    get_format,
+    handle_error,
+    load_yaml_safely,
+    print_output,
+)
+
+_MAX_OVERLAY_CHAIN_DEPTH = 64
 
 
-def _resolve_base_path(overlay_path: Path, base_ref: str) -> Path:
-    """Resolve the base file path relative to the overlay file."""
-    if Path(base_ref).is_absolute():
-        return Path(base_ref)
-    return overlay_path.parent / base_ref
+def _resolve_base_path(overlay_path: Path, base_ref: str, overlay_root: Path) -> Path:
+    """Resolve a relative base path without leaving the initial overlay root."""
+    if not isinstance(base_ref, str):
+        raise TypeError("Overlay 'extends' must be a relative path string")
+
+    reference_path = Path(base_ref)
+    if reference_path.is_absolute():
+        raise ValueError("Overlay 'extends' must be a relative path")
+
+    base_path = (overlay_path.parent / reference_path).resolve()
+    try:
+        base_path.relative_to(overlay_root)
+    except ValueError as exc:
+        raise ValueError(
+            "Overlay 'extends' path must stay within the overlay root"
+        ) from exc
+    return base_path
 
 
 def _deep_merge(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any]:
@@ -30,7 +50,9 @@ def _deep_merge(base: Dict[str, Any], override: Dict[str, Any]) -> Dict[str, Any
     for key, value in override.items():
         if key in result and isinstance(result[key], dict) and isinstance(value, dict):
             result[key] = _deep_merge(result[key], value)
-        elif key in result and isinstance(result[key], list) and isinstance(value, list):
+        elif (
+            key in result and isinstance(result[key], list) and isinstance(value, list)
+        ):
             # Only TVAR lists are merged by name. Other lists, such as enum domains
             # or numeric ranges, should be replaced by the overlay value.
             if key == "tvars":
@@ -55,7 +77,9 @@ def _merge_tvar_lists(base_tvars: List[Dict], override_tvars: List[Dict]) -> Lis
             result[idx] = _deep_merge(result[idx], override_tvar)
         else:
             # This is an error - can't add new TVARs in overlay
-            raise ValueError(f"Cannot add new TVAR '{name}' in overlay. Overlays can only narrow existing TVARs.")
+            raise ValueError(
+                f"Cannot add new TVAR '{name}' in overlay. Overlays can only narrow existing TVARs."
+            )
 
     return result
 
@@ -91,9 +115,13 @@ def _validate_narrowing(base: Dict[str, Any], composed: Dict[str, Any]) -> List[
                 base_range = base_domain["range"]
                 composed_range = composed_domain["range"]
                 if composed_range[0] < base_range[0]:
-                    errors.append(f"TVAR '{name}': cannot widen range minimum from {base_range[0]} to {composed_range[0]}")
+                    errors.append(
+                        f"TVAR '{name}': cannot widen range minimum from {base_range[0]} to {composed_range[0]}"
+                    )
                 if composed_range[1] > base_range[1]:
-                    errors.append(f"TVAR '{name}': cannot widen range maximum from {base_range[1]} to {composed_range[1]}")
+                    errors.append(
+                        f"TVAR '{name}': cannot widen range maximum from {base_range[1]} to {composed_range[1]}"
+                    )
 
     # Check budgets (can only decrease)
     base_budgets = base.get("exploration", {}).get("budgets", {})
@@ -102,21 +130,37 @@ def _validate_narrowing(base: Dict[str, Any], composed: Dict[str, Any]) -> List[
     for key in ["max_trials", "max_spend_usd", "max_wallclock_s"]:
         if key in base_budgets and key in composed_budgets:
             if composed_budgets[key] > base_budgets[key]:
-                errors.append(f"Budget '{key}': cannot increase from {base_budgets[key]} to {composed_budgets[key]}")
+                errors.append(
+                    f"Budget '{key}': cannot increase from {base_budgets[key]} to {composed_budgets[key]}"
+                )
 
     return errors
 
 
-def compose(overlay_path: Path, validate_narrowing: bool = True) -> Dict[str, Any]:
-    """Compose an overlay file into a valid TVL 1.0 module.
+def _format_cycle_path(path: Path, overlay_root: Path) -> str:
+    """Render a canonical overlay path relative to the composition root."""
+    return path.relative_to(overlay_root).as_posix()
 
-    Args:
-        overlay_path: Path to the overlay YAML file
-        validate_narrowing: If True, validate that overlay only narrows base
 
-    Returns:
-        Composed TVL 1.0 module as a dict
-    """
+def _compose(
+    overlay_path: Path,
+    validate_narrowing: bool,
+    overlay_root: Path,
+    resolution_chain: list[Path],
+) -> dict[str, Any]:
+    """Compose an overlay while enforcing its path and recursion boundaries."""
+    if overlay_path in resolution_chain:
+        cycle_start = resolution_chain.index(overlay_path)
+        cycle = resolution_chain[cycle_start:] + [overlay_path]
+        rendered_cycle = " -> ".join(
+            _format_cycle_path(path, overlay_root) for path in cycle
+        )
+        raise ValueError(f"Overlay extends cycle detected: {rendered_cycle}")
+    if len(resolution_chain) >= _MAX_OVERLAY_CHAIN_DEPTH:
+        raise ValueError(
+            f"Overlay extends chain exceeds maximum depth of {_MAX_OVERLAY_CHAIN_DEPTH}"
+        )
+
     overlay = load_yaml_safely(overlay_path)
 
     if not isinstance(overlay, dict):
@@ -132,7 +176,7 @@ def compose(overlay_path: Path, validate_narrowing: bool = True) -> Dict[str, An
         raise ValueError("Overlay must specify 'extends' in _tvl_overlay")
 
     # Load base module
-    base_path = _resolve_base_path(overlay_path, extends)
+    base_path = _resolve_base_path(overlay_path, extends, overlay_root)
     base = load_yaml_safely(base_path)
 
     if not isinstance(base, dict):
@@ -140,7 +184,12 @@ def compose(overlay_path: Path, validate_narrowing: bool = True) -> Dict[str, An
 
     # Recursively resolve if base is also an overlay
     if "_tvl_overlay" in base:
-        base = compose(base_path, validate_narrowing=False)
+        base = _compose(
+            base_path,
+            validate_narrowing=False,
+            overlay_root=overlay_root,
+            resolution_chain=resolution_chain + [overlay_path],
+        )
 
     # Get overrides
     overrides = overlay.get("overrides", {})
@@ -160,6 +209,21 @@ def compose(overlay_path: Path, validate_narrowing: bool = True) -> Dict[str, An
     return composed
 
 
+def compose(overlay_path: Path, validate_narrowing: bool = True) -> Dict[str, Any]:
+    """Compose an overlay file into a valid TVL 1.0 module.
+
+    The initial overlay's directory is the composition root. Every ``extends``
+    reference must resolve inside it, including references in nested overlays.
+    """
+    resolved_overlay_path = overlay_path.resolve()
+    return _compose(
+        resolved_overlay_path,
+        validate_narrowing=validate_narrowing,
+        overlay_root=resolved_overlay_path.parent,
+        resolution_chain=[],
+    )
+
+
 def text_renderer(data: Dict[str, Any]) -> None:
     """Render compose result as text."""
     if data.get("ok"):
@@ -167,7 +231,9 @@ def text_renderer(data: Dict[str, Any]) -> None:
             print(f"Composed: {data['output_file']}")
         else:
             # Print the composed YAML to stdout
-            print(yaml.dump(data["composed"], default_flow_style=False, sort_keys=False))
+            print(
+                yaml.dump(data["composed"], default_flow_style=False, sort_keys=False)
+            )
     elif data.get("validation") and not data["validation"]["ok"]:
         # Validation failure: surface the issues on stderr
         print("Validation failed:", file=sys.stderr)
@@ -183,7 +249,8 @@ def main() -> None:
     )
     parser.add_argument("file", type=Path, help="Path to overlay YAML file")
     parser.add_argument(
-        "-o", "--output",
+        "-o",
+        "--output",
         type=Path,
         help="Output file path (default: stdout)",
     )
@@ -211,8 +278,9 @@ def main() -> None:
 
         # Optionally validate the composed module (independent of output target)
         if args.validate:
-            from tvl_tools.tvl_validate.cli import _load_schema, _schema_issues
             from tvl.lints import lint_module
+
+            from tvl_tools.tvl_validate.cli import _load_schema, _schema_issues
 
             schema = _load_schema(Path(__file__))
             issues = _schema_issues(composed, schema)


### PR DESCRIPTION
## Summary

- reject absolute and canonical root-escaping `_tvl_overlay.extends` references before composition
- keep one immutable root from the initial overlay so nested overlays cannot re-anchor containment
- detect self/mutual cycles and cap distinct overlay chains at 64 before Python recursion exhaustion
- retain valid nested relative composition inside the initial root

Closes #43.

## Security properties

The resolver canonicalizes each target, including symlinks, and checks path components with `Path.relative_to()` before loading it. The cycle chain uses canonical paths, and the depth guard fails the 65th distinct overlay with a deterministic `ValueError`; cycle errors take priority at that boundary.

## Verification

- `uv run --frozen --extra dev pytest -q tests` — 468 passed
- `python -m compileall -q tvl_tools/tvl_compose`
- Black check and isort Black-profile check on both changed Python files
- `git diff --check`
- safe-push secret scan: `SAFE_PUSH_SCAN: PASS`
- fresh no-tools Claude Opus review of final exact diff SHA-256 `9c32ad3a266c22e7feb3a2439e526fe1b3cc5df032c9d1dbd66b9a3ed634a6ab`: **CONFIRM**, no blockers (session `4a28b67c-aa45-439d-a6e1-246582f85b6a`)

## Residual risk

A same-user concurrent symlink swap between canonicalization and file open would require fd-relative or `O_NOFOLLOW` I/O to eliminate. This local TOCTOU is not worsened by the patch; canonical traversal/symlink escapes from an untrusted spec are blocked. Absolute and initial-root-escaping references intentionally stop working.

Spine-Trail: st_bedd897d42a7
