### PR TITLE
fix: address six critical tvl bugs and gaps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,3 +67,6 @@ packages = [
   "tvl_tools.microsim_bridge",
 ]
 package-dir = { tvl = "python/tvl", tvl_book_plugins = "python/tvl_book_plugins", tvl_tools = "tvl_tools" }
+
+[tool.setuptools.package-data]
+tvl = ["spec/grammar/*.json", "py.typed"]

--- a/python/tvl/model.py
+++ b/python/tvl/model.py
@@ -116,13 +116,13 @@ def extract_domains(tvars: Dict[str, Any]) -> Dict[str, Domain]:
         return domains
 
     if isinstance(tvars, list):
-        for decl in tvars:
+        for idx, decl in enumerate(tvars):
             if not isinstance(decl, dict):
-                continue
+                raise ValueError(f"tvars[{idx}]: expected dict, got {type(decl).__name__}")
             name = decl.get("name")
             dtype = (decl.get("type") or "").lower()
             if not isinstance(name, str):
-                continue
+                raise ValueError(f"tvars[{idx}]: missing or non-string 'name' field (got {type(name).__name__ if name is not None else 'None'})")
             domain_spec = decl.get("domain")
             domains[name] = _domain_from_decl(name, dtype, domain_spec)
         return domains

--- a/tvl_tools/tvl_check_structural/cli.py
+++ b/tvl_tools/tvl_check_structural/cli.py
@@ -5,6 +5,7 @@ import json
 import hashlib
 import math
 import re
+import sys
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -13,6 +14,7 @@ from typing import Any, Dict, List, Optional
 
 import yaml
 
+from tvl.errors import TVLError
 from tvl.loader import load
 from tvl.structural_sat import check_structural
 
@@ -198,7 +200,31 @@ def main() -> None:
             temp_file = _write_temp_file(patched_text, suffix=args.file.suffix)
             module_path = temp_file
 
-    module = _load_module(module_path)
+    try:
+        module = _load_module(module_path)
+    except (TVLError, yaml.YAMLError, FileNotFoundError, ValueError) as exc:
+        error_msg = str(exc)
+        if args.json:
+            error_payload = {
+                "schemaVersion": "1.0",
+                "kind": "PhaseResult",
+                "phase": "structural",
+                "ok": False,
+                "status": "error",
+                "error": error_msg,
+                "timestamp": _current_timestamp(),
+                "durationMs": 0,
+            }
+            print(json.dumps(error_payload, indent=2))
+        else:
+            print(f"Error loading module: {error_msg}", file=sys.stderr)
+        if temp_file is not None:
+            try:
+                temp_file.unlink(missing_ok=True)
+            except OSError:
+                pass
+        raise SystemExit(2)
+
     start_time = time.perf_counter()
     result = check_structural(module)
     duration_ms = int((time.perf_counter() - start_time) * 1000)

--- a/tvl_tools/tvl_ci_gate/cli.py
+++ b/tvl_tools/tvl_ci_gate/cli.py
@@ -119,7 +119,7 @@ def main() -> None:
         )
 
         result = {
-            "ok": True,
+            "ok": decision == "Promote",
             "decision": decision,
             "warnings": warnings,
             "evidence": evidence,
@@ -136,6 +136,11 @@ def main() -> None:
                     print(f"- [{warning.get('code', 'warning')}] {warning.get('message', '')}")
             print("== Evidence Summary ==")
             print(json.dumps(evidence.get("summary", {}), indent=2))
+
+        if decision == "Promote":
+            raise SystemExit(0)
+        else:
+            raise SystemExit(2)
 
     except SystemExit:
         raise

--- a/tvl_tools/tvl_measure_validate/cli.py
+++ b/tvl_tools/tvl_measure_validate/cli.py
@@ -69,7 +69,11 @@ def main() -> None:
             "config": str(args.config),
             "measurement": str(args.measurement),
         }
-        print(json.dumps(diag if args.json else diag, indent=2))
+        if args.json:
+            print(json.dumps(diag, indent=2))
+        else:
+            print("Validation failed.")
+            print(f"Error: {exc}")
         raise SystemExit(2)
 
 


### PR DESCRIPTION
## Summary

This PR fixes six concrete, validated issues affecting the tvl package (HIGH, MEDIUM, and LOW severity):

- **#17 (HIGH)**: JSON Schema files missing from pip-installed wheel, causing `tvl.loader.load()` to fail with FileNotFoundError
- **#18 (LOW)**: `tvl-measure-validate` error path ignores `--json` flag due to dead ternary
- **#19 (LOW)**: Missing `py.typed` marker prevents downstream type-checking (PEP 561)
- **#20 (MEDIUM)**: `tvl-check-structural` dumps raw Python tracebacks on malformed files instead of JSON errors
- **#21 (MEDIUM)**: `tvl-ci-gate` exits 0 on Reject verdict, should exit 2
- **#25 (LOW-MEDIUM)**: `extract_domains()` silently drops malformed tvar declarations instead of raising

## Test plan

- Packaging: pip install wheel; verify schema JSONs are present
- CLI: test malformed input files, verify proper exit codes and JSON output
- SDK: verify extract_domains raises on bad input instead of silently continuing

## Fixes applied

1. **pyproject.toml**: Added `[tool.setuptools.package-data]` to include schema JSON and py.typed
2. **tvl/model.py**: Changed silent-continue to explicit ValueError in extract_domains
3. **tvl/py.typed**: Created empty marker file per PEP 561
4. **tvl_check_structural/cli.py**: Added error handling around module loading with proper JSON output
5. **tvl_ci_gate/cli.py**: Added exit code check for decision verdict (exit 2 if not Promote)
6. **tvl_measure_validate/cli.py**: Fixed ternary to properly handle --json flag

🤖 Generated with Claude Code