### PR TITLE
ci(security): restore CodeQL code scanning (disabled by org config 259257)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,73 @@
+name: CodeQL
+
+# Restores CodeQL code scanning on this repository.
+#
+# Scanning previously ran via GitHub "default setup" and went dark on
+# 2026-07-11 when the org code-security configuration "Traigent-trial-fullscan"
+# (id 259257, description: "Code scanning OFF") set
+# code_scanning_default_setup=disabled. No workflow existed to take over, so the
+# repository has since reported "0 open alerts" — a false clean, not a clean.
+# CodeQL is free on public repositories, so this costs nothing to run.
+#
+# This workflow is deliberately GUARD-FREE. There is no availability probe, no
+# `continue-on-error`, and no conditional skip around init/analyze. A future
+# security-configuration change therefore cannot silently disable scanning
+# again; it can only make this job fail loudly. (A sibling repo's workflow
+# guarded on the admin-only code-scanning/default-setup API, always got HTTP 403
+# from GITHUB_TOKEN, and reported success while scanning nothing — do not
+# reintroduce that pattern.) See CLAUDE.md production-safety rule 1 (policy
+# surfaces fail closed) and rule 2 (no fake completion).
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    - cron: '23 3 * * 1'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  # github.event_name is part of the key so a push never cancels the weekly
+  # security-extended scan (both run against refs/heads/main).
+  group: codeql-${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # python/  tvl_tools/  tests/  conformance/
+          - language: python
+            build-mode: none
+          # website/  vscode-tvl/  editor_shared/
+          - language: javascript-typescript
+            build-mode: none
+          - language: actions
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          # Deep taint suite (security-extended) only on the weekly schedule so
+          # PR/push scans stay fast and low-noise on the default suite.
+          queries: ${{ github.event_name == 'schedule' && 'security-extended' || '' }}
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4


### PR DESCRIPTION
## What this fixes

Code scanning on this repository ran via GitHub **default setup** until it went
dark on **2026-07-11** (last analysis: `2026-07-11T11:51:44Z`,
`refs/heads/main`).

The cause is an org code-security configuration — **`Traigent-trial-fullscan`,
id `259257`, whose description literally reads "Code scanning OFF"** — attached
to this repo with `code_scanning_default_setup: disabled`. `GET
/repos/Traigent/tvl/code-scanning/default-setup` today returns
`{"state":"not-configured"}`.

No `.github/workflows/codeql.yml` existed to take over (HTTP 404), so nothing
replaced default setup. The repository has since reported **"0 open alerts"**,
which is a **false clean, not a clean** — the Security tab looks green because
nothing has been scanned for three weeks.

## Why a workflow file rather than re-enabling default setup

Deliberate. Default setup is a *repository setting*, and a setting is exactly
what silently switched it off. A workflow file lives in the repo, is
code-reviewed, and shows up in `git log` — a future security-configuration
change can no longer turn scanning off without a visible commit.

## Why this workflow has no availability guard

A sibling repo (`traigent-js`) has a CodeQL workflow that **reports success
while scanning nothing**: its guard `curl`s the admin-only
`code-scanning/default-setup` API with `${{ github.token }}`, always receives
`403 "Resource not accessible by integration"` (GITHUB_TOKEN never has admin
scope), interprets that as "Code Security not enabled", skips init/build/analyze,
and exits 0.

This workflow therefore contains **no availability probe, no
`continue-on-error`, and no conditional skip**. `github/codeql-action/analyze`
runs unconditionally and the job fails if it fails. Fail closed, never fail open
— CLAUDE.md production-safety rule 1 (policy surfaces fail closed) and rule 2
(no fake completion).

## Cost

**Zero.** This repository is public, and CodeQL / GitHub Advanced Security code
scanning is free on public repositories.

## Shape

- Matrix over `python`, `javascript-typescript`, and `actions`. This repo has
  meaningful TS/JS (423 KB TypeScript + 28 KB JavaScript in `website/`,
  `vscode-tvl/`, `editor_shared/`), and default setup had also been configured
  for JS/TS here — so JS/TS is included rather than Python-only.
  `build-mode: none` for all three. (Lean under `proofs/` and `formalization/`
  is not a CodeQL-supported language and is simply not scanned.)
- `pull_request` + `push` on `main` (this repo has no `develop` branch);
  weekly `schedule` (`23 3 * * 1`).
- `security-extended` reserved for the scheduled run so PR/push latency and
  noise stay on the default suite.
- Minimum permissions: `security-events: write`, `contents: read`,
  `actions: read`.
- Actions pinned by commit SHA, same pins as the working advanced setup in
  `TraigentBackend`.
- `concurrency` keyed on `github.event_name` as well as `github.ref`, so a push
  to `main` cannot cancel the weekly `security-extended` scan.

## Verification

- `yaml.safe_load` parses (T3, executed).
- `actionlint` (docker `rhysd/actionlint`) reports **0 findings** — positive-
  controlled against a deliberately broken workflow in the same run, which it
  correctly flagged with 3 errors, so the clean result is meaningful (T3).
- Grep over the comment-stripped executable YAML: 0 hits for `default-setup`,
  `continue-on-error`, `github.token`, `GITHUB_TOKEN`, `curl`, `if:`, `skip`
  (T3).
- Structural check of the parsed YAML: 3 steps, **0** with `if` or
  `continue-on-error`, exactly 1 unconditional `github/codeql-action/analyze`
  step, no job-level `if` or `continue-on-error` (T3).

## PR checklist

1. **Worst-case prod path** — none; CI-only, no runtime code path. The worst
   case is a failing CI job, which is the intended fail-closed direction.
2. **Production-branch test** — n/a. The fail-closed property is structural and
   is asserted by the greps/structural check above.
3. **Contract regeneration** — none.
4. **Public surface delta** — none.
5. **Review threads resolved** — will be resolved before merge; none open at
   time of opening.
6. **Quality gates not relaxed** — no threshold widened. This PR *restores* a
   security gate that had been silently removed.
