### PR TITLE
fix(deps): patch website nanoid

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -52,7 +52,7 @@
     "input-otp": "^1.4.2",
     "lucide-react": "^0.453.0",
     "mermaid": "^11.15.0",
-    "nanoid": "^5.1.5",
+    "nanoid": "^5.1.16",
     "next-themes": "^0.4.6",
     "prismjs": "^1.30.0",
     "react": "^18.3.1",

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -134,8 +134,8 @@ importers:
         specifier: ^11.15.0
         version: 11.15.0
       nanoid:
-        specifier: ^5.1.5
-        version: 5.1.7
+        specifier: ^5.1.16
+        version: 5.1.16
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3056,8 +3056,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@5.1.7:
-    resolution: {integrity: sha512-ua3NDgISf6jdwezAheMOk4mbE1LXjm1DfMUDMuJf4AqxLFK3ccGpgWizwa5YV7Yz9EpXwEaWoRXSb/BnV0t5dQ==}
+  nanoid@5.1.16:
+    resolution: {integrity: sha512-kVrnsrJqMR8+oLJnGEmSWw9BivK5mt7H3FZatVRjrc5wGqFYuBxX1yG7+A7Gi5AefkX6t/oCkizcQgpu0cY1dQ==}
     engines: {node: ^18 || >=20}
     hasBin: true
 
@@ -6885,7 +6885,7 @@ snapshots:
 
   nanoid@3.3.16: {}
 
-  nanoid@5.1.7: {}
+  nanoid@5.1.16: {}
 
   negotiator@0.6.3: {}
 
@@ -7651,7 +7651,7 @@ snapshots:
       '@medv/finder': 4.0.2
       clsx: 2.1.1
       modern-screenshot: 4.6.8
-      nanoid: 5.1.7
+      nanoid: 5.1.16
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       tailwind-merge: 3.5.0


### PR DESCRIPTION
## Summary
- raise the direct website nanoid dependency from 5.1.7 to 5.1.16
- refresh only the matching lockfile resolution and integrity
- remediate Dependabot alert 167 without broad dependency drift

## Verification
- frozen pnpm install passed
- pnpm check passed
- production build passed
- server Vitest 3/3 passed
- production audit no longer reports nanoid
- independent review at the exact head passed
- isolated merge with open PR #75 was clean

## Residual scope
The separate nanoid 3.3.16 copy is dev-only through PostCSS and outside alert 167's affected range.

Spine-Trail: st_0043da9b8ea3
