### PR TITLE
fix(constraints): close three fail-open gaps, on top of the #51 hardening

### DIFF
--- a/python/tvl/constraints.py
+++ b/python/tvl/constraints.py
@@ -22,11 +22,18 @@ _AND_SPLIT = re.compile(r"\s+and\s+", re.IGNORECASE)
 # this pattern so config-validate agrees with structural_parser and the grammar.
 _IDENT_PATTERN = r"[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*"
 _IDENT_RE = re.compile(rf"^{_IDENT_PATTERN}$")
-_LITERAL_RE = re.compile(rf"^\s*({_IDENT_PATTERN})\s*(<=|>=|!=|=|<|>)\s*(.+?)\s*$")
+# Operator alternation lists '==' before '=' so 'a == 1' matches the two-char
+# equality operator instead of the parser matching a bare '=' and leaving a
+# residual '= 1' in the value (issue #37). Group 1 stays _IDENT_PATTERN — the
+# #51 hardening — this only widens the *operator* set, never the identifier
+# set; a hyphenated/illegal identifier is rejected before the operator is
+# even considered (see test_hardened_identifier_regex_* in
+# tests/test_constraints_fail_open_regression.py).
+_LITERAL_RE = re.compile(rf"^\s*({_IDENT_PATTERN})\s*(<=|>=|!=|==|=|<|>)\s*(.+?)\s*$")
 # Permissive lexer retained only to produce a precise "illegal identifier"
 # diagnostic when the strict pattern rejects an atom that the old regex accepted.
-_PERMISSIVE_LITERAL_RE = re.compile(r"^\s*([A-Za-z0-9_.\-]+)\s*(<=|>=|!=|=|<|>)\s*(.+?)\s*$")
-_COMPARISON_OP_RE = re.compile(r"(<=|>=|!=|=|<|>)")
+_PERMISSIVE_LITERAL_RE = re.compile(r"^\s*([A-Za-z0-9_.\-]+)\s*(<=|>=|!=|==|=|<|>)\s*(.+?)\s*$")
+_COMPARISON_OP_RE = re.compile(r"(<=|>=|!=|==|=|<|>)")
 
 _TRUE_COUNTER = 0
 
@@ -376,18 +383,24 @@ def evaluate_assignment(compiled: CompiledConstraints, assignments: Dict[str, An
         antecedent = constraint.antecedent or [[]]
         consequent = constraint.consequent or [[]]
 
-        satisfied = False
-        for cond in antecedent:
-            cond_true = all(atom_true(atom) for atom in cond)
-            if not cond_true:
-                satisfied = True
-                break
-
+        # The antecedent is a DNF (OR of conjunctions); it holds iff ANY
+        # disjunct holds. It is vacuously true only when EVERY disjunct is
+        # false. Short-circuiting on the first false disjunct (the previous
+        # behaviour) declared the whole constraint satisfied as soon as one
+        # disjunct was false — a fail-open that mirrored neither the intended
+        # semantics nor the SAT encoder, which encodes (d1 ∨ d2) → C as
+        # (d1 → C) ∧ (d2 → C) (issue #38).
+        antecedent_true = any(
+            all(atom_true(atom) for atom in cond) for cond in antecedent
+        )
+        if not antecedent_true:
+            # antecedent false → constraint vacuously satisfied
+            satisfied = True
+        else:
             # antecedent holds → consequent must hold
-            conseq_ok = any(all(atom_true(atom) for atom in conj) for conj in consequent)
-            if conseq_ok:
-                satisfied = True
-                break
+            satisfied = any(
+                all(atom_true(atom) for atom in conj) for conj in consequent
+            )
 
         if not satisfied:
             constraint_issues.append({"code": "constraint_failed", "constraint_index": idx, "raw": constraint.raw})
@@ -516,9 +529,16 @@ def _atom_literal(
             _reify_index_membership(model, var, allowed, len(values), lit)
             return lit
 
-        # Unsupported comparison on symbolic enum; fall back to conservative true.
-        model.Add(lit == 1)
-        return lit
+        # Ordering comparison (<, <=, >, >=) on a symbolic (non-numeric) enum
+        # has no defined order, so it cannot be encoded soundly. Forcing the
+        # literal true (the previous behaviour) made the atom a tautology and
+        # the whole clause fail open, letting violating configs pass. Reject it
+        # instead — matching the fail-closed `raise` for unsupported operators
+        # on ordered domains below (issue #40).
+        raise ValueError(
+            f"Unsupported ordering operator {atom.op!r} on symbolic enum "
+            f"'{atom.path}' (enum values are not ordered)"
+        )
 
     encoded = domain.encode(atom.value)
     lit = model.NewBoolVar(f"lit_{atom.path.replace('.', '_')}_{atom.op}_{atom.value}")

--- a/tests/test_constraints_fail_open_regression.py
+++ b/tests/test_constraints_fail_open_regression.py
@@ -1,0 +1,167 @@
+"""Regression tests for fail-open defects in the assignment-constraint path.
+
+Re-cut of PR #42 (IsraelTraigent, ``cl/b4-tvl-bugs-37``) on top of the #51
+identifier-hardening fix (PR #53 / commit 805f557), which landed on ``main``
+after #42 was opened and tightened the same ``_LITERAL_RE`` line #42 touches.
+#42's diff re-loosened the identifier group back to the pre-#51 permissive
+pattern as a side effect of adding ``==`` support; this file (and the
+matching fix in ``constraints.py``) reproduces #42's three fixes against the
+*hardened* regex (``_IDENT_RE`` / ``_LITERAL_RE`` with ``_IDENT_PATTERN``)
+instead, and adds an explicit test proving the #51 hardening survives.
+
+Covers three divergences between the shipped ``tvl-config-validate`` path
+(``compile_constraints`` / ``evaluate_assignment`` / ``_atom_literal``) and the
+intended constraint semantics:
+
+- #37 — the ``==`` equality operator was truncated to ``=`` by the regex literal
+  parser, swallowing the sign into the value string so ``==`` constraints were
+  never enforced (fail-open).
+- #38 — a disjunctive antecedent (``when: "a = 1 or b = 1"``) short-circuited to
+  satisfied on the first false disjunct, so OR-antecedent constraints were never
+  enforced (fail-open).
+- #40 — an ordering comparison on a symbolic (non-numeric) enum was encoded as
+  unconditionally satisfied in the CP-SAT encoder (fail-open); it must be
+  rejected instead.
+
+Plus a guard test (``test_hardened_identifier_regex_still_rejects_hyphen_...``)
+proving the #51 identifier hardening is not undone by the ``==`` fix: an
+identifier the *old* permissive regex would have accepted (a mid-token hyphen)
+must still be rejected, with or without ``==``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tvl.constraints import (
+    ConstraintParseError,
+    compile_constraints,
+    evaluate_assignment,
+    parse_expression,
+)
+
+
+# --- #37: `==` equality operator ------------------------------------------
+
+
+def test_double_equals_parses_as_equality_with_typed_value():
+    disjuncts = parse_expression("a == 1")
+    assert len(disjuncts) == 1
+    (atom,) = disjuncts[0]
+    assert atom.path == "a"
+    assert atom.op == "=="
+    # The value must be the typed int 1 — not the swallowed string "= 1".
+    assert atom.value == 1
+    assert isinstance(atom.value, int)
+
+
+def test_double_equals_constraint_reports_violation():
+    module = {
+        "tvars": [
+            {"name": "a", "type": "enum", "domain": {"set": [0, 1]}},
+            {"name": "c", "type": "enum", "domain": {"set": [0, 1]}},
+        ],
+        "constraints": {"structural": [{"when": "a == 1", "then": "c == 1"}]},
+    }
+    compiled = compile_constraints(module)
+    result = evaluate_assignment(compiled, {"a": 1, "c": 0})
+    # a==1 holds, c==1 fails → the constraint must be reported violated.
+    assert any(i["code"] == "constraint_failed" for i in result["constraints"])
+
+    ok = evaluate_assignment(compiled, {"a": 1, "c": 1})
+    assert ok["constraints"] == []
+
+
+# --- #38: disjunctive antecedent ------------------------------------------
+
+
+@pytest.mark.parametrize("a,b", [(0, 1), (1, 0)])
+def test_or_antecedent_violation_is_reported(a, b):
+    module = {
+        "tvars": [
+            {"name": "a", "type": "enum", "domain": {"set": [0, 1]}},
+            {"name": "b", "type": "enum", "domain": {"set": [0, 1]}},
+            {"name": "c", "type": "enum", "domain": {"set": [0, 1]}},
+        ],
+        "constraints": {
+            "structural": [{"when": "a = 1 or b = 1", "then": "c = 1"}]
+        },
+    }
+    compiled = compile_constraints(module)
+    # (a or b) holds but c != 1 → antecedent true, consequent false → violation.
+    result = evaluate_assignment(compiled, {"a": a, "b": b, "c": 0})
+    assert any(i["code"] == "constraint_failed" for i in result["constraints"])
+
+
+def test_or_antecedent_vacuously_true_when_all_disjuncts_false():
+    module = {
+        "tvars": [
+            {"name": "a", "type": "enum", "domain": {"set": [0, 1]}},
+            {"name": "b", "type": "enum", "domain": {"set": [0, 1]}},
+            {"name": "c", "type": "enum", "domain": {"set": [0, 1]}},
+        ],
+        "constraints": {
+            "structural": [{"when": "a = 1 or b = 1", "then": "c = 1"}]
+        },
+    }
+    compiled = compile_constraints(module)
+    # Neither disjunct holds → antecedent false → vacuously satisfied.
+    result = evaluate_assignment(compiled, {"a": 0, "b": 0, "c": 0})
+    assert result["constraints"] == []
+
+
+# --- #40: ordering comparison on a symbolic enum --------------------------
+
+
+def test_symbolic_enum_ordering_is_rejected_not_fail_open():
+    pytest.importorskip("ortools")
+    from tvl.constraints import check_structural_satisfiable
+
+    module = {
+        "tvars": [
+            {
+                "name": "model",
+                "type": "enum",
+                "domain": {"set": ["gpt-3.5", "gpt-4", "claude"]},
+            }
+        ],
+        "constraints": {"structural": [{"expr": 'model < "gpt-4"'}]},
+    }
+    compiled = compile_constraints(module)
+    with pytest.raises(ValueError, match="symbolic enum"):
+        check_structural_satisfiable(compiled)
+
+
+# --- #51 hardening must survive the #37 fix --------------------------------
+
+
+def test_hardened_identifier_regex_still_rejects_hyphen_with_double_equals():
+    """Guard: the #51 identifier hardening (mid-ident hyphen forbidden) must
+    still apply to literals using the new ``==`` operator. The *old*
+    permissive regex (``[A-Za-z0-9_.-]+``) would have accepted ``foo-bar`` as
+    an identifier; the hardened ``_IDENT_PATTERN`` must not, regardless of
+    which equality spelling triggers the parse."""
+    with pytest.raises(ConstraintParseError) as exc:
+        parse_expression("foo-bar == 5")
+    assert exc.value.code == "illegal_ident"
+
+    # Same illegal identifier is rejected with the pre-existing single '='
+    # spelling too, proving #37's fix didn't change identifier handling.
+    with pytest.raises(ConstraintParseError) as exc_single:
+        parse_expression("foo-bar = 5")
+    assert exc_single.value.code == "illegal_ident"
+
+
+@pytest.mark.parametrize("expr", [".foo == 5", "2x == 5", "-foo == 5", "foo-bar == 5"])
+def test_hardened_identifier_regex_rejects_all_51_shapes_with_double_equals(expr):
+    """The full #51 parametrized illegal-identifier matrix (leading digit/'.'/'-',
+    mid-ident hyphen), replayed with the ``==`` operator #37 adds."""
+    with pytest.raises(ConstraintParseError) as exc:
+        parse_expression(expr)
+    assert exc.value.code == "illegal_ident"
+
+
+def test_legal_dotted_identifier_still_parses_with_double_equals():
+    dnf = parse_expression("a.b.c == 1")
+    assert dnf[0][0].path == "a.b.c"
+    assert dnf[0][0].op == "=="


### PR DESCRIPTION
**Re-cut of #42 by @IsraelTraigent — full credit for finding and diagnosing all three gaps.**

#42 has been conflicting for 22 days. Its conflict is not incidental: it was cut *before* the #51 identifier hardening landed, so rebasing it would have **re-opened a fail-open security fix** in order to add a feature. This re-implements the same three fixes on top of the hardened base instead.

## The three gaps — all still open on `main` today

**1. `==` truncated to `=` (#37).** `_LITERAL_RE`'s operator alternation had no `==`, so `a == 1` matched a bare `=` and left a residual `= 1`. At the `compile_constraints` / `evaluate_assignment` API the constraint is **silently dropped — no violation reported**.

**2. OR-antecedent short-circuit (#38).** `evaluate_assignment` declared a constraint satisfied on the *first false* disjunct instead of requiring *any* disjunct true. So `when: "a = 1 or b = 1"` constraints were **never checked**.

**3. Symbolic-enum ordering fail-open (#40).** `_atom_literal` encoded an ordering comparison on a non-numeric enum as `model.Add(lit == 1)` — an unconditional tautology, making the whole clause pass regardless of assignment.

## No security trade-off was required

The #51 hardening lives in **group 1** of the regex (`_IDENT_PATTERN`); `==` belongs to the **operator alternation**. They are orthogonal:

```diff
-_LITERAL_RE = re.compile(rf"^\s*({_IDENT_PATTERN})\s*(<=|>=|!=|=|<|>)\s*(.+?)\s*$")
+_LITERAL_RE = re.compile(rf"^\s*({_IDENT_PATTERN})\s*(<=|>=|!=|==|=|<|>)\s*(.+?)\s*$")
```

Group 1 is untouched. #42's diff had reverted it to the old permissive `[A-Za-z0-9_.-]+`; this does not.

`_PERMISSIVE_LITERAL_RE` also gains `==`, but it **cannot accept anything** — its only use is to `raise ConstraintParseError(code="illegal_ident")` with a better message. Verified at `constraints.py:231`.

Gaps 2 and 3 are carried over verbatim from #42 — both live in code paths #51 never touched.

## Verification

**Against unmodified `origin/main` (clean detached worktree) — 6 of the new tests FAIL**, proving all three gaps are real and still open:

```
test_double_equals_parses_as_equality_with_typed_value          FAILED
test_double_equals_constraint_reports_violation                 FAILED
test_or_antecedent_violation_is_reported[0-1]                   FAILED
test_or_antecedent_violation_is_reported[1-0]                   FAILED
test_symbolic_enum_ordering_is_rejected_not_fail_open           FAILED
test_legal_dotted_identifier_still_parses_with_double_equals    FAILED
```

The failure shape is the point — a silent fail-open, not an exception:

```
    result = evaluate_assignment(compiled, {"a": 1, "c": 0})
>   assert any(i["code"] == "constraint_failed" for i in result["constraints"])
E   assert False
```

**With the fix — 12 passed**, including five that assert the #51 hardening is still intact: `.foo == 5`, `2x == 5`, `-foo == 5`, `foo-bar == 5` all still raise `illegal_ident`.

**Full suite: 517 passed** (505 baseline + 12 new, zero regressions).

Also spot-checked the CLI path: a violating `a==1,c==1` config now returns `constraint_failed` — it previously misreported as `unsupported_interval`.

## Out of scope, as in #42

#41 (consolidating the two divergent parsers onto `structural_parser`) stays deferred, for the same reason: no bridging exists between `Atom`'s flat comparison model and `structural_parser`'s membership/interval/NNF model.

Closing #42 in favour of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)