### PR TITLE
fix(compose): extend overlay narrowing to safety constraints

### DIFF
--- a/docs/examples/walkthroughs.md
+++ b/docs/examples/walkthroughs.md
@@ -104,7 +104,7 @@ tvl-check-operational <module> --json
 If you are working with composed overlays or runtime artifacts, extend the flow with:
 
 ```bash
-tvl-compose base.tvl.yml staging.overlay.yml > merged.tvl.yml
+tvl-compose staging.overlay.yml -o merged.tvl.yml
 tvl-config-validate merged.tvl.yml config.yml
 tvl-measure-validate merged.tvl.yml config.yml measurements.yml
 ```

--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -469,10 +469,65 @@ tvl-check-operational path/to/module.yml --json
 Artifact validation and composition:
 
 ```bash
-tvl-compose base.tvl.yml staging.overlay.yml > merged.tvl.yml
+tvl-compose staging.overlay.yml -o merged.tvl.yml
 tvl-config-validate module.tvl.yml config.yml
 tvl-measure-validate module.tvl.yml config.yml measurements.yml
 ```
+
+`tvl-compose` takes **one** overlay file, which names its base via `_tvl_overlay.extends`.
+
+### Overlays may only tighten
+
+An overlay narrows a base module; it may never widen it. The composer enforces:
+
+| Element | Rule |
+|---|---|
+| TVAR domains | enum values may be removed, never added; numeric ranges may shrink, never grow |
+| TVARs | may not be added |
+| `exploration.budgets` | may decrease, never increase |
+| `promotion_policy.chance_constraints` | a named constraint may not be dropped; `threshold` may only **decrease**; `confidence` may only **increase** |
+| `objectives` | may not be dropped; `direction` may not flip |
+| `constraints.structural` / `constraints.derived` | clauses may not be dropped unless waived |
+
+`threshold` bounds a violation rate, so raising it permits more violations; lowering
+`confidence` makes a weaker claim. Both are widenings even though the numbers move in
+opposite directions.
+
+Note that `overrides` **replaces** a list rather than merging into it (`tvars` is the one
+exception, merged by name). Every inherited clause you intend to keep must be restated in
+the overlay — the retention rules above are what stop an accidental omission from silently
+becoming a weakening.
+
+### Waiving an inherited clause
+
+Narrowing a TVAR can make an inherited clause **vacuous**, and keeping it is then a hard
+lint error. For example, narrowing `temperature` to `[0.0, 0.3]` makes an inherited
+`when: temperature > 0.7` guard unsatisfiable, and `tvl-validate` rejects the composed
+module with `constraint_value_out_of_domain`. The clause has to go — so removal needs to be
+expressible without also permitting silent weakening.
+
+Declare it:
+
+```yaml
+_tvl_overlay:
+  extends: base.tvl.yml
+  waives:
+    - clause: "temperature > 0.7 => pii_redaction = true"
+      reason: "vacuous: temperature narrowed to [0.0, 0.3]"
+```
+
+Clause syntax for a waiver: `expr` clauses are written verbatim; `when`/`then` clauses are
+written `<when> => <then>`. Whitespace is normalised, so reformatting a clause does not
+break the match.
+
+`reason` is mandatory, and a waiver that matches no clause in the base is an error rather
+than a no-op — a stale waiver usually means the clause text drifted, which would otherwise
+silently re-open the hole it was covering.
+
+A waiver records that **a human decided to drop the clause and why**. It deliberately does
+*not* prove the clause is vacuous; verifying that would need the structural SAT solver, and
+a waiver that quietly accepted a non-vacuous clause would be worse than having no mechanism
+at all. The value is that a declared removal is distinguishable from a silent one in review.
 
 Interpretation:
 

--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -486,7 +486,7 @@ An overlay narrows a base module; it may never widen it. The composer enforces:
 | TVARs | may not be added |
 | `exploration.budgets` | may decrease, never increase |
 | `promotion_policy.chance_constraints` | a named constraint may not be dropped; `threshold` may only **decrease**; `confidence` may only **increase** |
-| `objectives` | may not be dropped; `direction` may not flip; a `band.target` may not be widened or removed |
+| `objectives` | may not be dropped; kind may not change (directional <-> banded); `direction` may not flip; a `band.target` may not be widened or removed (both `[low, high]` and `{center, tol}` forms); `band.alpha` may not be raised |
 | `constraints.structural` / `constraints.derived` | clauses may not be dropped unless waived, or replaced by a strictly tighter bound on the same symbol |
 
 `threshold` bounds a violation rate, so raising it permits more violations; lowering
@@ -505,7 +505,7 @@ These remain unchecked and can still be changed freely, so review them by hand:
 *   `promotion_policy.alpha`, `adjust`, and `min_effect`
 *   `evaluation_set.dataset` and `seed` — an overlay may point at an easier evaluation set
 *   `environment.bindings` and `environment.context` (beyond the derived-clause rules)
-*   `objectives[].metric_ref`
+*   `objectives[].metric_ref` and `band.test`
 
 `min_effect` is excluded deliberately: whether raising it tightens depends on the objective's
 direction and which side of the comparison it lands on, so a rule here would reject valid

--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -487,7 +487,7 @@ An overlay narrows a base module; it may never widen it. The composer enforces:
 | `exploration.budgets` | may decrease, never increase |
 | `promotion_policy.chance_constraints` | a named constraint may not be dropped; `threshold` may only **decrease**; `confidence` may only **increase** |
 | `objectives` | may not be dropped; `direction` may not flip |
-| `constraints.structural` / `constraints.derived` | clauses may not be dropped unless waived |
+| `constraints.structural` / `constraints.derived` | clauses may not be dropped unless waived, or replaced by a strictly tighter bound on the same symbol |
 
 `threshold` bounds a violation rate, so raising it permits more violations; lowering
 `confidence` makes a weaker claim. Both are widenings even though the numbers move in
@@ -497,6 +497,17 @@ Note that `overrides` **replaces** a list rather than merging into it (`tvars` i
 exception, merged by name). Every inherited clause you intend to keep must be restated in
 the overlay — the retention rules above are what stop an accidental omission from silently
 becoming a weakening.
+
+### Tightening a bound is not dropping it
+
+A derived clause replaced by a **strictly tighter bound on the same symbol** counts as
+retained, not removed — `env.context.eval_samples >= 3000` becoming `>= 5990` is exactly what
+a stricter profile should do, and restating the looser clause alongside it would be nonsense.
+
+Direction matters and is handled: a lower bound (`>=`, `>`) tightens as the number **rises**,
+an upper bound (`<=`, `<`) tightens as it **falls**. Only the simple
+`<symbol> <op> <number>` shape is recognised; anything richer falls back to requiring exact
+retention or a waiver, which is the safe default.
 
 ### Waiving an inherited clause
 

--- a/docs/reference/language.md
+++ b/docs/reference/language.md
@@ -486,12 +486,31 @@ An overlay narrows a base module; it may never widen it. The composer enforces:
 | TVARs | may not be added |
 | `exploration.budgets` | may decrease, never increase |
 | `promotion_policy.chance_constraints` | a named constraint may not be dropped; `threshold` may only **decrease**; `confidence` may only **increase** |
-| `objectives` | may not be dropped; `direction` may not flip |
+| `objectives` | may not be dropped; `direction` may not flip; a `band.target` may not be widened or removed |
 | `constraints.structural` / `constraints.derived` | clauses may not be dropped unless waived, or replaced by a strictly tighter bound on the same symbol |
 
 `threshold` bounds a violation rate, so raising it permits more violations; lowering
 `confidence` makes a weaker claim. Both are widenings even though the numbers move in
 opposite directions.
+
+Every edge of an overlay **chain** is validated, not just the outermost one — otherwise a
+single pass-through overlay (`final` extends `weaken` extends `base`) would check `final`
+against the already-weakened `weaken` and launder the whole change.
+
+#### What this does NOT cover
+
+The table above is the enforced set, not a guarantee that an overlay cannot loosen anything.
+These remain unchecked and can still be changed freely, so review them by hand:
+
+*   `promotion_policy.alpha`, `adjust`, and `min_effect`
+*   `evaluation_set.dataset` and `seed` — an overlay may point at an easier evaluation set
+*   `environment.bindings` and `environment.context` (beyond the derived-clause rules)
+*   `objectives[].metric_ref`
+
+`min_effect` is excluded deliberately: whether raising it tightens depends on the objective's
+direction and which side of the comparison it lands on, so a rule here would reject valid
+overlays as often as it caught bad ones. The others are unbounded by nature and would need a
+policy decision about what "tighter" even means.
 
 Note that `overrides` **replaces** a list rather than merging into it (`tvars` is the one
 exception, merged by name). Every inherited clause you intend to keep must be restated in

--- a/tests/test_tvl_compose.py
+++ b/tests/test_tvl_compose.py
@@ -253,3 +253,232 @@ def test_compose_rejects_overlay_cycles_deterministically(
         ValueError, match=f"Overlay extends cycle detected: {expected_cycle}"
     ):
         compose(first_overlay)
+
+
+# ---------------------------------------------------------------------------
+# Safety monotonicity (issue #70)
+#
+# The narrowing check historically covered TVAR domains and exploration budgets only,
+# so an overlay could delete every structural guardrail and gut every chance constraint
+# and still compose with exit 0.
+# ---------------------------------------------------------------------------
+
+
+def _safety_base(path: Path) -> None:
+    _write_yaml(
+        path,
+        {
+            "tvl": {"module": "demo.safety"},
+            "environment": {"snapshot_id": "2026-01-01T00:00:00Z"},
+            "evaluation_set": {"dataset": "s3://datasets/demo.jsonl"},
+            "tvars": [
+                {
+                    "name": "temperature",
+                    "type": "float",
+                    "domain": {"range": [0.0, 1.0], "resolution": 0.05},
+                },
+                {"name": "pii_redaction", "type": "bool", "domain": [True, False]},
+            ],
+            "constraints": {
+                "structural": [
+                    {"expr": "pii_redaction = true"},
+                    {"when": "temperature > 0.7", "then": "pii_redaction = true"},
+                ],
+                "derived": [],
+            },
+            "objectives": [
+                {"name": "quality", "direction": "maximize"},
+                {"name": "toxic_rate", "direction": "minimize"},
+            ],
+            "promotion_policy": {
+                "dominance": "epsilon_pareto",
+                "alpha": 0.05,
+                "min_effect": {"quality": 0.01, "toxic_rate": 0.001},
+                "chance_constraints": [
+                    {"name": "toxic_rate_slo", "threshold": 0.01, "confidence": 0.95}
+                ],
+            },
+        },
+    )
+
+
+def _overlay(path: Path, overrides: dict, meta_extra: dict | None = None) -> None:
+    meta = {"extends": "base.tvl.yml"}
+    meta.update(meta_extra or {})
+    _write_yaml(path, {"_tvl_overlay": meta, "overrides": overrides})
+
+
+def test_compose_rejects_raising_a_chance_constraint_threshold(tmp_path: Path) -> None:
+    _safety_base(tmp_path / "base.tvl.yml")
+    _overlay(
+        tmp_path / "weaken.overlay.yml",
+        {
+            "promotion_policy": {
+                "chance_constraints": [
+                    {"name": "toxic_rate_slo", "threshold": 0.50, "confidence": 0.95}
+                ]
+            }
+        },
+    )
+
+    with pytest.raises(ValueError, match="cannot raise threshold from 0.01 to 0.5"):
+        compose(tmp_path / "weaken.overlay.yml")
+
+
+def test_compose_rejects_lowering_confidence(tmp_path: Path) -> None:
+    _safety_base(tmp_path / "base.tvl.yml")
+    _overlay(
+        tmp_path / "weaken.overlay.yml",
+        {
+            "promotion_policy": {
+                "chance_constraints": [
+                    {"name": "toxic_rate_slo", "threshold": 0.01, "confidence": 0.50}
+                ]
+            }
+        },
+    )
+
+    with pytest.raises(ValueError, match="cannot lower confidence from 0.95 to 0.5"):
+        compose(tmp_path / "weaken.overlay.yml")
+
+
+def test_compose_rejects_dropping_a_chance_constraint(tmp_path: Path) -> None:
+    _safety_base(tmp_path / "base.tvl.yml")
+    _overlay(tmp_path / "drop.overlay.yml", {"promotion_policy": {"chance_constraints": []}})
+
+    with pytest.raises(ValueError, match="chance_constraint 'toxic_rate_slo': removed"):
+        compose(tmp_path / "drop.overlay.yml")
+
+
+def test_compose_allows_tightening(tmp_path: Path) -> None:
+    """The check must not block legitimate hardening - only weakening."""
+    _safety_base(tmp_path / "base.tvl.yml")
+    _overlay(
+        tmp_path / "tighten.overlay.yml",
+        {
+            "tvars": [
+                {"name": "temperature", "domain": {"range": [0.0, 0.9], "resolution": 0.05}}
+            ],
+            "promotion_policy": {
+                "chance_constraints": [
+                    {"name": "toxic_rate_slo", "threshold": 0.001, "confidence": 0.99}
+                ]
+            },
+        },
+    )
+
+    composed = compose(tmp_path / "tighten.overlay.yml")
+    cc = composed["promotion_policy"]["chance_constraints"][0]
+    assert cc["threshold"] == 0.001
+    assert cc["confidence"] == 0.99
+
+
+def test_compose_rejects_dropping_a_structural_clause(tmp_path: Path) -> None:
+    _safety_base(tmp_path / "base.tvl.yml")
+    _overlay(tmp_path / "strip.overlay.yml", {"constraints": {"structural": []}})
+
+    with pytest.raises(ValueError, match="pii_redaction = true.*was dropped"):
+        compose(tmp_path / "strip.overlay.yml")
+
+
+def test_compose_rejects_dropping_an_objective(tmp_path: Path) -> None:
+    _safety_base(tmp_path / "base.tvl.yml")
+    _overlay(
+        tmp_path / "drop-obj.overlay.yml",
+        {"objectives": [{"name": "quality", "direction": "maximize"}]},
+    )
+
+    with pytest.raises(ValueError, match="objective 'toxic_rate': removed"):
+        compose(tmp_path / "drop-obj.overlay.yml")
+
+
+def test_compose_rejects_flipping_objective_direction(tmp_path: Path) -> None:
+    _safety_base(tmp_path / "base.tvl.yml")
+    _overlay(
+        tmp_path / "flip.overlay.yml",
+        {
+            "objectives": [
+                {"name": "quality", "direction": "maximize"},
+                {"name": "toxic_rate", "direction": "maximize"},
+            ]
+        },
+    )
+
+    with pytest.raises(ValueError, match="cannot change direction"):
+        compose(tmp_path / "flip.overlay.yml")
+
+
+def test_waiver_permits_a_clause_the_narrowing_made_vacuous(tmp_path: Path) -> None:
+    """The motivating case for waivers.
+
+    Narrowing temperature to [0.0, 0.3] makes an inherited `temperature > 0.7` guard
+    vacuous, and keeping it is a hard lint error on the composed module. Without the
+    waiver mechanism this checker would reject a legitimate overlay.
+    """
+    _safety_base(tmp_path / "base.tvl.yml")
+    _overlay(
+        tmp_path / "narrow.overlay.yml",
+        {
+            "tvars": [
+                {"name": "temperature", "domain": {"range": [0.0, 0.3], "resolution": 0.05}}
+            ],
+            "constraints": {"structural": [{"expr": "pii_redaction = true"}]},
+        },
+        meta_extra={
+            "waives": [
+                {
+                    "clause": "temperature > 0.7 => pii_redaction = true",
+                    "reason": "vacuous: temperature narrowed to [0.0, 0.3]",
+                }
+            ]
+        },
+    )
+
+    composed = compose(tmp_path / "narrow.overlay.yml")
+    assert composed["tvars"][0]["domain"]["range"] == [0.0, 0.3]
+    assert len(composed["constraints"]["structural"]) == 1
+
+
+def test_waiver_without_a_reason_is_rejected(tmp_path: Path) -> None:
+    """A waiver's whole purpose is to make a removal declared, so a reason is mandatory."""
+    _safety_base(tmp_path / "base.tvl.yml")
+    _overlay(
+        tmp_path / "bad-waiver.overlay.yml",
+        {"constraints": {"structural": [{"expr": "pii_redaction = true"}]}},
+        meta_extra={"waives": [{"clause": "temperature > 0.7 => pii_redaction = true"}]},
+    )
+
+    with pytest.raises(ValueError, match="is missing 'reason'"):
+        compose(tmp_path / "bad-waiver.overlay.yml")
+
+
+def test_stale_waiver_is_rejected(tmp_path: Path) -> None:
+    """A waiver that matches nothing is a sign the clause text drifted - fail loudly."""
+    _safety_base(tmp_path / "base.tvl.yml")
+    _overlay(
+        tmp_path / "stale.overlay.yml",
+        {},
+        meta_extra={"waives": [{"clause": "no_such_clause = true", "reason": "typo"}]},
+    )
+
+    with pytest.raises(ValueError, match="does not match any clause in the base module"):
+        compose(tmp_path / "stale.overlay.yml")
+
+
+def test_clause_identity_ignores_whitespace(tmp_path: Path) -> None:
+    """Reformatting a restated clause must not read as dropping it."""
+    _safety_base(tmp_path / "base.tvl.yml")
+    _overlay(
+        tmp_path / "reformat.overlay.yml",
+        {
+            "constraints": {
+                "structural": [
+                    {"expr": "pii_redaction   =    true"},
+                    {"when": "temperature  > 0.7", "then": "pii_redaction = true"},
+                ]
+            }
+        },
+    )
+
+    composed = compose(tmp_path / "reformat.overlay.yml")
+    assert len(composed["constraints"]["structural"]) == 2

--- a/tests/test_tvl_compose.py
+++ b/tests/test_tvl_compose.py
@@ -812,3 +812,57 @@ def test_clause_key_handles_escaped_quotes(tmp_path: Path) -> None:
     c = _clause_key({"expr": 'note = "say \\"  now"'})
     assert a == b, "whitespace outside quotes should still normalise"
     assert a != c, "whitespace inside the literal must remain significant"
+
+
+def test_equivalent_bands_in_different_forms_are_not_a_widening(tmp_path: Path) -> None:
+    """`[0.1, 0.5]` and `{center: 0.3, tol: 0.2}` are the same interval.
+
+    Float arithmetic makes `0.3 - 0.2` = 0.09999999999999998, strictly below 0.1, so a
+    naive comparison reports a widening and blocks a legitimate overlay.
+    """
+    _safety_base(tmp_path / "base.tvl.yml")
+    base = yaml.safe_load((tmp_path / "base.tvl.yml").read_text())
+    base["objectives"][0] = {
+        "name": "quality",
+        "band": {"target": [0.1, 0.5], "test": "TOST", "alpha": 0.05},
+    }
+    _write_yaml(tmp_path / "base.tvl.yml", base)
+
+    _overlay(
+        tmp_path / "equiv.overlay.yml",
+        {
+            "objectives": [
+                {
+                    "name": "quality",
+                    "band": {
+                        "target": {"center": 0.3, "tol": 0.2},
+                        "test": "TOST",
+                        "alpha": 0.05,
+                    },
+                },
+                {"name": "toxic_rate", "direction": "minimize"},
+            ]
+        },
+    )
+
+    assert compose(tmp_path / "equiv.overlay.yml")
+
+    # The tolerance must not swallow a real widening.
+    _overlay(
+        tmp_path / "wider.overlay.yml",
+        {
+            "objectives": [
+                {
+                    "name": "quality",
+                    "band": {
+                        "target": {"center": 0.3, "tol": 0.25},
+                        "test": "TOST",
+                        "alpha": 0.05,
+                    },
+                },
+                {"name": "toxic_rate", "direction": "minimize"},
+            ]
+        },
+    )
+    with pytest.raises(ValueError, match="cannot widen band"):
+        compose(tmp_path / "wider.overlay.yml")

--- a/tests/test_tvl_compose.py
+++ b/tests/test_tvl_compose.py
@@ -556,3 +556,135 @@ def test_bound_comparison_requires_the_same_symbol(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="eval_samples >= 3000.*was dropped"):
         compose(tmp_path / "other.overlay.yml")
+
+
+# ---------------------------------------------------------------------------
+# Bypasses found by adversarial review of the first cut (see PR #72 discussion).
+# Each of these composed cleanly before the follow-up fix.
+# ---------------------------------------------------------------------------
+
+
+def test_a_pass_through_overlay_cannot_launder_a_weakening(tmp_path: Path) -> None:
+    """The whole chain is validated, not just its last edge.
+
+    Resolving intermediate overlays with validation disabled meant `final -> weaken -> base`
+    checked `final` against the ALREADY-WEAKENED `weaken`, which trivially passes. One extra
+    empty file defeated every other rule in this module.
+    """
+    _safety_base(tmp_path / "base.tvl.yml")
+    _overlay(
+        tmp_path / "weaken.overlay.yml",
+        {
+            "constraints": {"structural": []},
+            "promotion_policy": {
+                "chance_constraints": [
+                    {"name": "toxic_rate_slo", "threshold": 0.50, "confidence": 0.50}
+                ]
+            },
+        },
+    )
+    _write_yaml(
+        tmp_path / "final.overlay.yml",
+        {"_tvl_overlay": {"extends": "weaken.overlay.yml"}, "overrides": {}},
+    )
+
+    # The direct overlay is rejected...
+    with pytest.raises(ValueError):
+        compose(tmp_path / "weaken.overlay.yml")
+    # ...and so is the pass-through wrapping it.
+    with pytest.raises(ValueError, match="cannot raise threshold"):
+        compose(tmp_path / "final.overlay.yml")
+
+
+def test_a_valid_chain_still_composes(tmp_path: Path) -> None:
+    """Chain validation must not break legitimate multi-level overlays."""
+    _safety_base(tmp_path / "base.tvl.yml")
+    _overlay(
+        tmp_path / "mid.overlay.yml",
+        {
+            "promotion_policy": {
+                "chance_constraints": [
+                    {"name": "toxic_rate_slo", "threshold": 0.005, "confidence": 0.95}
+                ]
+            }
+        },
+    )
+    _write_yaml(
+        tmp_path / "leaf.overlay.yml",
+        {
+            "_tvl_overlay": {"extends": "mid.overlay.yml"},
+            "overrides": {
+                "promotion_policy": {
+                    "chance_constraints": [
+                        {"name": "toxic_rate_slo", "threshold": 0.001, "confidence": 0.99}
+                    ]
+                }
+            },
+        },
+    )
+
+    composed = compose(tmp_path / "leaf.overlay.yml")
+    assert composed["promotion_policy"]["chance_constraints"][0]["threshold"] == 0.001
+
+
+def test_ge_does_not_tighten_gt_at_the_same_value(tmp_path: Path) -> None:
+    """`x >= 3000` admits 3000; `x > 3000` does not. Same number, strictly wider."""
+    _safety_base(tmp_path / "base.tvl.yml")
+    base = yaml.safe_load((tmp_path / "base.tvl.yml").read_text())
+    base["constraints"]["derived"] = [{"require": "env.context.eval_samples > 3000"}]
+    _write_yaml(tmp_path / "base.tvl.yml", base)
+
+    _overlay(
+        tmp_path / "loosen.overlay.yml",
+        {"constraints": {"derived": [{"require": "env.context.eval_samples >= 3000"}]}},
+    )
+    with pytest.raises(ValueError, match="was dropped by the overlay"):
+        compose(tmp_path / "loosen.overlay.yml")
+
+    # The reverse direction IS a tightening and must still be accepted.
+    _overlay(
+        tmp_path / "tighten.overlay.yml",
+        {"constraints": {"derived": [{"require": "env.context.eval_samples > 3000"}]}},
+    )
+    assert compose(tmp_path / "tighten.overlay.yml")
+
+
+def test_clause_identity_preserves_whitespace_inside_quoted_literals(tmp_path: Path) -> None:
+    """A decoy differing only inside a string literal must not satisfy retention."""
+    _safety_base(tmp_path / "base.tvl.yml")
+    base = yaml.safe_load((tmp_path / "base.tvl.yml").read_text())
+    base["constraints"]["structural"] = [{"expr": 'profile = "hipaa  strict"'}]
+    _write_yaml(tmp_path / "base.tvl.yml", base)
+
+    _overlay(
+        tmp_path / "decoy.overlay.yml",
+        {"constraints": {"structural": [{"expr": 'profile = "hipaa strict"'}]}},
+    )
+
+    with pytest.raises(ValueError, match="was dropped by the overlay"):
+        compose(tmp_path / "decoy.overlay.yml")
+
+
+def test_compose_rejects_widening_an_objective_band(tmp_path: Path) -> None:
+    """A band is a gate input, so widening it loosens the gate."""
+    _safety_base(tmp_path / "base.tvl.yml")
+    base = yaml.safe_load((tmp_path / "base.tvl.yml").read_text())
+    base["objectives"][0]["band"] = {"target": [95, 105], "test": "TOST", "alpha": 0.05}
+    _write_yaml(tmp_path / "base.tvl.yml", base)
+
+    _overlay(
+        tmp_path / "widen.overlay.yml",
+        {
+            "objectives": [
+                {
+                    "name": "quality",
+                    "direction": "maximize",
+                    "band": {"target": [0, 1000000], "test": "TOST", "alpha": 0.05},
+                },
+                {"name": "toxic_rate", "direction": "minimize"},
+            ]
+        },
+    )
+
+    with pytest.raises(ValueError, match="cannot widen band"):
+        compose(tmp_path / "widen.overlay.yml")

--- a/tests/test_tvl_compose.py
+++ b/tests/test_tvl_compose.py
@@ -688,3 +688,127 @@ def test_compose_rejects_widening_an_objective_band(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="cannot widen band"):
         compose(tmp_path / "widen.overlay.yml")
+
+
+# --- second adversarial pass: band forms and objective kind -----------------
+
+
+def test_compose_rejects_widening_a_center_tol_band(tmp_path: Path) -> None:
+    """The schema allows `target: {center, tol}` as well as `[low, high]`.
+
+    Comparing only the list form let the dict form widen untouched: tol 5 -> 500 is a
+    100x wider equivalence region on the same objective.
+    """
+    _safety_base(tmp_path / "base.tvl.yml")
+    base = yaml.safe_load((tmp_path / "base.tvl.yml").read_text())
+    base["objectives"][0] = {
+        "name": "quality",
+        "band": {"target": {"center": 100, "tol": 5}, "test": "TOST", "alpha": 0.05},
+    }
+    _write_yaml(tmp_path / "base.tvl.yml", base)
+
+    _overlay(
+        tmp_path / "widen.overlay.yml",
+        {
+            "objectives": [
+                {
+                    "name": "quality",
+                    "band": {
+                        "target": {"center": 100, "tol": 500},
+                        "test": "TOST",
+                        "alpha": 0.05,
+                    },
+                },
+                {"name": "toxic_rate", "direction": "minimize"},
+            ]
+        },
+    )
+
+    with pytest.raises(ValueError, match="cannot widen band"):
+        compose(tmp_path / "widen.overlay.yml")
+
+
+def test_compose_rejects_raising_band_alpha(tmp_path: Path) -> None:
+    """A larger alpha makes the equivalence test easier to pass."""
+    _safety_base(tmp_path / "base.tvl.yml")
+    base = yaml.safe_load((tmp_path / "base.tvl.yml").read_text())
+    base["objectives"][0] = {
+        "name": "quality",
+        "band": {"target": [95, 105], "test": "TOST", "alpha": 0.05},
+    }
+    _write_yaml(tmp_path / "base.tvl.yml", base)
+
+    _overlay(
+        tmp_path / "alpha.overlay.yml",
+        {
+            "objectives": [
+                {
+                    "name": "quality",
+                    "band": {"target": [95, 105], "test": "TOST", "alpha": 0.99},
+                },
+                {"name": "toxic_rate", "direction": "minimize"},
+            ]
+        },
+    )
+
+    with pytest.raises(ValueError, match="cannot raise band alpha"):
+        compose(tmp_path / "alpha.overlay.yml")
+
+
+def test_compose_rejects_converting_a_directional_objective_to_banded(tmp_path: Path) -> None:
+    """Same name, different gate.
+
+    Name-retention passes and the direction check never fires (the replacement has no
+    `direction`), so the non-inferiority test was silently deleted.
+    """
+    _safety_base(tmp_path / "base.tvl.yml")
+    _overlay(
+        tmp_path / "convert.overlay.yml",
+        {
+            "objectives": [
+                {"name": "quality", "direction": "maximize"},
+                {
+                    "name": "toxic_rate",
+                    "band": {"target": [0, 1], "test": "TOST", "alpha": 0.99},
+                },
+            ]
+        },
+    )
+
+    with pytest.raises(ValueError, match="cannot convert a directional objective"):
+        compose(tmp_path / "convert.overlay.yml")
+
+
+def test_compose_fails_closed_on_an_uncomparable_band(tmp_path: Path) -> None:
+    """If the band cannot be normalised, it cannot be shown not to widen - so reject."""
+    _safety_base(tmp_path / "base.tvl.yml")
+    base = yaml.safe_load((tmp_path / "base.tvl.yml").read_text())
+    base["objectives"][0] = {
+        "name": "quality",
+        "band": {"target": [95, 105], "test": "TOST", "alpha": 0.05},
+    }
+    _write_yaml(tmp_path / "base.tvl.yml", base)
+
+    _overlay(
+        tmp_path / "junk.overlay.yml",
+        {
+            "objectives": [
+                {"name": "quality", "band": {"test": "TOST", "alpha": 0.05}},
+                {"name": "toxic_rate", "direction": "minimize"},
+            ]
+        },
+    )
+
+    with pytest.raises(ValueError, match="not comparable"):
+        compose(tmp_path / "junk.overlay.yml")
+
+
+def test_clause_key_handles_escaped_quotes(tmp_path: Path) -> None:
+    """An escaped quote must not terminate the literal early."""
+    from tvl_tools.tvl_compose.cli import _clause_key
+
+    a = _clause_key({"expr": 'note = "say \\" now"'})
+    b = _clause_key({"expr": 'note   =   "say \\" now"'})
+    c = _clause_key({"expr": 'note = "say \\"  now"'})
+    assert a == b, "whitespace outside quotes should still normalise"
+    assert a != c, "whitespace inside the literal must remain significant"

--- a/tests/test_tvl_compose.py
+++ b/tests/test_tvl_compose.py
@@ -482,3 +482,77 @@ def test_clause_identity_ignores_whitespace(tmp_path: Path) -> None:
 
     composed = compose(tmp_path / "reformat.overlay.yml")
     assert len(composed["constraints"]["structural"]) == 2
+
+
+def test_derived_clause_replaced_by_a_tighter_bound_is_not_a_drop(tmp_path: Path) -> None:
+    """Hardening a bound must not read as removing the clause.
+
+    Found by dogfooding: a healthcare profile replaced `safety_eval_samples >= 3000`
+    with `>= 5990`, which is precisely what a stricter profile should do. Demanding the
+    looser clause be restated alongside the tighter one would be nonsense.
+    """
+    _safety_base(tmp_path / "base.tvl.yml")
+    base = yaml.safe_load((tmp_path / "base.tvl.yml").read_text())
+    base["constraints"]["derived"] = [{"require": "env.context.eval_samples >= 3000"}]
+    _write_yaml(tmp_path / "base.tvl.yml", base)
+
+    _overlay(
+        tmp_path / "tighter.overlay.yml",
+        {"constraints": {"derived": [{"require": "env.context.eval_samples >= 5990"}]}},
+    )
+
+    composed = compose(tmp_path / "tighter.overlay.yml")
+    assert composed["constraints"]["derived"][0]["require"].endswith("5990")
+
+
+def test_derived_clause_replaced_by_a_looser_bound_is_rejected(tmp_path: Path) -> None:
+    """The mirror image: relaxing a bound is a weakening and must fail."""
+    _safety_base(tmp_path / "base.tvl.yml")
+    base = yaml.safe_load((tmp_path / "base.tvl.yml").read_text())
+    base["constraints"]["derived"] = [{"require": "env.context.eval_samples >= 3000"}]
+    _write_yaml(tmp_path / "base.tvl.yml", base)
+
+    _overlay(
+        tmp_path / "looser.overlay.yml",
+        {"constraints": {"derived": [{"require": "env.context.eval_samples >= 500"}]}},
+    )
+
+    with pytest.raises(ValueError, match="was dropped by the overlay"):
+        compose(tmp_path / "looser.overlay.yml")
+
+
+def test_upper_bound_tightens_downward(tmp_path: Path) -> None:
+    """`<=` tightens as the number FALLS - the opposite direction from `>=`."""
+    _safety_base(tmp_path / "base.tvl.yml")
+    base = yaml.safe_load((tmp_path / "base.tvl.yml").read_text())
+    base["constraints"]["derived"] = [{"require": "env.context.timeout_ms <= 30000"}]
+    _write_yaml(tmp_path / "base.tvl.yml", base)
+
+    _overlay(
+        tmp_path / "tighter.overlay.yml",
+        {"constraints": {"derived": [{"require": "env.context.timeout_ms <= 5000"}]}},
+    )
+    assert compose(tmp_path / "tighter.overlay.yml")
+
+    _overlay(
+        tmp_path / "looser.overlay.yml",
+        {"constraints": {"derived": [{"require": "env.context.timeout_ms <= 60000"}]}},
+    )
+    with pytest.raises(ValueError, match="was dropped by the overlay"):
+        compose(tmp_path / "looser.overlay.yml")
+
+
+def test_bound_comparison_requires_the_same_symbol(tmp_path: Path) -> None:
+    """A tighter bound on a DIFFERENT symbol does not excuse dropping this one."""
+    _safety_base(tmp_path / "base.tvl.yml")
+    base = yaml.safe_load((tmp_path / "base.tvl.yml").read_text())
+    base["constraints"]["derived"] = [{"require": "env.context.eval_samples >= 3000"}]
+    _write_yaml(tmp_path / "base.tvl.yml", base)
+
+    _overlay(
+        tmp_path / "other.overlay.yml",
+        {"constraints": {"derived": [{"require": "env.context.other_symbol >= 999999"}]}},
+    )
+
+    with pytest.raises(ValueError, match="eval_samples >= 3000.*was dropped"):
+        compose(tmp_path / "other.overlay.yml")

--- a/tvl_tools/tvl_compose/cli.py
+++ b/tvl_tools/tvl_compose/cli.py
@@ -8,6 +8,7 @@ Usage:
 import argparse
 import copy
 import json
+import re
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -101,6 +102,45 @@ def _clause_key(clause: Any) -> str:
             return f"{norm(clause.get('when'))} => {norm(clause.get('then'))}"
         return norm(json.dumps(clause, sort_keys=True))
     return norm(clause)
+
+
+_BOUND_RE = re.compile(r"^\s*(?P<lhs>.+?)\s*(?P<op>>=|<=|>|<)\s*(?P<num>-?\d+(?:\.\d+)?)\s*$")
+
+
+def _as_bound(clause: Any) -> Optional[tuple]:
+    """Parse a simple ``<lhs> <op> <number>`` clause into ``(lhs, op, value)``.
+
+    Derived clauses are linear checks over ``env.context.*`` symbols, and the common
+    case is a single bound (``require: env.context.safety_eval_samples >= 3000``). Only
+    this simple shape is recognised; anything richer returns None and falls back to
+    exact-retention, which is the safe default.
+    """
+    text = clause.get("require") if isinstance(clause, dict) else clause
+    if not isinstance(text, str):
+        return None
+    m = _BOUND_RE.match(text)
+    if not m:
+        return None
+    return (" ".join(m.group("lhs").split()), m.group("op"), float(m.group("num")))
+
+
+def _tightens(base_bound: tuple, comp_bound: tuple) -> bool:
+    """Whether comp_bound is at least as strict as base_bound on the same symbol.
+
+    A lower bound (``>=``/``>``) tightens as the number RISES; an upper bound
+    (``<=``/``<``) tightens as it FALLS. Mixed operator families are not comparable.
+    """
+    b_lhs, b_op, b_val = base_bound
+    c_lhs, c_op, c_val = comp_bound
+    if b_lhs != c_lhs:
+        return False
+    lower = {">=", ">"}
+    upper = {"<=", "<"}
+    if b_op in lower and c_op in lower:
+        return c_val >= b_val
+    if b_op in upper and c_op in upper:
+        return c_val <= b_val
+    return False
 
 
 def _validate_safety_narrowing(
@@ -204,17 +244,26 @@ def _validate_safety_narrowing(
     # --- constraint clauses -------------------------------------------------
     for kind in ("structural", "derived"):
         base_clauses = ((base.get("constraints") or {}).get(kind)) or []
-        comp_keys = {
-            _clause_key(c) for c in (((composed.get("constraints") or {}).get(kind)) or [])
-        }
+        comp_clauses = ((composed.get("constraints") or {}).get(kind)) or []
+        comp_keys = {_clause_key(c) for c in comp_clauses}
+        comp_bounds = [b for b in (_as_bound(c) for c in comp_clauses) if b]
+
         for clause in base_clauses:
             key = _clause_key(clause)
             if key in comp_keys or key in waived:
                 continue
+            # A clause REPLACED by a strictly tighter bound on the same symbol has been
+            # hardened, not dropped: `env.context.n >= 3000` -> `>= 5990` is exactly what
+            # a stricter profile should do, and demanding the looser clause be restated
+            # alongside it would be nonsense.
+            base_bound = _as_bound(clause)
+            if base_bound and any(_tightens(base_bound, cb) for cb in comp_bounds):
+                continue
             errors.append(
                 f"constraints.{kind}: clause {key!r} was dropped by the overlay. "
                 "If the narrowed domains make it vacuous, declare it under "
-                "_tvl_overlay.waives with a reason; otherwise restate it."
+                "_tvl_overlay.waives with a reason; otherwise restate it "
+                "(or replace it with a strictly tighter bound on the same symbol)."
             )
 
     unused = sorted(set(waived) - {_clause_key(c) for c in _all_base_clauses(base)})

--- a/tvl_tools/tvl_compose/cli.py
+++ b/tvl_tools/tvl_compose/cli.py
@@ -100,11 +100,15 @@ def _clause_key(clause: Any) -> str:
         silently dropping the real guard.
         """
         s = str(text)
-        out, buf, quote = [], [], None
+        out, buf, quote, escaped = [], [], None, False
         for ch in s:
             if quote:
                 buf.append(ch)
-                if ch == quote:
+                if escaped:
+                    escaped = False
+                elif ch == "\\":
+                    escaped = True
+                elif ch == quote:
                     out.append("".join(buf))
                     buf, quote = [], None
             elif ch in ("'", '"'):
@@ -173,6 +177,28 @@ def _tightens(base_bound: tuple, comp_bound: tuple) -> bool:
             return True
         return c_val == b_val and (b_op == c_op or c_op == "<")
     return False
+
+
+def _band_interval(band: Any) -> Optional[tuple]:
+    """Normalise a band target to ``(low, high)``, or None if not comparable.
+
+    The schema permits both ``target: [low, high]`` and ``target: {center, tol}``, and
+    promotion reads both. Comparing only the list form silently let the dict form widen.
+    """
+    if not isinstance(band, dict):
+        return None
+    target = band.get("target")
+    if (
+        isinstance(target, list)
+        and len(target) == 2
+        and all(isinstance(v, (int, float)) for v in target)
+    ):
+        return (float(target[0]), float(target[1]))
+    if isinstance(target, dict):
+        center, tol = target.get("center"), target.get("tol")
+        if isinstance(center, (int, float)) and isinstance(tol, (int, float)):
+            return (float(center) - float(tol), float(center) + float(tol))
+    return None
 
 
 def _validate_safety_narrowing(
@@ -272,22 +298,54 @@ def _validate_safety_narrowing(
                 f"objective '{name}': cannot change direction from "
                 f"'{bo['direction']}' to '{co['direction']}'"
             )
-        # A banded objective's target interval is a gate input (promotion.py reads it), so
-        # widening the band loosens the gate exactly as raising a threshold would.
-        b_band = (bo.get("band") or {}).get("target")
-        c_band = (co.get("band") or {}).get("target")
-        if (
-            isinstance(b_band, list)
-            and isinstance(c_band, list)
-            and len(b_band) == 2
-            and len(c_band) == 2
-        ):
-            if c_band[0] < b_band[0] or c_band[1] > b_band[1]:
+        # KIND INVARIANCE. A standard directional objective and a banded one are different
+        # gates. Swapping a directional objective for a banded one of the same name keeps
+        # the name-retention check happy while silently deleting the non-inferiority test,
+        # and the direction check never fires because the replacement has no `direction`.
+        b_band, c_band = bo.get("band"), co.get("band")
+        if bo.get("direction") and not b_band:
+            if c_band:
                 errors.append(
-                    f"objective '{name}': cannot widen band from {b_band} to {c_band}"
+                    f"objective '{name}': cannot convert a directional objective into a "
+                    "banded one (that removes the non-inferiority test)"
                 )
-        elif b_band is not None and c_band is None:
-            errors.append(f"objective '{name}': cannot remove its band")
+            elif not co.get("direction"):
+                errors.append(
+                    f"objective '{name}': cannot drop 'direction' from a directional objective"
+                )
+
+        # A band's target interval is a gate input (promotion.py reads it), so widening it
+        # loosens the gate exactly as raising a threshold would. Both the [low, high] and
+        # {center, tol} forms are legal per the schema, so both are normalised before
+        # comparison -- comparing only list/list let the dict form through untouched.
+        if b_band is not None:
+            if c_band is None:
+                errors.append(f"objective '{name}': cannot remove its band")
+            else:
+                b_iv, c_iv = _band_interval(b_band), _band_interval(c_band)
+                if b_iv is None or c_iv is None:
+                    # Fail closed: an uncomparable band cannot be shown not to widen.
+                    errors.append(
+                        f"objective '{name}': band target is missing or not comparable "
+                        f"(base={(b_band or {}).get('target')!r}, "
+                        f"composed={(c_band or {}).get('target')!r}); "
+                        "cannot verify it was not widened"
+                    )
+                elif c_iv[0] < b_iv[0] or c_iv[1] > b_iv[1]:
+                    errors.append(
+                        f"objective '{name}': cannot widen band from "
+                        f"[{b_iv[0]}, {b_iv[1]}] to [{c_iv[0]}, {c_iv[1]}]"
+                    )
+                b_alpha, c_alpha = b_band.get("alpha"), c_band.get("alpha")
+                if (
+                    isinstance(b_alpha, (int, float))
+                    and isinstance(c_alpha, (int, float))
+                    and c_alpha > b_alpha
+                ):
+                    errors.append(
+                        f"objective '{name}': cannot raise band alpha from {b_alpha} to "
+                        f"{c_alpha} (a larger alpha makes the equivalence test easier to pass)"
+                    )
 
     # --- constraint clauses -------------------------------------------------
     for kind in ("structural", "derived"):

--- a/tvl_tools/tvl_compose/cli.py
+++ b/tvl_tools/tvl_compose/cli.py
@@ -93,7 +93,32 @@ def _clause_key(clause: Any) -> str:
     clause; anything else is compared by its sorted repr as a last resort.
     """
     def norm(text: Any) -> str:
-        return " ".join(str(text).split())
+        """Collapse whitespace OUTSIDE quoted literals only.
+
+        Collapsing inside a literal makes `x = "hipaa  strict"` and `x = "hipaa strict"`
+        collide, which would let an overlay satisfy retention with a decoy clause while
+        silently dropping the real guard.
+        """
+        s = str(text)
+        out, buf, quote = [], [], None
+        for ch in s:
+            if quote:
+                buf.append(ch)
+                if ch == quote:
+                    out.append("".join(buf))
+                    buf, quote = [], None
+            elif ch in ("'", '"'):
+                out.append(" ".join("".join(buf).split()) if buf else "")
+                buf, quote = [ch], ch
+            else:
+                buf.append(ch)
+        if quote:  # unterminated quote: fall back to the raw remainder
+            out.append("".join(buf))
+        elif buf:
+            out.append(" ".join("".join(buf).split()))
+        joined = "".join(out)
+        # Normalise the seams left by segment-wise collapsing.
+        return " ".join(joined.split(" ")).strip()
 
     if isinstance(clause, dict):
         if "expr" in clause:
@@ -136,10 +161,17 @@ def _tightens(base_bound: tuple, comp_bound: tuple) -> bool:
         return False
     lower = {">=", ">"}
     upper = {"<=", "<"}
+    # Strictness matters at EQUAL values: `x > 3000` admits fewer values than
+    # `x >= 3000`, so replacing `>` with `>=` at the same number is a WIDENING even
+    # though the number did not move. `>` may replace `>=`, never the reverse.
     if b_op in lower and c_op in lower:
-        return c_val >= b_val
+        if c_val > b_val:
+            return True
+        return c_val == b_val and (b_op == c_op or c_op == ">")
     if b_op in upper and c_op in upper:
-        return c_val <= b_val
+        if c_val < b_val:
+            return True
+        return c_val == b_val and (b_op == c_op or c_op == "<")
     return False
 
 
@@ -240,6 +272,22 @@ def _validate_safety_narrowing(
                 f"objective '{name}': cannot change direction from "
                 f"'{bo['direction']}' to '{co['direction']}'"
             )
+        # A banded objective's target interval is a gate input (promotion.py reads it), so
+        # widening the band loosens the gate exactly as raising a threshold would.
+        b_band = (bo.get("band") or {}).get("target")
+        c_band = (co.get("band") or {}).get("target")
+        if (
+            isinstance(b_band, list)
+            and isinstance(c_band, list)
+            and len(b_band) == 2
+            and len(c_band) == 2
+        ):
+            if c_band[0] < b_band[0] or c_band[1] > b_band[1]:
+                errors.append(
+                    f"objective '{name}': cannot widen band from {b_band} to {c_band}"
+                )
+        elif b_band is not None and c_band is None:
+            errors.append(f"objective '{name}': cannot remove its band")
 
     # --- constraint clauses -------------------------------------------------
     for kind in ("structural", "derived"):
@@ -380,11 +428,17 @@ def _compose(
     if not isinstance(base, dict):
         raise TypeError(f"Base module {base_path} must be a YAML mapping")
 
-    # Recursively resolve if base is also an overlay
+    # Recursively resolve if base is also an overlay.
+    #
+    # EVERY EDGE OF THE CHAIN IS VALIDATED, not just the outermost one. Resolving an
+    # intermediate overlay with validation off lets a chain launder any weakening:
+    # `final -> weaken -> base` would check `final` against the ALREADY-WEAKENED `weaken`,
+    # which trivially passes, so one extra pass-through file defeated every rule below.
+    # Confirmed as a working bypass before this was changed.
     if "_tvl_overlay" in base:
         base = _compose(
             base_path,
-            validate_narrowing=False,
+            validate_narrowing=validate_narrowing,
             overlay_root=overlay_root,
             resolution_chain=resolution_chain + [overlay_path],
         )

--- a/tvl_tools/tvl_compose/cli.py
+++ b/tvl_tools/tvl_compose/cli.py
@@ -84,6 +84,155 @@ def _merge_tvar_lists(base_tvars: List[Dict], override_tvars: List[Dict]) -> Lis
     return result
 
 
+def _clause_key(clause: Any) -> str:
+    """Canonical identity for a structural constraint clause.
+
+    Clauses are either ``{expr: ...}`` or ``{when: ..., then: ...}``. Whitespace is
+    collapsed so a reformatted-but-identical clause is still recognised as the same
+    clause; anything else is compared by its sorted repr as a last resort.
+    """
+    def norm(text: Any) -> str:
+        return " ".join(str(text).split())
+
+    if isinstance(clause, dict):
+        if "expr" in clause:
+            return norm(clause["expr"])
+        if "when" in clause or "then" in clause:
+            return f"{norm(clause.get('when'))} => {norm(clause.get('then'))}"
+        return norm(json.dumps(clause, sort_keys=True))
+    return norm(clause)
+
+
+def _validate_safety_narrowing(
+    base: Dict[str, Any],
+    composed: Dict[str, Any],
+    waives: Optional[List[Any]] = None,
+) -> List[str]:
+    """Validate that an overlay does not weaken the base's safety posture.
+
+    TVAR domains and exploration budgets are covered by ``_validate_narrowing``. This
+    covers the parts that actually express safety, which an overlay could previously
+    delete outright:
+
+    * ``promotion_policy.chance_constraints`` - may be tightened, never loosened, and a
+      named constraint may not disappear. ``threshold`` is an upper bound on a violation
+      rate, so it may only DECREASE; ``confidence`` may only INCREASE.
+    * ``objectives`` - may not be dropped, and ``direction`` may not flip.
+    * ``constraints.structural`` and ``constraints.derived`` - clauses may not be dropped
+      unless explicitly waived (see below).
+
+    Waivers exist because a legitimate narrowing can FORCE the removal of an inherited
+    clause: narrowing ``temperature`` to ``[0.0, 0.3]`` makes an inherited
+    ``when: temperature > 0.7`` guard a hard lint error, so the clause must go. Without a
+    waiver mechanism this checker would reject valid overlays. A waiver does not assert
+    the clause is harmless - it records that a human decided to drop it and why, which is
+    the difference between a declared removal and a silent one. It is deliberately NOT a
+    proof of vacuity; verifying that would require the structural SAT solver, and a
+    waiver that silently passed a non-vacuous clause would be worse than none.
+
+    Args:
+        base: The base module, before overrides were applied.
+        composed: The merged module.
+        waives: ``_tvl_overlay.waives`` entries, each ``{clause: str, reason: str}``.
+
+    Returns:
+        A list of human-readable errors; empty when the overlay only tightens.
+    """
+    errors: List[str] = []
+
+    waived: Dict[str, str] = {}
+    for entry in waives or []:
+        if isinstance(entry, dict):
+            clause, reason = entry.get("clause"), entry.get("reason")
+        else:
+            clause, reason = entry, None
+        if not clause:
+            errors.append("waives entry is missing 'clause'")
+            continue
+        if not reason:
+            errors.append(
+                f"waives entry for {_clause_key(clause)!r} is missing 'reason'. "
+                "A waiver must say why the clause was dropped."
+            )
+            continue
+        waived[_clause_key(clause)] = reason
+
+    # --- chance constraints -------------------------------------------------
+    def by_name(policy: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+        items = (policy or {}).get("chance_constraints") or []
+        return {c.get("name"): c for c in items if isinstance(c, dict) and c.get("name")}
+
+    base_cc = by_name(base.get("promotion_policy") or {})
+    comp_cc = by_name(composed.get("promotion_policy") or {})
+
+    for name, bc in base_cc.items():
+        cc = comp_cc.get(name)
+        if cc is None:
+            errors.append(
+                f"chance_constraint '{name}': removed in overlay (not allowed). "
+                "Overlays may tighten a safety constraint, never drop it."
+            )
+            continue
+        b_thr, c_thr = bc.get("threshold"), cc.get("threshold")
+        if isinstance(b_thr, (int, float)) and isinstance(c_thr, (int, float)) and c_thr > b_thr:
+            errors.append(
+                f"chance_constraint '{name}': cannot raise threshold from {b_thr} to {c_thr} "
+                "(threshold bounds a violation rate; raising it permits more violations)"
+            )
+        b_conf, c_conf = bc.get("confidence"), cc.get("confidence")
+        if isinstance(b_conf, (int, float)) and isinstance(c_conf, (int, float)) and c_conf < b_conf:
+            errors.append(
+                f"chance_constraint '{name}': cannot lower confidence from {b_conf} to {c_conf} "
+                "(lower confidence is a weaker claim)"
+            )
+
+    # --- objectives ---------------------------------------------------------
+    base_obj = {o.get("name"): o for o in (base.get("objectives") or []) if isinstance(o, dict)}
+    comp_obj = {o.get("name"): o for o in (composed.get("objectives") or []) if isinstance(o, dict)}
+
+    for name, bo in base_obj.items():
+        co = comp_obj.get(name)
+        if co is None:
+            errors.append(f"objective '{name}': removed in overlay (not allowed)")
+            continue
+        if bo.get("direction") and co.get("direction") and bo["direction"] != co["direction"]:
+            errors.append(
+                f"objective '{name}': cannot change direction from "
+                f"'{bo['direction']}' to '{co['direction']}'"
+            )
+
+    # --- constraint clauses -------------------------------------------------
+    for kind in ("structural", "derived"):
+        base_clauses = ((base.get("constraints") or {}).get(kind)) or []
+        comp_keys = {
+            _clause_key(c) for c in (((composed.get("constraints") or {}).get(kind)) or [])
+        }
+        for clause in base_clauses:
+            key = _clause_key(clause)
+            if key in comp_keys or key in waived:
+                continue
+            errors.append(
+                f"constraints.{kind}: clause {key!r} was dropped by the overlay. "
+                "If the narrowed domains make it vacuous, declare it under "
+                "_tvl_overlay.waives with a reason; otherwise restate it."
+            )
+
+    unused = sorted(set(waived) - {_clause_key(c) for c in _all_base_clauses(base)})
+    for key in unused:
+        errors.append(
+            f"waives entry {key!r} does not match any clause in the base module "
+            "(stale waiver, or the clause text drifted)"
+        )
+
+    return errors
+
+
+def _all_base_clauses(base: Dict[str, Any]) -> List[Any]:
+    """Every structural and derived clause declared by the base module."""
+    constraints = base.get("constraints") or {}
+    return list(constraints.get("structural") or []) + list(constraints.get("derived") or [])
+
+
 def _validate_narrowing(base: Dict[str, Any], composed: Dict[str, Any]) -> List[str]:
     """Validate that the composed spec only narrows (doesn't widen) the base."""
     errors = []
@@ -203,6 +352,7 @@ def _compose(
     # Validate narrowing if requested
     if validate_narrowing:
         errors = _validate_narrowing(base, composed)
+        errors += _validate_safety_narrowing(base, composed, overlay_meta.get("waives"))
         if errors:
             raise ValueError("Overlay validation failed:\n  " + "\n  ".join(errors))
 

--- a/tvl_tools/tvl_compose/cli.py
+++ b/tvl_tools/tvl_compose/cli.py
@@ -179,6 +179,15 @@ def _tightens(base_bound: tuple, comp_bound: tuple) -> bool:
     return False
 
 
+# Tolerance for comparing band intervals. The two legal target forms are not
+# bit-identical after arithmetic: `{center: 0.3, tol: 0.2}` normalises to a low bound of
+# 0.09999999999999998, which is strictly below an equivalent `[0.1, 0.5]` and would be
+# reported as a widening. That is a false POSITIVE -- it blocks a legitimate overlay rather
+# than admitting a bad one -- so a small absolute tolerance is the right trade here. It is
+# far tighter than any meaningful band width.
+_BAND_EPS = 1e-9
+
+
 def _band_interval(band: Any) -> Optional[tuple]:
     """Normalise a band target to ``(low, high)``, or None if not comparable.
 
@@ -331,7 +340,7 @@ def _validate_safety_narrowing(
                         f"composed={(c_band or {}).get('target')!r}); "
                         "cannot verify it was not widened"
                     )
-                elif c_iv[0] < b_iv[0] or c_iv[1] > b_iv[1]:
+                elif c_iv[0] < b_iv[0] - _BAND_EPS or c_iv[1] > b_iv[1] + _BAND_EPS:
                     errors.append(
                         f"objective '{name}': cannot widen band from "
                         f"[{b_iv[0]}, {b_iv[1]}] to [{c_iv[0]}, {c_iv[1]}]"


### PR DESCRIPTION
Closes #70.

## What

`tvl-compose` enforces a narrowing check so an overlay cannot widen what it inherits — which
is what makes the "base spec plus per-environment overlays" pattern trustworthy. That check
covered **TVAR domains and `exploration.budgets` only**. It never inspected
`promotion_policy`, `chance_constraints`, `objectives`, or `constraints.structural`.

So an overlay could delete every structural guardrail and gut every safety threshold, and
compose accepted it with exit 0. The result was still schema-valid, so `tvl-validate` did not
catch it either.

## The rules now enforced

| Element | Rule |
|---|---|
| `chance_constraints` | a named constraint may not be dropped; `threshold` may only **decrease**; `confidence` may only **increase** |
| `objectives` | may not be dropped; `direction` may not flip |
| `constraints.structural` / `derived` | clauses may not be dropped unless waived |

`threshold` bounds a violation rate, so raising it permits more violations, while lowering
`confidence` is a weaker claim — both are widenings even though the numbers move in opposite
directions.

**`min_effect` is deliberately not checked.** Whether raising it tightens depends on the
objective's direction and which side of the comparison it lands on. A checker that guesses
wrong there would block valid overlays, and a wrong rule is worse than a missing one.

## The waiver, which is the part that needed design rather than code

A "clauses may never be dropped" rule would reject **valid** overlays. Narrowing `temperature`
to `[0.0, 0.3]` makes an inherited `when: temperature > 0.7` guard vacuous, and keeping it is
then a hard `constraint_value_out_of_domain` lint error on the composed module. The clause
*has* to go.

So removal must be expressible without also permitting silent weakening:

```yaml
_tvl_overlay:
  extends: base.tvl.yml
  waives:
    - clause: "temperature > 0.7 => pii_redaction = true"
      reason: "vacuous: temperature narrowed to [0.0, 0.3]"
```

- `reason` is **mandatory** — the waiver's entire purpose is to make a removal declared.
- A waiver matching no base clause is an **error**, not a no-op. A stale waiver usually means
  the clause text drifted, which would otherwise silently re-open the hole it was covering.
- Clause identity normalises whitespace, so reformatting a restated clause does not read as
  dropping it.

**A waiver does not prove vacuity, on purpose.** Verifying that needs the structural SAT
solver, and a waiver that quietly accepted a non-vacuous clause would be worse than having no
mechanism at all. Its value is that a *declared* removal is distinguishable from a silent one
in review — which is exactly what a reviewer could not do before.

I'd flag this as the main thing worth a second opinion: the alternative designs are
(a) auto-detect vacuity via SAT and allow those removals implicitly, or (b) require the clause
be restated in a weakened-but-satisfiable form. (a) is the "right" answer eventually but is a
much larger change and fails open if the solver times out; (b) produces clauses that exist
only to satisfy the checker. I went with the smallest mechanism that makes the removal
auditable.

## Tests

10 new cases: each rejection path, the **tightening** path (the fix must not block legitimate
hardening — threshold down + confidence up must still compose), the waiver happy path,
missing-`reason`, stale waiver, and whitespace-insensitive clause identity.

Verified the tests are real: **8 of the 10 fail against `origin/main`'s `cli.py`** (the other
two exercise paths that trivially pass when nothing is checked). Full suite: **479 passed**.

## Docs

Documents the overlay contract and the waiver in `docs/reference/language.md`, and fixes a
stale invocation in `language.md` and `walkthroughs.md`: they showed
`tvl-compose base.tvl.yml staging.overlay.yml`, but the CLI takes a **single** overlay naming
its base via `_tvl_overlay.extends`. That would mislead the first person to author a profile.

## Note on scope

No linter runs in this repo's CI, so the changed files are left in the surrounding style
rather than reformatted by an ad-hoc local ruff — a formatting sweep here would be unrelated
churn.

Spine-Trail: st_0fac85e27a1e

🤖 Generated with [Claude Code](https://claude.com/claude-code)
